### PR TITLE
feat(ansible): persistent journald + logrotate hourly (ANSIBLE-023)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,5 +121,8 @@ apps/wiki/generated_docs
 # Regenerate with: make deploy-k8s ENV=<env> (or toolkit infra k8s deploy --env <env>)
 # Previously gitignored, unignored for ARGO-007.
 
+# Ansible runtime cache (collections/modules/roles installed locally)
+.ansible/
+
 # Security scanning
 .cache_ggshield

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,20 @@
+---
+# Project-wide yamllint config.
+# Default line-length (80) is too tight for Ansible role tasks and K8s manifests.
+# 100 is the sweet spot — readable on side-by-side diffs and matches modern norms
+# (Prettier default, Go fmt style). Keep at 100 unless a real long-line case
+# (Argon2 hash, long URL) justifies a per-file override.
+extends: default
+
+rules:
+  line-length:
+    max: 100
+    level: warning
+  document-start: disable
+  truthy:
+    check-keys: false
+  comments-indentation: disable
+  # Allow either `{ key: val }` (compact) or `{key: val}` styles.
+  braces:
+    min-spaces-inside: 0
+    max-spaces-inside: 1

--- a/infra/ansible/roles/base_system/defaults/main.yml
+++ b/infra/ansible/roles/base_system/defaults/main.yml
@@ -29,3 +29,25 @@ firewall_allowed_ports:
   - { port: 41641, proto: udp }
 
 deploy_base_dir: "/opt"
+
+# --- Persistent journald + log retention bounds (ANSIBLE-023) ---
+# rpi3 outage 2026-05-11: journald ran volatile, crash forensics lost on power cycle.
+# These are explicit (do not rely on Storage=auto) and capped for low-disk nodes.
+journald_storage: "persistent"
+journald_system_max_use: "20M"
+journald_system_keep_free: "50M"
+journald_runtime_max_use: "10M"
+
+# --- Logrotate cadence (ANSIBLE-023) ---
+# Default logrotate.timer is daily — a burst between runs can fill the FS.
+# Hourly cadence means per-file `size` directives in /etc/logrotate.d/* trigger
+# near-real-time. RandomizedDelaySec spreads jitter across the fleet.
+logrotate_schedule: "hourly"
+logrotate_randomized_delay: "10m"
+
+# --- rsyslog active-file size cap (ANSIBLE-023) ---
+# Add `size <N>` to the /var/log/syslog block in /etc/logrotate.d/rsyslog so
+# logrotate rotates the active file before it crosses N (defense in depth on
+# top of node_maintenance maintenance_active_log_max_mb truncate).
+# Silently skipped on nodes where rsyslog is inactive (e.g. rpi3 trixie).
+rsyslog_logrotate_size_cap: "50M"

--- a/infra/ansible/roles/base_system/handlers/main.yml
+++ b/infra/ansible/roles/base_system/handlers/main.yml
@@ -6,3 +6,23 @@
 
 - name: apply netplan
   command: netplan apply
+
+- name: restart systemd-journald
+  systemd:
+    name: systemd-journald
+    state: restarted
+    daemon_reload: true
+
+# `restart systemd-journald` re-reads config but does NOT migrate the active
+# journal from /run/log/journal to /var/log/journal. journalctl --flush is the
+# canonical way to trigger that migration. Always notified together with the
+# restart handler so a config change actually takes effect end-to-end.
+- name: flush journald to persistent storage
+  command: journalctl --flush
+  changed_when: false
+
+- name: restart logrotate timer
+  systemd:
+    name: logrotate.timer
+    state: restarted
+    daemon_reload: true

--- a/infra/ansible/roles/base_system/tasks/main.yml
+++ b/infra/ansible/roles/base_system/tasks/main.yml
@@ -100,3 +100,104 @@
     path: "{{ deploy_base_dir }}"
     state: directory
     mode: "0755"
