### PR TITLE
feat(infra): RELIAB-009 hub IaC + Argo CD memory hygiene

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ help:
 	@echo "  make build-app APP=x    Build Astro app (static output)"
 	@echo ""
 	@echo "Infrastructure (Ansible):"
-	@echo "  make provision NODE=x ENV=y  Provision a node (NODE=ace1|ace2|bee|rpi3|rpi4|jetson|vps)"
+	@echo "  make provision NODE=x ENV=y  Provision a node (NODE=ace1|ace2|aws1|bee|rpi3|rpi4|jetson|vps, ENV=staging|prod|hub)"
 	@echo "  make maintain NODE=x         Disk cleanup (NODE=aws1|ace1|ace2|beelink|vps|all) [TIMER=1]"
 	@echo "  make deploy TARGET=x ENV=y  Deploy services (TARGET=vps|dns|k3s|harden-nodes)"
 	@echo "  make backup ENV=x           Backup VPS volumes (default: prod)"
@@ -561,8 +561,8 @@ rotate-spoke-token:
 
 .PHONY: provision
 provision:
-	@test -n "$(NODE)" || (echo "Usage: make provision NODE=ace1|ace2|rpi4|vps [ENV=staging|prod] [BOOTSTRAP=1] [ASK_PASS=1]" && exit 1)
-	$(eval _ENV := $(or $(filter staging prod,$(ENV)),staging))
+	@test -n "$(NODE)" || (echo "Usage: make provision NODE=ace1|ace2|aws1|rpi4|vps [ENV=staging|prod|hub] [BOOTSTRAP=1] [ASK_PASS=1]" && exit 1)
+	$(eval _ENV := $(or $(filter staging prod hub,$(ENV)),staging))
 	$(eval _K := $(if $(ASK_PASS),-K,))
 	@if [ -n "$(BOOTSTRAP)" ]; then \
 		echo "=== Bootstrap: generating inventory with LAN IPs ==="; \

--- a/infra/ansible/inventories/homelab.yml
+++ b/infra/ansible/inventories/homelab.yml
@@ -57,7 +57,8 @@ all:
     hub:
       hosts:
         kubelab-aws1:
-          ansible_host: 100.64.0.7   # networking.aws.tailscale_ip
+          # MagicDNS (ADR-025) — survives Spot replacement; Tailscale IP rotates.
+          ansible_host: aws1.kubelab.internal  # networking.aws.tailscale_dns
           ansible_user: deployer
 
     # Logical groups (for conditional tasks like docker prune, crictl prune)

