### PR TITLE
refactor(aws): migrate aws1 to aws_instance + instance_market_options (AWS-003)

### DIFF
--- a/infra/terraform/aws/main.tf
+++ b/infra/terraform/aws/main.tf
@@ -131,18 +131,29 @@ resource "aws_key_pair" "deployer" {
 # ---------------------------------------------------------------------------
 # Spot Instance (Argo CD Hub)
 # ---------------------------------------------------------------------------
+#
+# Uses aws_instance + instance_market_options (modern Spot API via
+# RunInstances) instead of the legacy aws_spot_instance_request resource.
+# The legacy resource does NOT propagate root_block_device updates to the
+# underlying EBS volume (provider issue hashicorp/terraform-provider-aws#4252),
+# turning every EBS resize into a destroy+recreate. aws_instance handles
+# root_block_device updates correctly via ec2:ModifyVolume.
 
-resource "aws_spot_instance_request" "argo_hub" {
+resource "aws_instance" "argo_hub" {
   ami                    = data.aws_ami.ubuntu.id
   instance_type          = var.instance_type
   key_name               = aws_key_pair.deployer.key_name
   vpc_security_group_ids = [aws_security_group.argo_hub.id]
   subnet_id              = data.aws_subnets.default.ids[0]
 
-  # Spot config
-  spot_type                      = "persistent"
-  instance_interruption_behavior = "stop"
-  wait_for_fulfillment           = true
+  # Spot config — modern API, mirrors the previous persistent + stop behaviour.
+  instance_market_options {
+    market_type = "spot"
+    spot_options {
+      spot_instance_type             = "persistent"
+      instance_interruption_behavior = "stop"
+    }
+  }
 
   # EBS root volume
   root_block_device {
@@ -153,15 +164,15 @@ resource "aws_spot_instance_request" "argo_hub" {
 
   # cloud-init bootstrap
   user_data = templatefile("${path.module}/cloud-init.yml", {
-    hostname            = var.hostname
-    deploy_user         = var.deploy_user
-    ssh_public_key      = file(var.ssh_public_key_path)
-    timezone            = var.timezone
-    k3s_version         = var.k3s_version
-    headscale_url       = var.headscale_url
-    tailscale_authkey   = var.tailscale_authkey
-    tailscale_hostname  = var.hostname
-    headscale_api_key   = var.headscale_api_key
+    hostname           = var.hostname
+    deploy_user        = var.deploy_user
+    ssh_public_key     = file(var.ssh_public_key_path)
+    timezone           = var.timezone
+    k3s_version        = var.k3s_version
+    headscale_url      = var.headscale_url
+    tailscale_authkey  = var.tailscale_authkey
+    tailscale_hostname = var.hostname
+    headscale_api_key  = var.headscale_api_key
   })
 
   tags = {
@@ -174,10 +185,11 @@ resource "aws_spot_instance_request" "argo_hub" {
 
   # Cattle pattern (ADR-028): replacements are deliberate, not side effects.
   # data.aws_ami.ubuntu uses most_recent=true → fresh Canonical AMIs land every
-  # plan, which would otherwise destroy+recreate the Spot on routine ops like
-  # an EBS resize. user_data is ignored for the same reason: SOPS rotations
-  # (tailscale_authkey, headscale_api_key) must not force replacement.
-  # To re-roll the instance with a fresh AMI/user_data: `make aws1-replace`.
+  # plan, which would otherwise destroy+recreate the instance on routine ops
+  # like an EBS resize. user_data is ignored for the same reason: SOPS
+  # rotations (tailscale_authkey, headscale_api_key) must not force
+  # replacement. To re-roll the instance with a fresh AMI/user_data:
+  # `make aws1-replace`.
   lifecycle {
     ignore_changes = [ami, user_data]
   }

--- a/infra/terraform/aws/outputs.tf
+++ b/infra/terraform/aws/outputs.tf
@@ -1,16 +1,16 @@
+output "instance_id" {
+  description = "EC2 instance ID"
+  value       = aws_instance.argo_hub.id
+}
+
 output "spot_request_id" {
-  description = "Spot instance request ID"
-  value       = aws_spot_instance_request.argo_hub.id
+  description = "Underlying Spot Persistent Request ID (informational)"
+  value       = aws_instance.argo_hub.spot_instance_request_id
 }
 
 output "public_ip" {
   description = "Public IP (temporary — only for SSH bootstrap)"
-  value       = aws_spot_instance_request.argo_hub.public_ip
-}
-
-output "instance_id" {
-  description = "EC2 instance ID"
-  value       = aws_spot_instance_request.argo_hub.spot_instance_id
+  value       = aws_instance.argo_hub.public_ip
 }
 
 output "ami_id" {
@@ -20,14 +20,14 @@ output "ami_id" {
 
 output "ssh_command" {
   description = "SSH command for bootstrap access"
-  value       = "ssh ${var.deploy_user}@${aws_spot_instance_request.argo_hub.public_ip}"
+  value       = "ssh ${var.deploy_user}@${aws_instance.argo_hub.public_ip}"
 }
 
 output "next_steps" {
   description = "Post-apply instructions"
   value       = <<-EOT
     1. Wait ~5 min for cloud-init to complete
-    2. SSH: ssh ${var.deploy_user}@${aws_spot_instance_request.argo_hub.public_ip}
+    2. SSH: ssh ${var.deploy_user}@${aws_instance.argo_hub.public_ip}
     3. Verify Tailscale: tailscale status (should show as aws1)
     4. Verify MagicDNS: dig aws1.kubelab.internal (should resolve to Tailscale IP)
     5. Fetch kubeconfig: make fetch-kubeconfig-hub


### PR DESCRIPTION
## Summary

- Migrates `aws_spot_instance_request.argo_hub` → `aws_instance.argo_hub` + `instance_market_options.spot_options` (modern Spot API). Same instance, same lifecycle, same tags.
- Applied zero-downtime via `terraform state rm` + `terraform import` of the existing EC2 (`i-0be7ecf199975bf1a`).
- Unblocks all future in-place EBS / root_block_device operations on aws1.
- Resolves the AWS-003 blocker that prevented PR #165 (EBS 8 → 12 GB) from actually applying.

## Why

PR #167 added `lifecycle { ignore_changes = [ami, user_data] }` to the legacy `aws_spot_instance_request` so that fresh Canonical AMIs wouldn't force replacement. The follow-up `make tf-aws-apply` reported success in 1 second — but AWS-side reality showed the volume still at 8 GB and `describe-volumes-modifications` returned `InvalidVolumeModification.NotFound`. The provider silently dropped the `root_block_device.volume_size` change.

This is the long-standing [hashicorp/terraform-provider-aws#4252](https://github.com/hashicorp/terraform-provider-aws/issues/4252): the `aws_spot_instance_request` resource manages the Spot Request, not the launched EC2, and `root_block_device` updates don't propagate to the underlying EBS volume. The 1-second apply duration was the tell — a real `ec2:ModifyVolume` takes ≥10s to enter `optimizing`.

The modern fix is `aws_instance` + `instance_market_options { market_type = "spot"; spot_options { ... } }`, which uses the unified `RunInstances + InstanceMarketOptions` API and handles `root_block_device` updates correctly.

## Changes

\`main.tf\`:

\`\`\`diff
-resource "aws_spot_instance_request" "argo_hub" {
-  spot_type                      = "persistent"
-  instance_interruption_behavior = "stop"
-  wait_for_fulfillment           = true
+resource "aws_instance" "argo_hub" {
+  instance_market_options {
+    market_type = "spot"
+    spot_options {
+      spot_instance_type             = "persistent"
+      instance_interruption_behavior = "stop"
+    }
+  }
\`\`\`

`lifecycle { ignore_changes = [ami, user_data] }` preserved. user_data templatefile, tags, SG, subnet, key — all unchanged.

\`outputs.tf\`: rewrites references —

| Old | New |
|---|---|
| `aws_spot_instance_request.argo_hub.id` | `aws_instance.argo_hub.spot_instance_request_id` |
| `aws_spot_instance_request.argo_hub.spot_instance_id` | `aws_instance.argo_hub.id` |
| `aws_spot_instance_request.argo_hub.public_ip` | `aws_instance.argo_hub.public_ip` |

## Zero-downtime migration (already executed on live state)

\`\`\`
1. cp terraform.tfstate terraform.tfstate.pre-aws-instance         # safety net
2. terraform state rm aws_spot_instance_request.argo_hub           # drop from state, AWS untouched
3. terraform import aws_instance.argo_hub i-0be7ecf199975bf1a      # re-adopt under new type
4. terraform plan
   -> Plan: 0 to add, 1 to change, 0 to destroy
   -> ~ root_block_device { ~ volume_size = 8 -> 12 } + tag fix
5. make tf-aws-apply
   -> Still modifying... 10s, 20s, 30s (real ec2:ModifyVolume)
   -> Modifications complete after 35s
6. ssh aws1 'sudo growpart /dev/nvme0n1 1 && sudo resize2fs /dev/root'
   -> partition expanded 14677983 → 23066591 sectors
   -> ext4 resized online, no remount, no reboot
\`\`\`

## Validation (live)

- **Same EC2**: `i-0be7ecf199975bf1a` (no replacement) → Tailscale machine key intact → Headscale registration intact.
- **Same Spot Request**: `sir-xng7dfkh` (backed instance lifecycle unchanged from AWS's perspective).
- **Argo CD pods**: 6/6 Running, **age = 11h through the operation** (no restart, no reschedule).
- **`argo.kubelab.live`**: HTTP 200 throughout.
- **Filesystem**: `/dev/root` 8G→11G online, `df -h /` went 94% → 60% (4.4 GB free).
- **Node**: `kubectl describe node aws1 | grep Taints` → `<none>` (no disk-pressure).

## Known caveat → AWS-004 follow-up

`terraform state rm aws_spot_instance_request.argo_hub` removed the resource from state but the underlying **Spot Persistent Request** (`sir-xng7dfkh`) is still active in AWS. The new `aws_instance` resource references it as a computed `spot_instance_request_id` but does NOT manage its lifecycle.

Implication: a future `terraform destroy aws_instance.argo_hub` will terminate the EC2 but the Spot Request will keep retrying to launch a replacement (free of charge, but zombie). Tracked as **AWS-004**: add `make aws1-destroy` wrapper that runs `aws ec2 cancel-spot-instance-requests --spot-instance-request-ids $(terraform output -raw spot_request_id)` before `terraform destroy`.

## Notes

- `terraform.tfstate.pre-aws-instance` backup preserved on workstation (not committed; tfstate is gitignored).
- Runbook `40-runbooks/aws1-ebs-resize.md` rewritten in the vault: new prerequisite (lifecycle on `aws_instance`), new procedure (growpart + online resize2fs, no reboot), new validation block.
- Lesson captured in `90-lessons.md` 2026-05-11: "aws_spot_instance_request silently drops root_block_device updates — migrate to aws_instance + instance_market_options".
- PR #167 (the lifecycle block on the legacy resource) is retained in history — the `ignore_changes` clause is still correct on the new `aws_instance` and carries over.

## Test plan

- [x] `terraform plan` shows in-place update only (volume_size 8 → 12 + tag fix)
- [x] `terraform apply` invokes ec2:ModifyVolume (35s duration)
- [x] `aws ec2 describe-volumes-modifications` reports `optimizing` → eventually `completed`
- [x] `growpart` + online `resize2fs` succeed on the running instance
- [x] No EC2 restart, no Tailscale reconnect, no Argo CD pod restart
- [x] `argo.kubelab.live` stays HTTP 200 throughout
- [ ] Post-merge: open AWS-004 PR (`make aws1-destroy`)