+
+# --- Persistent journald (ANSIBLE-023) -------------------------------------
+# rpi3 outage 2026-05-11 lost crash forensics because journald ran volatile.
+# Storage=auto is unreliable on hosts where /var/log/journal lacks a machine-id
+# subdir at journald start. Force persistent + cap size for low-disk nodes.
+- name: Ensure persistent journal directory exists
+  file:
+    path: /var/log/journal
+    state: directory
+    owner: root
+    group: systemd-journal
+    mode: "2755"
+  tags: [base, logging, journald]
+
+- name: Ensure journald drop-in dir exists
+  file:
+    path: /etc/systemd/journald.conf.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  tags: [base, logging, journald]
+
+# Filename prefix '99-' is intentional. On Raspberry Pi OS / Debian RPi images,
+# /usr/lib/systemd/journald.conf.d/40-rpi-volatile-storage.conf ships
+# Storage=volatile by default (preserves SD card life). systemd merges drop-ins
+# lexicographically across /etc and /usr/lib, so '00-' would lose to '40-'.
+# '99-' wins. Trade-off accepted: we cap SystemMaxUse to 20M to bound SD wear.
+- name: Drop in kubelab journald config
+  template:
+    src: journald-kubelab.conf.j2
+    dest: /etc/systemd/journald.conf.d/99-kubelab.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify:
+    - restart systemd-journald
+    - flush journald to persistent storage
+  tags: [base, logging, journald]
+
+- name: Remove legacy 00-kubelab.conf if present (renamed to 99-kubelab.conf)
+  file:
+    path: /etc/systemd/journald.conf.d/00-kubelab.conf
+    state: absent
+  notify:
+    - restart systemd-journald
+    - flush journald to persistent storage
+  tags: [base, logging, journald]
+
+# --- Logrotate cadence (ANSIBLE-023) ---------------------------------------
+# Default logrotate.timer runs daily. A burst between runs can fill the FS
+# even with per-file `size` directives, because those only evaluate when the
+# timer fires. Hourly + jitter keeps disk bounded across the fleet.
+- name: Ensure logrotate timer drop-in dir exists
+  file:
+    path: /etc/systemd/system/logrotate.timer.d
+    state: directory
+    mode: "0755"
+  tags: [base, logging, logrotate]
+
+- name: Drop in kubelab logrotate.timer override
+  template:
+    src: logrotate-timer-kubelab.conf.j2
+    dest: /etc/systemd/system/logrotate.timer.d/00-kubelab.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart logrotate timer
+  tags: [base, logging, logrotate]
+
+# --- rsyslog size cap (ANSIBLE-023) ----------------------------------------
+# Skipped on nodes where /etc/logrotate.d/rsyslog is absent or empty (Debian
+# trixie + rpi3 use journald-only). Only patches when a /var/log/syslog block
+# is actually present so logrotate has something to rotate.
+- name: Probe /etc/logrotate.d/rsyslog
+  stat:
+    path: /etc/logrotate.d/rsyslog
+  register: _rsyslog_logrotate
+  tags: [base, logging, logrotate]
+
+- name: Detect /var/log/syslog block in rsyslog logrotate config
+  command: grep -q '^/var/log/syslog$' /etc/logrotate.d/rsyslog
+  register: _rsyslog_has_syslog_block
+  changed_when: false
+  failed_when: false
+  when:
+    - _rsyslog_logrotate.stat.exists
+    - _rsyslog_logrotate.stat.size | int > 0
+  tags: [base, logging, logrotate]
+
+- name: Cap active /var/log/syslog at {{ rsyslog_logrotate_size_cap }}
+  lineinfile:
+    path: /etc/logrotate.d/rsyslog
+    insertafter: '^/var/log/syslog$'
+    line: "    size {{ rsyslog_logrotate_size_cap }}"
+    state: present
+  when:
+    - _rsyslog_logrotate.stat.exists
+    - _rsyslog_logrotate.stat.size | int > 0
+    - _rsyslog_has_syslog_block.rc | default(1) == 0
+  tags: [base, logging, logrotate]

--- a/infra/ansible/roles/base_system/templates/journald-kubelab.conf.j2
+++ b/infra/ansible/roles/base_system/templates/journald-kubelab.conf.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+# kubelab journald drop-in (ANSIBLE-023)
+# Forces persistent storage and caps disk usage so crash forensics survive
+# reboots even on low-disk nodes (1 GB rpi3, 2 GB t4g.small).
+[Journal]
+Storage={{ journald_storage }}
+SystemMaxUse={{ journald_system_max_use }}
+SystemKeepFree={{ journald_system_keep_free }}
+RuntimeMaxUse={{ journald_runtime_max_use }}

--- a/infra/ansible/roles/base_system/templates/logrotate-timer-kubelab.conf.j2
+++ b/infra/ansible/roles/base_system/templates/logrotate-timer-kubelab.conf.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+# kubelab logrotate.timer override (ANSIBLE-023)
+# Run logrotate hourly instead of daily so per-file `size` directives in
+# /etc/logrotate.d/* take effect near-real-time and bursts cannot fill disk
+# between cron runs.
+[Timer]
+OnCalendar=
+OnCalendar={{ logrotate_schedule }}
+RandomizedDelaySec={{ logrotate_randomized_delay }}