--- a/infra/ansible/playbooks/provision-aws1.yml
+++ b/infra/ansible/playbooks/provision-aws1.yml
@@ -1,0 +1,179 @@
+---
+# =============================================================================
+# aws1 Day-2 Provisioning — Argo CD Hub (ADR-023, RELIAB-009 §9.0 Plan B1)
+#
+# CLOUD-INIT vs ANSIBLE BOUNDARY (codified from aws1 deploy lessons)
+# ------------------------------------------------------------------------
+# Terraform cloud-init (AWS-001..005, owned in infra/terraform/aws/) handles:
+#   - K3s install with ExecStart flags (--disable=traefik --disable=servicelb
+#     --write-kubeconfig-mode=644 --resolv-conf --tls-san) — immortal once set.
+#   - 2 GB swap via cloud-init `swap:` directive (lesson 2026-03-22: t4g RAM
+#     alone OOM-kills sshd; swap MUST be cloud-init-managed to survive Spot
+#     reclaim/replacement, not configured manually).
+#   - sshd `UseDNS no` baked-in early (lesson 2026-03-26: Spot stop leaves
+#     stale PTR records causing SSH hangs before Ansible can reach the host).
+#     Ansible's `ssh_hardening` role also enforces it for drift.
+#   - Tailscale install + initial Headscale registration via API key
+#     `secrets.aws.headscale_api_key`, including stale-node cleanup (lesson
+#     2026-03-26: re-registration without cleanup yields `aws1-<random>`).
+#   - `instance_interruption_behavior = "terminate"` + ASG(1,1) — cattle, not
+#     pets (lesson 2026-03-26: `stop` corrupts WireGuard + SSH state).
+#
+# This Ansible playbook (day-2) owns:
+#   - /etc/rancher/k3s/config.yaml — injects kube-controller-manager-arg
+#     `terminated-pod-gc-threshold` (RELIAB-009 §9.3). K3s reads both CLI and
+#     config.yaml; CLI wins on conflicts. config.yaml additions stack on top.
+#   - Base packages + timezone. UFW disabled (AWS Security Groups are the
+#     authoritative network ACL — never run two firewalls on one host).
+#   - SSH hardening drift check — converges sshd_config to current standard.
+#   - Tailscale config drift check — idempotent; no-op when already registered.
+#
+# Hardware contract (asserted below):
+#   - t4g.small Spot — 2 GB RAM, 2 GB swap, 8 GB EBS gp3 (lessons 2026-03-22,
+#     2026-03-28: t4g.micro OOMs on every Helm upgrade; t4g.small clears it).
+#   - Hub services live in common SOPS — singleton credentials, not env-scoped
+#     (lessons 2026-03-27, 2026-03-28: hub creds always in common.enc.yaml).
+#
+# Pre-deploy hygiene for Helm operations (handled by `make deploy-argocd`):
+#   - Scales all argocd Deployments/StatefulSets to 0 before upgrade to free
+#     RAM (lesson 2026-03-28). Never `kubectl patch` during Helm operations.
+#
+# Usage:
+#   make provision NODE=aws1 ENV=hub
+#   toolkit infra ansible run -p provision-aws1 -e hub
+#   toolkit infra ansible run -p provision-aws1 -e hub --tags k3s
+#
+# Cloud-agnostic: a future GCP/Azure hub creates its own provision-<node>.yml
+# but reuses hub.yaml and every Ansible role unchanged.
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# Play 0: Pre-flight validation (no changes to target)
+# ---------------------------------------------------------------------------
+- name: "Pre-flight: validate aws1 connectivity"
+  hosts: aws1
+  gather_facts: false
+  become: false
+  tasks:
+    - name: Verify SSH + Python connectivity
+      ansible.builtin.ping:
+
+    - name: Verify become (sudo) works
+      command: sudo -n true
+      become: true
+      changed_when: false
+
+    - name: Verify K3s is installed (cloud-init bootstrap prerequisite)
+      stat:
+        path: /usr/local/bin/k3s
+      register: _k3s_bin
+      failed_when: not _k3s_bin.stat.exists
+
+    - name: Verify Tailscale is up (cloud-init bootstrap prerequisite)
+      command: tailscale status --json
+      changed_when: false
+      register: _ts
+      failed_when: _ts.rc != 0
+
+# ---------------------------------------------------------------------------
+# Play 1: Day-2 convergence
+# ---------------------------------------------------------------------------
+- name: Provision aws1 — Argo CD hub day-2 config
+  hosts: aws1
+  become: true
+  gather_facts: true
+
+  vars:
+    deploy_env: hub
+
+  pre_tasks:
+    - name: Load base config (SSOT)
+      include_vars:
+        file: "{{ playbook_dir }}/../../config/values/common.yaml"
+        name: common
+
+    - name: Load hub overrides
+      include_vars:
+        file: "{{ playbook_dir }}/../../config/values/{{ deploy_env }}.yaml"
+        name: env_overrides
+
+    - name: Merge configs (hub overrides win)
+      set_fact:
+        config: "{{ common | combine(env_overrides, recursive=True) }}"
+
+    - name: Decrypt common secrets (controller-side)
+      command: sops -d {{ playbook_dir }}/../../config/secrets/common.enc.yaml
+      register: sops_common
+      delegate_to: localhost
+      become: false
+      changed_when: false
+      check_mode: false
+      no_log: true
+
+    - name: Expose secrets fact (common only — hub has no env-scoped secrets)
+      set_fact:
+        secrets: "{{ sops_common.stdout | from_yaml }}"
+      no_log: true
+
+    - name: "Invariant: cloud-init swap directive applied"
+      assert:
+        that:
+          - ansible_facts["swaptotal_mb"] is defined
+          - ansible_facts["swaptotal_mb"] >= 1500
+        fail_msg: >-
+          Swap is {{ ansible_facts["swaptotal_mb"] | default(0) }}MB; expected
+          ≥1500MB from cloud-init. Lesson 2026-03-22: K3s + Argo CD OOM-kill
+          sshd without swap. Investigate cloud-init before continuing.
+
+    - name: "Invariant: host meets hub minimum (t4g.small, ~1.8GB RAM)"
+      assert:
+        that:
+          - ansible_facts["memtotal_mb"] >= 1700
+        fail_msg: >-
+          Memory is {{ ansible_facts["memtotal_mb"] }}MB; RELIAB-009 hub
+          minimum is t4g.small (lesson 2026-03-28). t4g.micro OOMs on Helm
+          upgrades.
+
+    - name: Build TLS SAN list (MagicDNS only — IP rotates on Spot replacement)
+      set_fact:
+        _k3s_tls_san:
+          - "{{ config.networking.aws.tailscale_dns }}"
+
+  roles:
+    - role: ../roles/base_system
+      tags: [base]
+      vars:
+        system_timezone: "{{ config.global.timezone }}"
+        # No netplan — EC2 eni is cloud-init managed.
+        # No UFW — AWS Security Groups are the authoritative network ACL.
+        firewall_enabled: false
+
+    - role: ../roles/ssh_hardening
+      tags: [ssh]
+
+    - role: ../roles/tailscale
+      tags: [tailscale]
+      vars:
+        # aws1 is already registered (cloud-init). Role is idempotent: install
+        # task skips (binary present), `tailscale up` skips (BackendState=Running).
+        tailscale_headscale_url: "https://{{ config.apps.services.core.headscale.domain }}"
+        tailscale_accept_routes: true   # Hub is remote — accepts subnet routes
+        tailscale_auth_key: ""           # No re-registration
+
+    - role: ../roles/k3s_server
+      tags: [k3s]
+      vars:
+        k3s_version: "{{ config.k3s.version }}"
+        k3s_install_script_url: "{{ config.k3s.install_script_url }}"
+        k3s_tls_san: "{{ _k3s_tls_san }}"
+        k3s_kubeconfig_mode: "{{ config.k3s.kubeconfig_mode }}"
+        k3s_resolv_conf: "/run/systemd/resolve/resolv.conf"
+        k3s_configure_traefik: "{{ config.k3s.configure_traefik }}"
+        k3s_traefik_acme_enabled: false
+        k3s_terminated_pod_gc_threshold: "{{ config.k3s.terminated_pod_gc_threshold }}"
+        k3s_etcd_snapshot_retention: "{{ config.k3s.etcd_snapshot_retention }}"
+        k3s_fetch_kubeconfig: true
+        k3s_kubeconfig_local_path: "~/.kube/kubelab-{{ deploy_env }}-config"
+        # MagicDNS in kubeconfig server URL — Spot replacement only requires
+        # MagicDNS auto-resolution, no kubeconfig edit (lesson 2026-03-26).
+        k3s_api_address: "{{ config.networking.aws.tailscale_dns }}"

