### PR TITLE
fix(ansible): inject rsyslog size cap inside shared logrotate block (ANSIBLE-025)

### DIFF
--- a/infra/ansible/roles/base_system/tasks/main.yml
+++ b/infra/ansible/roles/base_system/tasks/main.yml
@@ -190,12 +190,32 @@
     - _rsyslog_logrotate.stat.size | int > 0
   tags: [base, logging, logrotate]
 
-- name: Cap active /var/log/syslog at {{ rsyslog_logrotate_size_cap }}
-  lineinfile:
+# ANSIBLE-025: the previous lineinfile used `insertafter: ^/var/log/syslog$`,
+# which lands the directive BETWEEN the syslog path and the next entry — i.e.
+# outside the `{ ... }` block, where logrotate treats it as a second path and
+# silently ignores the cap. Ubuntu's stock rsyslog config groups 6 paths
+# (syslog, mail.log, kern.log, auth.log, user.log, cron.log) into a single
+# block, so the directive must land inside the shared `{ ... }`.
+- name: Scrub mis-inserted size line after /var/log/syslog path (ANSIBLE-023 bug)
+  ansible.builtin.replace:
     path: /etc/logrotate.d/rsyslog
-    insertafter: '^/var/log/syslog$'
-    line: "    size {{ rsyslog_logrotate_size_cap }}"
-    state: present
+    regexp: '(^/var/log/syslog\n)\s*size\s+\S+\n'
+    replace: '\1'
+  when:
+    - _rsyslog_logrotate.stat.exists
+    - _rsyslog_logrotate.stat.size | int > 0
+    - _rsyslog_has_syslog_block.rc | default(1) == 0
+  tags: [base, logging, logrotate]
+
+# Capture the full path-group that contains /var/log/syslog up to and
+# including the opening `{`, then inject the size cap immediately inside.
+# Negative lookahead `(?!\s*size\s)` makes the task idempotent — on re-run,
+# the next line after `{` is already `<ws>size <N>`, so no match.
+- name: Cap shared /var/log/syslog block at {{ rsyslog_logrotate_size_cap }}
+  ansible.builtin.replace:
+    path: /etc/logrotate.d/rsyslog
+    regexp: '(^(?:/var/log/\S+\n)*?/var/log/syslog\n(?:/var/log/\S+\n)*\{\n)(?!\s*size\s)'
+    replace: '\1    size {{ rsyslog_logrotate_size_cap }}\n'
   when:
     - _rsyslog_logrotate.stat.exists
     - _rsyslog_logrotate.stat.size | int > 0


### PR DESCRIPTION
## Summary

- Replaces the buggy `lineinfile` (`insertafter: '^/var/log/syslog$'`) from PR #166 with two `ansible.builtin.replace` tasks that put `size {{ rsyslog_logrotate_size_cap }}` **inside** the `/etc/logrotate.d/rsyslog` block.
- Adds a defensive scrub for any `size N` line that prior runs may have mis-inserted between the syslog path and the next entry.
- Idempotent by construction (negative lookahead on `size`).

## Why

Ubuntu's stock `/etc/logrotate.d/rsyslog` groups six paths (`syslog`, `mail.log`, `kern.log`, `auth.log`, `user.log`, `cron.log`) under **one shared block**. `insertafter: '^/var/log/syslog$'` placed the directive between paths, where logrotate treats it as a phantom path entry and silently ignores the cap. Catches every Ubuntu node we propagate to (rpi4, beelink, ace1, ace2, aws1, vps). Not triggered on rpi3 (Debian trixie has rsyslog inactive, file is empty, skip path engaged).

## Approach

- **Scrub task**: `regexp: '(^/var/log/syslog\n)\s*size\s+\S+\n'` -> `\1` — removes any `size N` line that landed directly after the syslog path.
- **Cap task**: `regexp: '(^(?:/var/log/\S+\n)*?/var/log/syslog\n(?:/var/log/\S+\n)*\{\n)(?!\s*size\s)'` -> `\1    size <cap>\n` — captures the full multi-path group up to and including the opening `{`, then injects the directive immediately inside. Negative lookahead on `\s*size\s` preserves idempotency.

## Test plan

Validated end-to-end on aws1 (2026-05-12) via `toolkit infra ansible run -p provision-aws1 -e hub -t logging`:

- [x] First apply: `changed=1` on Cap (Scrub no-op, no contamination)
- [x] `ssh aws1 "grep -A 10 '^/var/log/syslog\$' /etc/logrotate.d/rsyslog"` — `size 50M` is the first directive after `{`
- [x] Second apply: `changed=0` across all 11 logging tasks (idempotent)
- [x] yamllint clean
- [ ] ANSIBLE-024 roll-out to remaining Ubuntu nodes (rpi4, beelink, ace1, ace2, kubelab-vps, jetson) unblocks after merge

## Notes

aws1 was also fully propagated to ANSIBLE-023 (persistent journald + hourly logrotate) as a side-effect of validation — closes the 502/DiskPressure loop that triggered this sprint.

Multi-path block discovery + corrected regex captured as lesson in vault: `10_projects/kubelab/90-lessons.md` (2026-05-12).