--- a/infra/ansible/roles/node_maintenance/tasks/main.yml
+++ b/infra/ansible/roles/node_maintenance/tasks/main.yml
@@ -4,6 +4,23 @@
 # Works on all node types: K3s, Docker, hub, gateway
 # =============================================================================
 
+# --- Forensic sanity check (ANSIBLE-023) ---
+# Persistent journald is configured by base_system role. Surface a warning if
+# /var/log/journal is missing so an unprovisioned node is noticed during the
+# next scheduled maintenance run.
+- name: Probe persistent journal directory
+  stat:
+    path: /var/log/journal
+  register: _journal_dir
+  changed_when: false
+
+- name: Warn if persistent journal directory is missing
+  debug:
+    msg: >-
+      WARNING: /var/log/journal missing — journald is volatile, crash forensics
+      will be lost on reboot. Re-run base_system role (ANSIBLE-023).
+  when: not _journal_dir.stat.exists
+
 # --- Pre-cleanup report ---
 - name: Report disk usage (before)
   command: df -h /


### PR DESCRIPTION
## Summary

- Force persistent journald on every node so the **next** crash leaves forensics behind. Triggered by today's rpi3 outage where `journalctl -b -1` returned "no persistent journal" and we lost every byte of evidence at power-cycle.
- Tighten logrotate cadence to hourly so per-file `size` directives bound disk usage in near-real-time instead of waiting up to 24h.
- Tooling: project-wide `.yamllint` (line-length 100), `.gitignore` ansible cache.

## What changed

**`base_system` role**:
- `/etc/systemd/journald.conf.d/99-kubelab.conf` — `Storage=persistent`, `SystemMaxUse=20M`, `SystemKeepFree=50M`, `RuntimeMaxUse=10M`. The `99-` prefix is **intentional**: Debian RPi images ship `/usr/lib/systemd/journald.conf.d/40-rpi-volatile-storage.conf` (forces volatile to spare the SD card). Drop-ins merge lexicographically across `/etc` and `/usr/lib`, so a `00-` prefix loses to the system's `40-`. Trade-off accepted: cap at 20M minimises SD wear.
- Handler pair: `restart systemd-journald` + `flush journald to persistent storage`. Restart alone re-reads config but does **not** migrate the active journal from `/run` to `/var` — `journalctl --flush` is the canonical follow-up.
- `/etc/systemd/system/logrotate.timer.d/00-kubelab.conf` — `OnCalendar=hourly` (was daily).
- Idempotent `size 50M` injection in `/etc/logrotate.d/rsyslog` when a `/var/log/syslog` block is present. Silently skips on Debian 13 trixie (rpi3, journald-only).
- Removes legacy `00-kubelab.conf` if a previous run left it behind.

**`node_maintenance` role**:
- Warns when `/var/log/journal` is missing — surfaces unprovisioned nodes without failing the run.

**Tooling**:
- `.yamllint`: line-length max 100 (was default 80). CI's inline 120 and pre-commit's 130 untouched.
- `.gitignore`: add `.ansible/` runtime cache.

## Test plan

Tested on rpi3 (Debian 13 trixie):
- [x] `--check` clean (apart from expected apt false positive per lesson 2026-05-10 — out of scope, used `-t logging` to skip)
- [x] Real apply: 6 changes, handlers fire `restart` + `flush`
- [x] Re-apply: `changed=0` (idempotent)
- [x] `journalctl --header` reports `/var/log/journal/<machine-id>/system.journal` (was `/run/log/journal/`)
- [x] `journalctl --disk-usage`: 6.8M (under 20M cap)
- [x] `systemctl list-timers logrotate.timer`: next trigger within the hour
- [x] `make maintain NODE=rpi3` runs clean, sanity-check task does not fire (journal dir exists)

## Roll-out plan

- [x] rpi3 (this PR's testbed)
- [ ] rpi4, beelink, ace1, ace2, aws1, jetson, vps — one at a time post-merge, via the same `-t logging` tag

## Out of scope

- `provision-rpi3.yml` playbook (same cloud-init-day-2 gap as AWS-001..005 → RELIAB-009 §9.0). Separate ticket.
- SD card lifetime monitoring (read `/sys/block/mmcblk0/device/life_time`). Separate ticket worth doing for rpi3/rpi4.

Refs: vault `10_projects/kubelab/11-tasks.md` ANSIBLE-023, SSOT-003 (sibling ticket from the same incident).