--- a/infra/ansible/roles/k3s_server/defaults/main.yml
+++ b/infra/ansible/roles/k3s_server/defaults/main.yml
@@ -10,6 +10,19 @@ k3s_kubeconfig_mode: "0600"
 k3s_node_labels: []
 k3s_resolv_conf: ""  # Override pod DNS (e.g. /run/systemd/resolve/resolv.conf for systemd-resolved hosts)
 
+# kube-controller-manager — terminated pod GC threshold.
+# K3s default 12500 → on low-RAM hubs (e.g. t4g.small) one OOM loop can leave
+# thousands of zombie pods saturating etcd. RELIAB-009 §9.3: hub.yaml overrides
+# to 100. Staging/prod keep the K3s default.
+k3s_terminated_pod_gc_threshold: 12500
+
+# K3s embedded etcd snapshot retention. Default 5; on small EBS volumes
+# (e.g. 8GB hub) each snapshot is ~30-40MB and aged ones bloat /var/lib/rancher.
+# RELIAB-009 follow-up (2026-05-10 incident): give the hub more disk headroom
+# so a §9.3 bulk-delete log spike doesn't trip the kubelet disk-pressure
+# threshold (85%). Staging/prod with larger volumes keep the K3s default.
+k3s_etcd_snapshot_retention: 5
+
 # Traefik HelmChartConfig — ports from SSOT (config.k3s.traefik.*)
 k3s_configure_traefik: true
 k3s_traefik_http_port: 80

