### PR TITLE
feat(ci): self-hosted runner support + Beelink resource limits (ANSIBLE-015)

### DIFF
--- a/.github/workflows/ci-cleanup.yml
+++ b/.github/workflows/ci-cleanup.yml
@@ -13,7 +13,10 @@ jobs:
 
   detect-changes:
     name: Detect Changes
-    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    runs-on: >-
+      ${{ github.event.pull_request.head.repo.fork
+          && 'ubuntu-latest'
+          || fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     outputs:
       changed_apps: ${{ steps.list.outputs.apps }}
       any_changed: ${{ steps.check.outputs.any_changed }}
@@ -64,7 +67,10 @@ jobs:
     name: Cleanup RC Tags
     needs: detect-changes
     if: needs.detect-changes.outputs.any_changed == 'true'
-    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    runs-on: >-
+      ${{ github.event.pull_request.head.repo.fork
+          && 'ubuntu-latest'
+          || fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     env:
       REGISTRY_PREFIX: ${{ vars.REGISTRY_PREFIX || 'kubelab' }}
     steps:

--- a/.github/workflows/ci-cleanup.yml
+++ b/.github/workflows/ci-cleanup.yml
@@ -13,7 +13,7 @@ jobs:
 
   detect-changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     outputs:
       changed_apps: ${{ steps.list.outputs.apps }}
       any_changed: ${{ steps.check.outputs.any_changed }}
@@ -64,7 +64,7 @@ jobs:
     name: Cleanup RC Tags
     needs: detect-changes
     if: needs.detect-changes.outputs.any_changed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     env:
       REGISTRY_PREFIX: ${{ vars.REGISTRY_PREFIX || 'kubelab' }}
     steps:

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -7,6 +7,11 @@ on:
       app:
         required: true
         type: string
+      runner:
+        required: false
+        type: string
+        default: '"ubuntu-latest"'
+        description: "JSON-encoded runner label (string or array for self-hosted)"
     outputs:
       docker_version:
         description: "Generated Docker version for this app"
@@ -28,7 +33,7 @@ on:
 jobs:
   app-pipeline:
     name: CI + Build for ${{ inputs.app }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner) }}
     outputs:
       docker_version: ${{ steps.docker_version.outputs.version }}
       sha_short: ${{ steps.short_sha.outputs.sha }}
@@ -298,6 +303,7 @@ jobs:
       sha: ${{ needs.app-pipeline.outputs.sha_short }}
       context: ${{ needs.app-pipeline.outputs.context }}
       extra_build_args: ${{ needs.app-pipeline.outputs.extra_build_args }}
+      runner: ${{ inputs.runner }}
     secrets: inherit
 
   # GitOps update + tagging handled by release-please (release.yml)

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -22,11 +22,16 @@ on:
         type: string
         default: ""
         description: "Additional build args (multiline key=value)"
+      runner:
+        required: false
+        type: string
+        default: '"ubuntu-latest"'
+        description: "JSON-encoded runner label (string or array for self-hosted)"
 
 jobs:
   docker-build-push:
     name: Build & Push ${{ inputs.app }}:${{ inputs.tag }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner) }}
     permissions:
       contents: read
       security-events: write
@@ -43,6 +48,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Set up QEMU for multi-arch builds
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -127,7 +135,7 @@ jobs:
 
   notify-build-completion:
     name: Notify Build Completion
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner) }}
     needs: [docker-build-push]
     if: always() && (needs.docker-build-push.result == 'success')
     steps:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   create-global-release:
     name: Create Release Bundle
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,20 @@ jobs:
 
   validate:
     name: Validate
