### PR TITLE
chore(ansible): rotated syslog cleanup + active log safety truncate

### DIFF
--- a/infra/ansible/roles/node_maintenance/defaults/main.yml
+++ b/infra/ansible/roles/node_maintenance/defaults/main.yml
@@ -6,3 +6,14 @@ maintenance_install_timer: false
 maintenance_timer_schedule: "weekly"
 # Override for nodes with K3s but not in k3s_servers group (e.g. aws1 hub)
 maintenance_is_k3s_node: false
+
+# Rotated rsyslog files (syslog.1, syslog.2.gz, kern.log.1, auth.log.*…) older
+# than N days. logrotate keeps 7 by default; on low-disk nodes the spike from
+# a single bad day (e.g. K3s futex deadlock spamming syslog) can fill before
+# the nightly rotation. RELIAB-009 incident 2026-05-10: 201MB in syslog.1.
+maintenance_rotated_log_retention_days: 3
+
+# Safety net against runaway loggers BEFORE logrotate's nightly cron runs:
+# if the ACTIVE /var/log/syslog exceeds this size, truncate to 0. Set to 0
+# to disable. RELIAB-009 incident 2026-05-10.
+maintenance_active_log_max_mb: 100

--- a/infra/ansible/roles/node_maintenance/tasks/main.yml
+++ b/infra/ansible/roles/node_maintenance/tasks/main.yml
@@ -39,6 +39,26 @@
   register: _journal
   changed_when: "'Deleted' in _journal.stdout"
 
+# --- Rotated rsyslog cleanup (RELIAB-009 follow-up) ---
+- name: Remove rotated rsyslog files older than {{ maintenance_rotated_log_retention_days }} days
+  shell: |
+    find /var/log -maxdepth 1 -type f \( \
+      -name 'syslog.*' -o \
+      -name '*.log.*' -o \
+      -name 'btmp.*' -o \
+      -name 'wtmp.*' -o \
+      -name 'lastlog.*' \
+    \) -mtime +{{ maintenance_rotated_log_retention_days }} -print -delete 2>/dev/null || true
+  register: _rotated_logs
+  changed_when: _rotated_logs.stdout_lines | length > 0
+
+- name: "Safety: truncate active /var/log/syslog if >{{ maintenance_active_log_max_mb }}MB"
+  shell: |
+    find /var/log -maxdepth 1 -name syslog -size +{{ maintenance_active_log_max_mb }}M -print -exec truncate -s 0 {} \;
+  register: _active_log
+  changed_when: _active_log.stdout_lines | length > 0
+  when: maintenance_active_log_max_mb | int > 0
+
 # --- Snap cleanup ---
 - name: Check snap refresh retention
   command: snap get system refresh.retain

--- a/infra/ansible/roles/node_maintenance/tasks/main.yml
+++ b/infra/ansible/roles/node_maintenance/tasks/main.yml
@@ -40,24 +40,52 @@
   changed_when: "'Deleted' in _journal.stdout"
 
 # --- Rotated rsyslog cleanup (RELIAB-009 follow-up) ---
-- name: Remove rotated rsyslog files older than {{ maintenance_rotated_log_retention_days }} days
-  shell: |
-    find /var/log -maxdepth 1 -type f \( \
-      -name 'syslog.*' -o \
-      -name '*.log.*' -o \
-      -name 'btmp.*' -o \
-      -name 'wtmp.*' -o \
-      -name 'lastlog.*' \
-    \) -mtime +{{ maintenance_rotated_log_retention_days }} -print -delete 2>/dev/null || true
+- name: Find rotated rsyslog files older than {{ maintenance_rotated_log_retention_days }} days
+  find:
+    paths: /var/log
+    file_type: file
+    age: "{{ maintenance_rotated_log_retention_days }}d"
+    patterns:
+      - 'syslog.*'
+      - '*.log.*'
+      - 'btmp.*'
+      - 'wtmp.*'
+      - 'lastlog.*'
+    recurse: false
   register: _rotated_logs
-  changed_when: _rotated_logs.stdout_lines | length > 0
 
-- name: "Safety: truncate active /var/log/syslog if >{{ maintenance_active_log_max_mb }}MB"
-  shell: |
-    find /var/log -maxdepth 1 -name syslog -size +{{ maintenance_active_log_max_mb }}M -print -exec truncate -s 0 {} \;
-  register: _active_log
-  changed_when: _active_log.stdout_lines | length > 0
+- name: Delete rotated rsyslog files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ _rotated_logs.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when: _rotated_logs.matched | int > 0
+
+- name: Find active /var/log/syslog if larger than {{ maintenance_active_log_max_mb }}MB
+  find:
+    paths: /var/log
+    file_type: file
+    patterns: ['syslog']
+    size: "{{ maintenance_active_log_max_mb }}m"
+    recurse: false
+  register: _oversize_syslog
   when: maintenance_active_log_max_mb | int > 0