--- a/infra/ansible/roles/k3s_server/templates/config.yaml.j2
+++ b/infra/ansible/roles/k3s_server/templates/config.yaml.j2
@@ -15,3 +15,10 @@ node-label:
   - "{{ label }}"
 {% endfor %}
 {% endif %}
+{% if k3s_terminated_pod_gc_threshold | int != 12500 %}
+kube-controller-manager-arg:
+  - "terminated-pod-gc-threshold={{ k3s_terminated_pod_gc_threshold }}"
+{% endif %}
+{% if k3s_etcd_snapshot_retention | int != 5 %}
+etcd-snapshot-retention: {{ k3s_etcd_snapshot_retention }}
+{% endif %}

--- a/infra/ansible/roles/ssh_hardening/templates/sshd_config.j2
+++ b/infra/ansible/roles/ssh_hardening/templates/sshd_config.j2
@@ -23,6 +23,10 @@ AllowTcpForwarding no
 AllowAgentForwarding no
 PermitTunnel no
 PermitUserEnvironment no
+# Skip reverse-DNS lookup on connect — avoids SSH hangs on cloud nodes
+# whose PTR records lag behind their public IP rotation (Spot reclaim).
+UseDNS no
+GSSAPIAuthentication no
 
 # Logging
 SyslogFacility AUTH

--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -63,9 +63,11 @@ networking:
     ami_name_filter: "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"
     ebs_size_gb: 8
     hostname: "aws1"
+    # Tailscale IP rotates on every Spot replacement. MagicDNS (ADR-025) is the
+    # stable identity — prefer tailscale_dns over tailscale_ip in IaC.
     tailscale_ip: "100.64.0.7"
+    tailscale_dns: "aws1.kubelab.internal"
     ssh_user: "deployer"
-    tailscale_dns: "aws1.kubelab.internal"  # MagicDNS (ADR-025) — IP-independent
     k3s_version: "v1.34.4+k3s1"  # Match spoke versions
   nodes:
     # ADR-023 Phase 1: bare metal MiniPCs replace Proxmox VMs
@@ -149,6 +151,17 @@ k3s:
   version: "v1.34.4+k3s1"
   api_port: 6443
   install_script_url: "https://get.k3s.io"
+  # kube-controller-manager terminated-pod-gc-threshold.
+  # K3s default 12500; hub.yaml overrides to 100 (low-RAM Spot).
+  terminated_pod_gc_threshold: 12500
+  # Embedded etcd snapshot retention. K3s default 5; hub.yaml overrides to 2
+  # for small-disk Spot instances. RELIAB-009 follow-up 2026-05-10.
+  etcd_snapshot_retention: 5
+  # Bundled Traefik HelmChartConfig. Hub disables it (Argo CD only, no ingress).
+  configure_traefik: true
+  # kubeconfig file mode written by K3s. Hub overrides to 0644 to match its
+  # cloud-init ExecStart (--write-kubeconfig-mode=644).
+  kubeconfig_mode: "0600"
   traefik:
     http_port: 80
     https_port: 443

