### PR TITLE
fix(aws): ignore AMI/user_data drift on aws1 Spot (AWS-003)

### DIFF
--- a/infra/terraform/aws/main.tf
+++ b/infra/terraform/aws/main.tf
@@ -171,4 +171,14 @@ resource "aws_spot_instance_request" "argo_hub" {
     ManagedBy   = "terraform"
     Role        = "argo-cd"
   }
+
+  # Cattle pattern (ADR-028): replacements are deliberate, not side effects.
+  # data.aws_ami.ubuntu uses most_recent=true → fresh Canonical AMIs land every
+  # plan, which would otherwise destroy+recreate the Spot on routine ops like
+  # an EBS resize. user_data is ignored for the same reason: SOPS rotations
+  # (tailscale_authkey, headscale_api_key) must not force replacement.
+  # To re-roll the instance with a fresh AMI/user_data: `make aws1-replace`.
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
 }


### PR DESCRIPTION
## Summary

- Adds `lifecycle { ignore_changes = [ami, user_data] }` on `aws_spot_instance_request.argo_hub` so that fresh Canonical AMIs and routine SOPS rotations stop triggering destroy+recreate of the Argo CD hub Spot.
- Unblocks application of PR #165 (`feat/aws-002-ebs-resize-12gb`): `make tf-aws-apply` now performs an online `ec2:ModifyVolume` (8 → 12 GB) instead of destroying the running instance.

## Why

`data.aws_ami.ubuntu` is declared with `most_recent = true`. Canonical publishes new Ubuntu 24.04 ARM64 images regularly, so every `terraform plan` resolves to an AMI newer than the one in state — and `ami` is a `ForceNew` attribute on `aws_spot_instance_request`. Result: ANY plan (EBS resize, SG tweak, tag change) was marked `must be replaced`. For cattle infra (ADR-028) replacements must be deliberate, not side effects.

`user_data` is also ignored because it embeds short-lived SOPS-rotated secrets (`tailscale_authkey`, `headscale_api_key`) — routine rotations must not destroy the Spot either.

Deliberate replacements (kernel pin, K3s major version bumps, degraded-instance rebootstrap) will be wired in a follow-up PR as a `make aws1-replace` target — kept out of this PR to stay atomic at ~10 lines.

## Validation (live state, eu-central-1, aws1 running Argo CD)

**Baseline** — `terraform plan` without the lifecycle block:

\`\`\`
Plan: 1 to add, 0 to change, 1 to destroy.

  # aws_spot_instance_request.argo_hub must be replaced
-/+ resource "aws_spot_instance_request" "argo_hub" {
      ~ ami = "ami-023c2be60b92b00a3" -> "ami-050a364ece0d45bcd" # forces replacement
      ...
      ~ root_block_device {
          ~ volume_size = 8 -> 12
        }
    }
\`\`\`

**After** — same plan with the lifecycle block:

\`\`\`
Plan: 0 to add, 1 to change, 0 to destroy.

  # aws_spot_instance_request.argo_hub will be updated in-place
  ~ resource "aws_spot_instance_request" "argo_hub" {
      ~ root_block_device {
          ~ volume_size = 8 -> 12
        }
    }
\`\`\`

Output-only diffs (\`ami_id\`, \`public_ip\`) still appear in the after-plan — they are cosmetic refreshes of computed values and do not trigger replacement.

## Context

Discovered 2026-05-10 during the application of PR #165, which got merged but was never \`terraform apply\`-ed for this exact reason. The session today (2026-05-11) hit \`argo.kubelab.live = 502\` again because aws1 returned to DiskPressure on the original 8 GB EBS — \`make maintain NODE=aws1 ENV=hub\` recovered it short-term, but the structural fix (12 GB resize) needs this PR first.

Lesson captured: see \`90-lessons.md\` 2026-05-10 entry "Terraform data.aws_ami filter drift triggers Spot replacement on every plan" (already in vault). Runbook \`40-runbooks/aws1-ebs-resize.md\` updated to list the lifecycle block as a hard prerequisite of the resize procedure.

## Test plan

- [x] \`terraform plan\` baseline captured (\`1 to destroy\`, ami forces replacement)
- [x] \`terraform plan\` with lifecycle block (\`0 to destroy\`, in-place volume_size only)
- [ ] Post-merge: \`make tf-aws-plan\` once more on master, confirm no replacement
- [ ] \`make tf-aws-apply\` → AWS issues \`ec2:ModifyVolume\`, volume reaches \`optimizing\` then \`in-use\` ~30s, no Spot recreation
- [ ] \`ssh aws1 sudo reboot\` → cloud-init \`cc_growpart\` + \`cc_resizefs\` expand partition + ext4
- [ ] Verify \`df -h /\` ≈ 11.5 GB usable, \`kubectl describe node aws1 | grep Taints\` shows no \`disk-pressure\`
- [ ] Argo CD hub returns to 6/6 Running on the resized volume

## Related

- Unblocks: PR #165 (\`feat/aws-002-ebs-resize-12gb\`)
- Follow-up: \`make aws1-replace\` Makefile target (separate PR)
- ADR-028 (cattle vs pets, on-demand vs always-on topology)