### PR TITLE
feat(aws): aws1-destroy + aws1-replace wrappers manage orphaned Spot Request (AWS-006)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -631,6 +631,35 @@ tf-aws-destroy:
 	@cd infra/terraform/aws && terraform destroy -var-file=aws.tfvars
 	@rm -f infra/terraform/aws/aws.tfvars
 
+# aws1 lifecycle wrappers — cancel the underlying Spot Persistent Request
+# BEFORE terraform destroy/replace. Without this, AWS keeps the request
+# active and relaunches a replacement instance after terraform terminates
+# the EC2, costing money and creating zombie nodes outside Terraform.
+# The Spot Request is orphaned from state since the AWS-003 refactor
+# (state rm aws_spot_instance_request + import aws_instance) — it lives
+# in AWS only and must be cancelled out-of-band.
+.PHONY: aws1-destroy aws1-replace _aws1-cancel-spot-request
+_aws1-cancel-spot-request:
+	@SIR=$$(cd infra/terraform/aws && terraform output -raw spot_request_id 2>/dev/null) && \
+		if [ -n "$$SIR" ] && [ "$$SIR" != "null" ]; then \
+			echo "Cancelling Spot Persistent Request $$SIR..." && \
+			aws ec2 cancel-spot-instance-requests \
+				--spot-instance-request-ids $$SIR \
+				--profile kubelab --region eu-central-1 \
+				--output text >/dev/null && \
+			echo "✓ Spot Request cancelled"; \
+		else \
+			echo "No spot_request_id in terraform state — skipping cancellation"; \
+		fi
+
+aws1-destroy: _aws1-cancel-spot-request tf-aws-destroy
+
+aws1-replace: _aws1-cancel-spot-request
+	@$(POETRY) run toolkit infra terraform aws-tfvars
+	@cd infra/terraform/aws && terraform apply -auto-approve -var-file=aws.tfvars -replace=aws_instance.argo_hub
+	@rm -f infra/terraform/aws/aws.tfvars
+	@echo "✓ aws1 replaced. Wait ~5 min for cloud-init, then run: make deploy-argocd"
+
 # Terraform DNS (Cloudflare) — SOPS-injected token
 .PHONY: tf-dns-plan tf-dns-apply
 tf-dns-plan:


### PR DESCRIPTION
## Summary

- Adds `make aws1-destroy` and `make aws1-replace` wrappers that cancel the underlying Spot Persistent Request (`aws ec2 cancel-spot-instance-requests`) before tearing down or replacing the EC2.
- Closes the codex **P1 review comment** on PR #168 ("Avoid unmanaged persistent Spot request mode").
- Closes backlog ticket AWS-006 (renumbered to avoid collision with the historical AWS-004 = Headscale pre-auth key).

## Why

The AWS-003 refactor (PR #168) migrated `aws_spot_instance_request` → `aws_instance` + `instance_market_options.spot_options` via `terraform state rm` + `terraform import`. That preserved the running EC2 zero-downtime, but the underlying Spot Persistent Request (`sir-xng7dfkh`) became orphaned from Terraform state — it lives in AWS only and is referenced read-only as `aws_instance.argo_hub.spot_instance_request_id`.

> Codex P1 comment (PR #168 inline, main.tf:153):
> *"Setting `spot_instance_type = \"persistent\"` on `aws_instance` creates a Spot request that `terraform destroy` does not manage through this resource, so running the existing destroy workflow can terminate the current EC2 and leave an active request that relaunches a replacement instance."*

Without these wrappers, a bare `make tf-aws-destroy` would terminate the EC2 but AWS would honour the still-active Spot Persistent Request and relaunch a replacement within minutes — a zombie outside Terraform.

## Changes

\`Makefile\`:

\`\`\`
.PHONY: aws1-destroy aws1-replace _aws1-cancel-spot-request

_aws1-cancel-spot-request:
    # reads spot_request_id from terraform output
    # invokes aws ec2 cancel-spot-instance-requests
    # idempotent: no-op when output is empty

aws1-destroy: _aws1-cancel-spot-request tf-aws-destroy

aws1-replace: _aws1-cancel-spot-request
    # toolkit aws-tfvars + terraform apply -replace=aws_instance.argo_hub
    # cleanup tfvars
\`\`\`

29 lines total, fully DRY (no duplicated cancellation logic).

## Usage

\`\`\`bash
# Decommission aws1 fully (cancels Spot Request → terminates EC2)
make aws1-destroy

# Deliberate cattle re-roll (cancels Spot Request → terraform replace → manual deploy-argocd)
make aws1-replace
# wait ~5 min for cloud-init
make deploy-argocd
\`\`\`

\`aws1-replace\` is the blessed cattle re-roll path. Because \`aws_instance.argo_hub\` has \`lifecycle { ignore_changes = [ami, user_data] }\` (from PR #167), accidental replacement on routine plans is impossible; \`-replace=aws_instance.argo_hub\` is the explicit override.

## Test plan

- [x] \`make -n aws1-destroy\` shows correct shell recipe (dry-run validated locally)
- [x] \`make -n aws1-replace\` shows correct shell recipe
- [x] Internal target is idempotent: prints "No spot_request_id in terraform state — skipping cancellation" when output empty
- [ ] (Future) live test on a non-prod Spot when one exists — current aws1 is hub prod, can't be torn down for a smoke test

## Docs

- New runbook: \`40-runbooks/aws1-destroy-replace.md\` (procedures + history of why these wrappers exist).
- Updated runbook: \`40-runbooks/aws1-ebs-resize.md\` (rollback section now points to \`make aws1-replace\`).
- Backlog: AWS-006 marked \`[x]\` in \`11-tasks.md\`.

## Notes

- The branch name \`feat/aws-004-spot-request-mgmt\` is retained for trace continuity with the codex comment / AWS-003 refactor, but the backlog entry lives under **AWS-006** to avoid collision with the historical AWS-004 (Headscale pre-auth key, done 2026-03-22).
- This is the last piece of the AWS-003 sprint. After merge, the aws1 module is fully clean: in-place EBS resizes work, deliberate replacements are codified, accidental destroys cannot leave zombies.