--- a/infra/config/values/hub.yaml
+++ b/infra/config/values/hub.yaml
@@ -1,0 +1,22 @@
+---
+# Hub overrides — Argo CD management plane (ADR-023).
+# Currently single hub on AWS (aws1, t4g.small Spot, 2GB RAM).
+# Same overrides apply to any future hub (GCP, Azure) — cloud-agnostic.
+#
+# Composition: common.yaml ← hub.yaml (env_overrides wins, recursive merge).
+
+k3s:
+  # RELIAB-009 §9.3 — low-RAM hub reaps zombie pods aggressively.
+  # K3s default 12500 left thousands of zombies after the 2026-05-06 OOM
+  # cascade. 100 keeps recent diagnostic context without etcd bloat.
+  terminated_pod_gc_threshold: 100
+  # Hub does not serve user traffic; Argo CD UI is exposed via prod VPS Traefik
+  # over Tailscale (EndpointSlice → aws1:30443). No bundled Traefik on the hub.
+  configure_traefik: false
+  # Match cloud-init ExecStart (--write-kubeconfig-mode=644). The CLI flag
+  # always wins, but keeping config.yaml consistent avoids documentation drift.
+  kubeconfig_mode: "0644"
+  # 8 GB EBS root: keep only 2 etcd snapshots (~60-80MB each). RELIAB-009
+  # 2026-05-10 incident: §9.3 bulk-delete log spike pushed disk past 85% =
+  # kubelet disk-pressure → NotReady. Fewer snapshots = more headroom.
+  etcd_snapshot_retention: 2

--- a/infra/helm/argocd/values.yaml
+++ b/infra/helm/argocd/values.yaml
@@ -6,6 +6,8 @@ global:
 
 server:
   replicas: 1
+  # RELIAB-009 §9.2 — keep two-step rollback; collapse ReplicaSet graveyard.
+  revisionHistoryLimit: 3
   service:
     type: NodePort
     nodePortHttp: 30080
@@ -21,6 +23,7 @@ server:
 
 controller:
   replicas: 1
+  revisionHistoryLimit: 3
   resources:
     requests:
       cpu: 100m
@@ -30,6 +33,7 @@ controller:
 
 repoServer:
   replicas: 1
+  revisionHistoryLimit: 3
   resources:
     requests:
       cpu: 50m
@@ -38,6 +42,7 @@ repoServer:
       memory: 256Mi
 
 redis:
+  revisionHistoryLimit: 3
   resources:
     requests:
       cpu: 10m
@@ -50,6 +55,7 @@ dex:
 
 notifications:
   enabled: true
+  revisionHistoryLimit: 3
   resources:
     requests:
       cpu: 10m
@@ -128,6 +134,7 @@ notifications:
 
 applicationSet:
   replicas: 1
+  revisionHistoryLimit: 3
   resources:
     requests:
       cpu: 25m

--- a/toolkit/features/generator_ansible.py
+++ b/toolkit/features/generator_ansible.py
@@ -89,13 +89,15 @@ class AnsibleGenerator(BaseGenerator):
                 }
             )
 
-        # AWS hub node (ADR-023 Phase 3) — always uses Tailscale IP
+        # AWS hub node (ADR-023 Phase 3) — prefer MagicDNS (ADR-025) so Spot
+        # replacement does not require an inventory regenerate. Falls back to
+        # tailscale_ip only when tailscale_dns is unset (e.g. early bootstrap).
         aws = networking.get("aws", {})