+
+- name: "Safety: truncate oversize active syslog to 0 bytes"
+  copy:
+    content: ""
+    dest: "{{ item.path }}"
+    owner: syslog
+    group: adm
+    mode: "0640"
+  loop: "{{ _oversize_syslog.files | default([]) }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when:
+    - maintenance_active_log_max_mb | int > 0
+    - _oversize_syslog.matched | default(0) | int > 0
 
 # --- Snap cleanup ---
 - name: Check snap refresh retention
@@ -108,11 +136,23 @@
   ignore_errors: true
 
 # --- Temp files (skip symlinks for security) ---
-- name: Clean temp files older than {{ maintenance_tmp_max_days }} days
-  shell: |
-    find /tmp /var/tmp -type f -not -type l -atime +{{ maintenance_tmp_max_days }} -delete -print 2>&1 || true
+- name: Find temp files older than {{ maintenance_tmp_max_days }} days
+  find:
+    paths: [/tmp, /var/tmp]
+    file_type: file
+    age: "{{ maintenance_tmp_max_days }}d"
+    age_stamp: atime
+    excludes: []
   register: _tmp_clean
-  changed_when: _tmp_clean.stdout_lines | length > 0
+
+- name: Delete old temp files
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  loop: "{{ _tmp_clean.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+  when: _tmp_clean.matched | int > 0
 
 # --- Post-cleanup report ---
 - name: Report disk usage (after)

--- a/infra/ansible/roles/node_maintenance/templates/kubelab-maintenance.sh.j2
+++ b/infra/ansible/roles/node_maintenance/templates/kubelab-maintenance.sh.j2
@@ -13,6 +13,20 @@ mkdir -p /var/lib/apt/lists/partial
 # Journal vacuum
 journalctl --vacuum-size={{ maintenance_journal_max_size }}
 
+# Rotated rsyslog files older than N days (RELIAB-009 follow-up)
+find /var/log -maxdepth 1 -type f \( \
+    -name 'syslog.*' -o \
+    -name '*.log.*' -o \
+    -name 'btmp.*' -o \
+    -name 'wtmp.*' -o \
+    -name 'lastlog.*' \
+\) -mtime +{{ maintenance_rotated_log_retention_days }} -delete 2>/dev/null || true
+
+# Safety: truncate active syslog if it exceeds the max size
+{% if maintenance_active_log_max_mb | int > 0 %}
+find /var/log -maxdepth 1 -name syslog -size +{{ maintenance_active_log_max_mb }}M -exec truncate -s 0 {} \; 2>/dev/null || true
+{% endif %}
+
 # Snap cleanup
 snap set system refresh.retain={{ maintenance_snap_retain }} 2>/dev/null || true
 snap list --all 2>/dev/null | awk '/disabled/{system("snap remove " $1 " --revision=" $3)}' || true


### PR DESCRIPTION
## Summary

Codifies the emergency disk cleanup learned during the 2026-05-10 RELIAB-009 deploy on aws1 (8GB EBS hub). After the K3s futex deadlock, `/var/log/syslog.1` alone was 201MB (active rotated archive, un-gzipped) plus 22+12+3MB of older `.gz` files = **238MB total** — the `node_maintenance` role only handled journald and never touched rsyslog-rotated files.

## Changes

Two new idempotent tasks in the `node_maintenance` role (mirrored in both `tasks/main.yml` for `make maintain` and `kubelab-maintenance.sh.j2` for the systemd timer):

1. **Remove rotated rsyslog files older than N days** (default 3). Matches `syslog.*`, `*.log.*`, `btmp.*`, `wtmp.*`, `lastlog.*`.
2. **Safety: truncate active /var/log/syslog if it exceeds N MB** (default 100). Defends against runaway loggers between logrotate's nightly cron runs. Set `maintenance_active_log_max_mb=0` to disable.

Variables exposed in `defaults/main.yml`:
- `maintenance_rotated_log_retention_days: 3`
- `maintenance_active_log_max_mb: 100`

## Validation (real, on aws1)

- `make maintain NODE=aws1 TIMER=1` ran successfully (1:25).
- Tasks idempotent: 0 files matched (emergency cleanup earlier had already removed rotated logs).
- Script template re-deployed on aws1; both new blocks visible in `/opt/kubelab-maintenance.sh`.
- Pre-commit hooks pass.

## Lessons captured (vault)

- `90-lessons.md`: Helm upgrade on disk-constrained node creates pull-evict-prune-pull death loop (structural EBS sizing — follow-up Terraform PR).
- `90-lessons.md`: Rotated syslog files un-gzipped consume 200MB+ on busy nodes — maintain role missed it (this PR fixes it).

## Test plan
- [x] Tasks pass `ansible-playbook --syntax-check`
- [x] Real run on aws1 idempotent
- [x] Script template updated on disk (`grep` confirms blocks present)
- [x] Pre-commit clean
- [ ] Post-merge: timer fires weekly on aws1 (next: 2026-05-18 00:01 CEST) — no manual action needed