### PR TITLE
feat(aws): resize aws1 EBS root volume 8 → 12 GB

### DIFF
--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -61,7 +61,11 @@ networking:
     profile: "kubelab"
     instance_type: "t4g.small"
     ami_name_filter: "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"
-    ebs_size_gb: 8
+    # 12 GB is the practical minimum for K3s + Argo CD steady-state (~6.4GB base)
+    # plus headroom for Helm upgrades (image pulls ~250MB) + log spikes (~500MB)
+    # before kubelet's 85% disk-pressure threshold trips. 8GB hit 96% during
+    # the 2026-05-10 RELIAB-009 deploy. ~$0.38/mo extra (eu-central-1 gp3).
+    ebs_size_gb: 12
     hostname: "aws1"
     # Tailscale IP rotates on every Spot replacement. MagicDNS (ADR-025) is the
     # stable identity — prefer tailscale_dns over tailscale_ip in IaC.

--- a/infra/terraform/aws/aws.tfvars.example
+++ b/infra/terraform/aws/aws.tfvars.example
@@ -6,11 +6,13 @@
 # headscale preauthkeys create --user kubelab --reusable --expiration 365d
 tailscale_authkey = "REPLACE_WITH_HEADSCALE_PREAUTH_KEY"
 
-# Optional overrides (defaults from variables.tf are usually correct)
+# Optional overrides (defaults from variables.tf are usually correct).
+# Values shown below mirror the current variables.tf defaults — uncomment
+# only if you need to override locally.
 # aws_region      = "eu-central-1"
 # aws_profile     = "kubelab"
-# instance_type   = "t4g.micro"
-# ebs_size_gb     = 8
-# hostname        = "argo-hub"
+# instance_type   = "t4g.small"
+# ebs_size_gb     = 12
+# hostname        = "aws1"
 # k3s_version     = "v1.34.4+k3s1"
 # headscale_url   = "https://vpn.kubelab.live"

--- a/infra/terraform/aws/variables.tf
+++ b/infra/terraform/aws/variables.tf
@@ -32,9 +32,14 @@ variable "ami_name_filter" {
 }
 
 variable "ebs_size_gb" {
-  description = "Root EBS volume size in GB"
+  description = <<-EOT
+    Root EBS volume size in GB. Online resize: terraform apply triggers
+    ec2:ModifyVolume (no instance replacement). After resize, reboot the
+    instance — cloud-init cc_growpart + cc_resizefs auto-expand the
+    partition + ext4 filesystem on next boot. See 40-runbooks/aws1-ebs-resize.md.
+  EOT
   type        = number
-  default     = 8
+  default     = 12
 }
 
 variable "hostname" {


### PR DESCRIPTION
## Summary

Closes the structural disk-pressure gap surfaced during the 2026-05-10 RELIAB-009 deploy on aws1 (8 GB EBS hit 96% during Helm upgrade → kubelet 85% threshold → pull-evict-prune-pull death loop). 12 GB gives ~5 GB headroom above steady-state 6.4 GB footprint.

## Changes (3 files, 18+/7−)

| File | Change |
|---|---|
| `infra/config/values/common.yaml` | `networking.aws.ebs_size_gb: 8 → 12` (SSOT) |
| `infra/terraform/aws/variables.tf` | default `8 → 12` + docstring referencing the runbook and the in-place resize semantics |
| `infra/terraform/aws/aws.tfvars.example` | sync stale optional-overrides block to current SSOT (`t4g.small`, `aws1`, `ebs_size_gb = 12`) — was stuck on pre-2026-03-28 values |

## Approach: pure declarative IaC — no Ansible playbook needed

Terraform owns cloud; cloud-init's stock modules own host-side growth. No imperative scripts.

| Layer | Tool | Action |
|---|---|---|
| Cloud | Terraform | `ec2:ModifyVolume` in-place (no instance replacement) |
| Host | cloud-init `cc_growpart` | Expands partition on next boot |
| Host | cloud-init `cc_resizefs` | Extends ext4 on next boot |

aws1's cloud-init was verified during RELIAB-009 pre-flight: `cc_resizefs` ran successfully on 2026-05-08 boot; `growpart` + `resizefs` modules are in the config list (Ubuntu 24.04 stock).

## Validation strategy

Cannot validate the resize until merge + `terraform apply` + reboot. Pre-merge validation:

- [x] Pre-commit hooks pass
- [x] `terraform fmt` clean on edits
- [x] Runbook published in vault (`40-runbooks/aws1-ebs-resize.md`)
- [ ] Post-merge: follow runbook — `terraform plan` shows only in-place modify (no replacement), apply, reboot aws1, verify `df -h /` ≈ 11.5 GB

## Cost

eu-central-1 gp3: `$0.0952/GB-month` × 4 GB delta = **+$0.38/mo** = **$4.57/year**.

## Rationale: why 12 GB and not 16 GB

| Tier | Headroom | Cost/year delta | Verdict |
|---|---|---|---|
| 12 GB | 5.1 GB (covers Helm upgrade + log spike + 24h logs + etcd snapshots) | +$4.57 | Right-sized for current Argo CD-only hub |
| 16 GB | 9 GB (would also fit image-updater + prometheus-on-hub) | +$9.14 | Reserved for future controllers (capture: ticket below) |

User chose 12 GB; if image-updater is added to the hub later, evaluate going to 16 GB then (ticket to be captured).

## Test plan
- [x] Lint: pre-commit + yamllint clean
- [x] Runbook in vault with full procedure + rollback + cost
- [ ] Post-merge: `cd infra/terraform/aws && terraform plan` → expect 1 in-place change on `aws_instance.argo_hub.root_block_device.volume_size`
- [ ] Post-merge: `terraform apply` → AWS modify-volume completes (~30s)
- [ ] Post-merge: `ssh deployer@aws1.kubelab.internal sudo reboot` → cloud-init grows partition + ext4
- [ ] Post-merge: `df -h /` reports ~11.5 GB usable
- [ ] Post-merge: kubelet `disk-pressure` condition stays `False` under steady-state Argo CD load

## References

- Lesson 2026-05-10 "Helm upgrade on disk-constrained node creates pull-evict-prune-pull death loop" (`90-lessons.md`)
- ADR-023 (Hub-and-Spoke Multi-Cloud GitOps)
- ADR-026 (Spot = cattle, not pets)
- Runbook (`40-runbooks/aws1-ebs-resize.md`) — created by this PR's vault sibling