-        if aws and aws.get("tailscale_ip"):
+        if aws and (aws.get("tailscale_dns") or aws.get("tailscale_ip")):
             all_nodes.append(
                 {
                     "hostname": aws.get("hostname", "aws1"),
-                    "ansible_host": aws["tailscale_ip"],
+                    "ansible_host": aws.get("tailscale_dns") or aws["tailscale_ip"],
                     "ansible_user": aws.get("ssh_user", "deployer"),
                     "groups": ["hub"],
                 }


### PR DESCRIPTION
## Summary

Resolves the [2026-05-06 OOM cascade on aws1](https://github.com/mlorentedev/kubelab/blob/master/.. "argo.kubelab.live 502 ~10h") (Argo CD hub, t4g.small Spot). Pre-flight 2026-05-09 revealed that the planned `make provision NODE=aws1 ENV=hub` did not exist — aws1 was bootstrapped purely by Terraform cloud-init with no Ansible day-2 counterpart. **Plan B1** closes that gap.

Three RELIAB-009 sub-tasks land here:

| § | Change | File(s) |
|---|---|---|
| 9.0 | New `provision-aws1.yml` day-2 playbook + `hub.yaml` SSOT overrides; reuses `k3s_server` role; documents cloud-init/Ansible boundary | `infra/ansible/playbooks/provision-aws1.yml`, `infra/config/values/hub.yaml`, `Makefile`, `toolkit/features/generator_ansible.py` |
| 9.2 | Argo CD `revisionHistoryLimit: 3` on six components (keeps two-step rollback; collapses ReplicaSet graveyard) | `infra/helm/argocd/values.yaml` |
| 9.3 | New `k3s_terminated_pod_gc_threshold` var (default 12500; hub.yaml=100). Emitted as `kube-controller-manager-arg` | `infra/ansible/roles/k3s_server/{defaults,templates}`, `infra/config/values/common.yaml`, `hub.yaml` |

§9.1 (resource requests/limits) already in `values.yaml` since t4g.small upgrade — verified, no changes.

## Hardening codified from prior aws1 deploy lessons

- **ssh_hardening**: add `UseDNS no` + `GSSAPIAuthentication no` to sshd template (was cloud-init only — lesson 2026-03-26 Spot SSH hang).
- **MagicDNS for aws1** (ADR-025): generator + inventory prefer `tailscale_dns` (`aws1.kubelab.internal`) over `tailscale_ip` so Spot replacement does not require inventory regen.
- **New `k3s_etcd_snapshot_retention`** var (default 5; hub=2): 8GB EBS hub needs disk headroom against bulk-delete log spikes.
- **Pre-deploy asserts**: swap ≥1500MB, RAM ≥1700MB on hub (codifies the t4g.small minimum spec).

## Validation (real, not check-mode)

| Check | Result |
|---|---|
| First provision run | 42 ok / 8 changed / 0 failed (3:47) |
| Idempotency re-run | 41 ok / 2 changed / 0 failed (2:09; only template + K3s restart fired) |
| K3s logs | `kube-controller-manager --terminated-pod-gc-threshold=100` live |
| Node status | aws1 Ready, kubectl responsive (after a futex deadlock recovery — see lessons) |
| Helm render | 6 components emit `revisionHistoryLimit: 3` (5 Deployments + 1 StatefulSet) |
| Pre-commit hooks | All clean (yamllint, ruff, mypy, secrets) |

## Vault captures (auto-committed by Hive)

- `90-lessons.md`: K3s futex deadlock post-bulk-delete; `systemctl restart k3s` releases it.
- `90-lessons.md`: Activating aggressive GC threshold on a backlog cluster needs manual chunked pre-cleanup; otherwise kine SQLite saturates.
- `90-lessons.md`: Ansible `apt: name=...` in `--check` mode reports stale-cache false positives (the upstream module limitation).
- `11-tasks.md` **ANSIBLE-019**: standardize node hostname `kubelab-` prefix convention (three patterns coexist).
- `11-tasks.md` **ANSIBLE-020**: decide fate of legacy `homelab.yml` (still used by tests + README; diverged from generator output).

## Post-merge operational steps (not part of this PR)

- [ ] `make deploy-argocd` to apply §9.2 `revisionHistoryLimit` to the running Argo CD chart.
- [ ] Scale Argo CD back to 1 replica per component.
- [ ] 24h soak: `kubectl get pods -n argocd | wc -l` must stabilize below 20.

## Test plan
- [x] Ansible syntax-check + yamllint clean
- [x] Real run on aws1 (no `--check`)
- [x] Idempotency re-run (2 changed = template + restart handler)
- [x] kube-controller-manager flag verified live
- [x] sshd `UseDNS no` + `GSSAPIAuthentication no` applied
- [x] Tailscale stable; MagicDNS kubeconfig works
- [x] Helm template renders revisionHistoryLimit on 6 components
- [ ] Post-merge: `make deploy-argocd` + 24h soak (operational)