-    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    # Fork PRs run on GitHub-hosted (self-hosted has Docker socket access)
+    runs-on: >-
+      ${{ github.event.pull_request.head.repo.fork
+          && 'ubuntu-latest'
+          || fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Validate branch name
         if: github.event_name == 'push' && github.ref_name != 'master'
+        env:
+          BRANCH_NAME: ${{ github.ref_name }}
         run: |
-          if [[ ! "${{ github.ref_name }}" =~ ^(feature|fix|hotfix|chore)/.+ ]]; then
+          if [[ ! "$BRANCH_NAME" =~ ^(feature|fix|hotfix|chore)/.+ ]]; then
             echo "::error::Branch name must match feature/*, fix/*, hotfix/*, or chore/*"
             exit 1
           fi
@@ -44,7 +50,10 @@ jobs:
   detect-changes:
     name: Detect Changes
     needs: validate
-    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    runs-on: >-
+      ${{ github.event.pull_request.head.repo.fork
+          && 'ubuntu-latest'
+          || fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     outputs:
       api: ${{ steps.filter.outputs.api }}
       web: ${{ steps.filter.outputs.web }}
@@ -104,7 +113,10 @@ jobs:
     uses: ./.github/workflows/ci-pipeline.yml
     with:
       app: api
-      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
+      runner: >-
+        ${{ github.event.pull_request.head.repo.fork
+            && '"ubuntu-latest"'
+            || vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit
 
   web-pipeline:
@@ -114,7 +126,10 @@ jobs:
     uses: ./.github/workflows/ci-pipeline.yml
     with:
       app: web
-      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
+      runner: >-
+        ${{ github.event.pull_request.head.repo.fork
+            && '"ubuntu-latest"'
+            || vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit
 
   errors-pipeline:
@@ -124,5 +139,8 @@ jobs:
     uses: ./.github/workflows/ci-pipeline.yml
     with:
       app: errors
-      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
+      runner: >-
+        ${{ github.event.pull_request.head.repo.fork
+            && '"ubuntu-latest"'
+            || vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
   validate:
     name: Validate
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -44,7 +44,7 @@ jobs:
   detect-changes:
     name: Detect Changes
     needs: validate
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     outputs:
       api: ${{ steps.filter.outputs.api }}
       web: ${{ steps.filter.outputs.web }}
@@ -104,6 +104,7 @@ jobs:
     uses: ./.github/workflows/ci-pipeline.yml
     with:
       app: api
+      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit
 
   web-pipeline:
@@ -113,6 +114,7 @@ jobs:
     uses: ./.github/workflows/ci-pipeline.yml
     with:
       app: web
+      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit
 
   errors-pipeline:
@@ -122,4 +124,5 @@ jobs:
     uses: ./.github/workflows/ci-pipeline.yml
     with:
       app: errors
+      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   release-please:
     name: Release Please
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       api_release_created: ${{ steps.release.outputs['apps/api--release_created'] }}
@@ -46,6 +46,7 @@ jobs:
       tag: ${{ needs.release-please.outputs.api_version }}
       sha: ${{ github.sha }}
       context: ./apps/api
+      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit
 
   publish-web:
@@ -58,6 +59,7 @@ jobs:
       tag: ${{ needs.release-please.outputs.web_version }}
       sha: ${{ github.sha }}
       context: ./apps/web
+      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit
 
   publish-errors:
@@ -70,4 +72,5 @@ jobs:
       tag: ${{ needs.release-please.outputs.errors_version }}
       sha: ${{ github.sha }}
       context: ./edge/errors
+      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit

--- a/infra/ansible/playbooks/provision-bee.yml
+++ b/infra/ansible/playbooks/provision-bee.yml
@@ -154,13 +154,15 @@
       vars:
         restart_policy: "{{ config.global.restart_policy }}"
         tailscale_ip: "{{ config.networking.nodes.beelink.tailscale_ip }}"
-        glances_image: "{{ config.apps.services.observability.glances.image }}"
-        glances_port: "{{ config.apps.services.observability.glances.default_port }}"
+        # MinIO
         minio_image: "{{ config.apps.services.data.minio.image }}"
         minio_api_port: "{{ config.apps.services.data.minio.default_port_api }}"
         minio_console_port: "{{ config.apps.services.data.minio.default_port_console }}"
         minio_root_user: "{{ secrets.apps.services.data.minio.root_user }}"
         minio_root_password: "{{ secrets.apps.services.data.minio.root_password }}"
+        minio_cpu_limit: "{{ config.apps.services.data.minio.resources.cpu_limit }}"
+        minio_memory_limit: "{{ config.apps.services.data.minio.resources.memory_limit }}"
+        # GitHub Actions Runner
         runner_image: "{{ config.apps.services.automation.github_runner.image }}"
         runner_repo_url: "{{ config.apps.services.automation.github_runner.repo_url }}"
         runner_access_token: "{{ secrets.apps.services.automation.github_runner.token }}"
@@ -168,3 +170,8 @@
         runner_labels: "{{ config.apps.services.automation.github_runner.labels }}"
         runner_cpu_limit: "{{ config.apps.services.automation.github_runner.resources.cpu_limit }}"
         runner_memory_limit: "{{ config.apps.services.automation.github_runner.resources.memory_limit }}"
+        # Glances
+        glances_image: "{{ config.apps.services.observability.glances.image }}"
+        glances_port: "{{ config.apps.services.observability.glances.default_port }}"
+        glances_cpu_limit: "{{ config.apps.services.observability.glances.resources.cpu_limit }}"
+        glances_memory_limit: "{{ config.apps.services.observability.glances.resources.memory_limit }}"

--- a/infra/ansible/roles/beelink_services/tasks/main.yml
+++ b/infra/ansible/roles/beelink_services/tasks/main.yml
@@ -74,15 +74,21 @@
   command: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
   when: not _binfmt.stat.exists
 
-- name: Check if buildx builder exists
+- name: Check if buildx builder is healthy
   command: docker buildx inspect multiarch
   register: _buildx_check
   changed_when: false
   ignore_errors: true
 
+- name: Clean stale buildx builder state
+  shell: |
+    docker buildx rm multiarch 2>/dev/null || true
+    rm -rf /root/.docker/buildx/instances/multiarch 2>/dev/null || true
+  when: _buildx_check.rc != 0
+  changed_when: true
+
 - name: Create Docker buildx builder
   command: docker buildx create --name multiarch --driver docker-container --use
-  become: false
   when: _buildx_check.rc != 0
 
 # --- Deploy ---

--- a/infra/ansible/roles/beelink_services/templates/compose.yml.j2
+++ b/infra/ansible/roles/beelink_services/templates/compose.yml.j2
@@ -20,6 +20,11 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
+    deploy:
+      resources:
+        limits:
+          cpus: "{{ minio_cpu_limit }}"
+          memory: "{{ minio_memory_limit }}"
     networks:
       - kubelab
 
@@ -38,6 +43,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - runner_data:/tmp/runner
+      - runner_toolcache:/opt/hostedtoolcache
     deploy:
       resources:
         limits:
@@ -57,11 +63,18 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /etc/os-release:/etc/os-release:ro
+    deploy:
+      resources:
+        limits:
+          cpus: "{{ glances_cpu_limit }}"
+          memory: "{{ glances_memory_limit }}"
     pid: host
 
 volumes:
   runner_data:
     name: github_runner_data
+  runner_toolcache:
+    name: github_runner_toolcache
 
 networks:
   kubelab:

--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -371,10 +371,10 @@ apps:
         runner_group: default
         labels: self-hosted,linux,docker
         resources:
-          cpu_limit: "1.0"
-          memory_limit: 1G
-          cpu_reservation: "0.25"
-          memory_reservation: 512M
+          cpu_limit: "4.0"
+          memory_limit: 6G
+          cpu_reservation: "1.0"
+          memory_reservation: 2G
 
     # Data services (storage, databases)
     data:
@@ -386,6 +386,11 @@ apps:
         enable_auth: false
         auth_level: bypass
         default_port_api: 9000
+        resources:
+          cpu_limit: "0.5"
+          memory_limit: 512M
+          cpu_reservation: "0.1"
+          memory_reservation: 128M
         default_port_console: 9001
         health_path: /minio/health/live
 
@@ -432,6 +437,11 @@ apps:
         name: glances
         image: nicolargo/glances:4.5.2-full
         default_port: 61208
+        resources:
+          cpu_limit: "0.25"
+          memory_limit: 256M
+          cpu_reservation: "0.1"
+          memory_reservation: 64M
 
     # Security (authentication, authorization, secrets)
     security:


### PR DESCRIPTION
## Summary
- Wire all 6 CI workflows to self-hosted GitHub Actions runner on Beelink via `fromJSON(vars.RUNNER_DOCKER)` pattern
- Safe fallback to `ubuntu-latest` when repo variable is unset (default behavior unchanged)
- Bump runner resources to 4 CPU / 6GB RAM + add resource limits for MinIO and Glances
- Add persistent tool cache volume (`/opt/hostedtoolcache`) for Go/Node setup actions across ephemeral jobs
- Add `setup-qemu-action` for explicit multi-arch build support (was implicit, now portable)

## Architecture
```
vars.RUNNER_DOCKER not set → fromJSON('"ubuntu-latest"') → GitHub-hosted (safe default)
vars.RUNNER_DOCKER = '["self-hosted","linux","docker"]' → fromJSON(...) → Beelink runner
```

Reusable workflows (`ci-pipeline`, `ci-publish`) receive runner as input from callers.
Standalone workflows read `vars.RUNNER_DOCKER` directly.

## Beelink Resource Budget (8GB total)
| Service | CPU | RAM |
|---------|-----|-----|
| GH Runner | 4.0 | 6G |
| MinIO | 0.5 | 512M |
| Glances | 0.25 | 256M |
| OS + Docker | — | ~1.2G |

## Activation
After merge, set GitHub repo variable:
```
Settings → Variables → Actions → New variable
Name: RUNNER_DOCKER
Value: ["self-hosted","linux","docker"]
```

## Test plan
- [ ] CI passes on this PR (validates workflow syntax + YAML lint)
- [ ] After merge + variable set: trigger workflow_dispatch on a test branch to verify self-hosted execution
- [ ] `make provision NODE=bee ENV=staging` to deploy updated resource limits
- [ ] Verify tool cache persistence across jobs (second run should skip Go/Node download)