### PR TITLE
feat(argo): toolkit + Makefile set-revision wrapper (TOOL-006)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ help:
 	@echo "  make restart-argocd            Restart Argo CD controller (clear cache)"
 	@echo "  make register-spoke ENV=x      Register spoke cluster in Argo CD hub"
 	@echo "  make unregister-spoke ENV=x    Remove spoke from Argo CD hub"
+	@echo "  make argo-set-revision APP=x REV=y  Patch Application targetRevision (preview/patch-back)"
 	@echo "  make check-spokes              Verify registered spokes are reachable"
 	@echo "  make rotate-spoke-token ENV=x  Rotate spoke SA token and re-register"
 	@echo ""
@@ -459,6 +460,14 @@ restart-argocd:
 	@kubectl --kubeconfig $(HUB_KUBECONFIG) -n argocd rollout restart statefulset argocd-application-controller
 	@kubectl --kubeconfig $(HUB_KUBECONFIG) -n argocd rollout status statefulset argocd-application-controller --timeout=120s
 	@echo "✓ Argo CD restarted (cache flushed)"
+
+# Patch an Argo CD Application's spec.source.targetRevision (preview-per-PR + patch-back).
+# Usage: make argo-set-revision APP=kubelab-staging REV=master
+.PHONY: argo-set-revision
+argo-set-revision:
+	@test -n "$(APP)" || (echo "Usage: make argo-set-revision APP=kubelab-staging REV=master" && exit 1)
+	@test -n "$(REV)" || (echo "Usage: make argo-set-revision APP=kubelab-staging REV=master" && exit 1)
+	@$(TOOLKIT) infra argo set-revision --app $(APP) --rev $(REV)
 
 # Trigger Argo CD sync for an Application
 # Usage: make sync-app APP=kubelab-staging

--- a/specs/TOOL-006-argo-revision-cli/proposal.md
+++ b/specs/TOOL-006-argo-revision-cli/proposal.md
@@ -1,0 +1,54 @@
+---
+id: "TOOL-006-argo-revision-cli"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-05-18"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# TOOL-006-argo-revision-cli
+
+## Why
+
+Argo CD `targetRevision` swaps are a recurrent operation in this repo: previewing a PR on staging requires pointing the `kubelab-staging` Application at the feature branch, and patching it back to `master` after merge. Today both operations are manual `kubectl patch application` calls, which violates `feedback_no_manual_kubectl` and `feedback_never_adhoc_commands`. The 2026-05-13 preview of PR #171 left staging anchored to `fix/dash-ui-cosmetic` after merge — the patch-back was skipped because no Makefile/toolkit target existed. The drift went undetected for 5 days. Closing this gap stops both this incident and the next one.
+
+## What
+
+Two new entry points:
+
+1. `poetry run toolkit infra argo set-revision --app NAME --rev REF` — Typer subcommand that resolves the hub kubeconfig, verifies the Application exists in namespace `argocd`, patches `spec.source.targetRevision` to `REF`, and prints the before/after revision plus the current sync state.
+2. `make argo-set-revision APP=NAME REV=REF` — thin Makefile wrapper around the above so the command surfaces in `make help` and follows the project's "always go through Makefile" rule.
+
+Both commands target the hub cluster (aws1) only.
+
+## Out of scope
+
+- `status` and `list-apps` subcommands (separate future TOOL-XXX once needed).
+- Preview-per-PR ApplicationSet automation (ADR-pending; out of this spec's surface).
+- Validating that `REF` exists on the remote git source (Argo CD surfaces broken refs on next sync; pre-checking adds latency without preventing user error).
+- Spoke clusters (this spec targets the hub Application list only; spoke targeting would require kubeconfig switching logic).
+- Rolling back the revision atomically if the patch succeeds but sync fails (Argo CD self-heal handles that domain).
+
+## Risks / open questions
+
+- **Hub kubeconfig discovery**: existing convention is `~/.kube/kubelab-hub-config` (per lessons). RESOLVED: use `KUBECONFIG_HUB` env var with that path as default; matches the existing toolkit patterns in `cli/monitoring.py` and `cli/infra.py`.
+- **`kubectl` invocation**: 5 toolkit modules already shell out to `kubectl` via `subprocess`. RESOLVED: follow the same pattern; do NOT introduce a Python K8s client dependency just for one `patch` call.
+- **Error UX when Application is missing**: pre-flight `kubectl get application NAME -n argocd` for a clean error message before attempting the patch.
+
+## Acceptance criteria
+
+- [ ] `poetry run toolkit infra argo set-revision --app kubelab-staging --rev master` patches the Application and prints lines like `targetRevision: fix/dash-ui-cosmetic → master` plus the current `status.sync.status` value.
+- [ ] `make argo-set-revision APP=kubelab-staging REV=master` invokes the toolkit subcommand and exits 0 on success.
+- [ ] Running against a non-existent app prints `Application '<name>' not found in namespace argocd` and exits with non-zero code.
+- [ ] Running the CLI without `--app` or `--rev` prints Typer usage and exits non-zero.
+- [ ] Unit tests cover: happy-path patch payload construction, missing-application error path, CLI argument validation.
+- [ ] Smoke test on live hub: `make argo-set-revision APP=kubelab-staging REV=master` closes the inherited drift; `kubectl --kubeconfig ~/.kube/kubelab-hub-config get application kubelab-staging -n argocd -o jsonpath='{.spec.source.targetRevision}'` returns `master`.
+- [ ] `make help` shows the new target with a one-line usage hint.
+
+## References
+
+- Vault: `10_projects/kubelab/11-tasks.md` (TOOL-006 entry, line 349)
+- Lesson: `90-lessons.md` — Argo CD targetRevision swap pattern (Option A preview), already documents the `kubectl patch` payload this command encapsulates.
+- Related memory: `feedback_no_manual_kubectl.md`, `feedback_never_adhoc_commands.md`, `feedback_use_makefile.md`.
+- Existing toolkit kubectl-wrap pattern: `toolkit/cli/monitoring.py`, `toolkit/cli/infra.py`.

--- a/specs/TOOL-006-argo-revision-cli/tasks.md
+++ b/specs/TOOL-006-argo-revision-cli/tasks.md
@@ -1,0 +1,43 @@
+---
+tags: [spec, tasks]
+created: "2026-05-18"
+---
+
+# Tasks - TOOL-006-argo-revision-cli
+
+> TDD order. One task = one focused commit. Tick as you go. Frozen on entry to `implementing` state.
+
+## Setup
+
+- [x] Branch created from master: `feat/tool-006-argo-revision-cli`
+- [x] `proposal.md` complete with testable acceptance criteria
+- [x] No unresolved questions in `proposal.md`
+
+## Implementation
+
+> TDD order: failing test first, then minimal implementation. One commit per ticked pair.
+
+- [ ] Add failing unit test: `set_revision` happy-path returns expected patch payload (`{"spec":{"source":{"targetRevision":"<rev>"}}}`).
+- [ ] Implement `toolkit/features/argo_manager.py` with `set_revision(app, rev, kubeconfig)` invoking `kubectl patch application --type merge`. Capture old/new revision + sync status. Subprocess wrap following existing pattern.
+- [ ] Add failing unit test: missing-application path returns `ApplicationNotFoundError` with the app name in the message.
+- [ ] Implement pre-flight `kubectl get application NAME -n argocd` check; raise typed error mapped to non-zero exit.
+- [ ] Add failing CLI test (Typer `CliRunner`): `toolkit infra argo set-revision --app X --rev Y` produces expected output lines and exit code.
+- [ ] Wire `argo` Typer subcommand into `toolkit/cli/infra.py`. Reuse `KUBECONFIG_HUB` env var pattern from existing modules.
+- [ ] Add Makefile target `argo-set-revision` with usage hint and dependency check (`@test -n "$(APP)"` / `@test -n "$(REV)"`).
+- [ ] Update `make help` section (under Hub block) with one-line entry.
+
+## Closing
+
+- [ ] All acceptance criteria from `proposal.md` covered by ≥1 test.
+- [ ] `make test` (or `pytest toolkit/`) passes.
+- [ ] `mypy toolkit/features/argo_manager.py toolkit/cli/infra.py` clean.
+- [ ] `ruff check` clean.
+- [ ] No unrelated diff (Makefile + 2-3 toolkit files + tests + spec only).
+- [ ] Smoke test on live hub executed (closes inherited drift); evidence captured in `verification.md`.
+- [ ] `verification.md` filled with command outputs and commit hashes.
+- [ ] PR opened linking this spec folder.
+- [ ] On merge: `git mv specs/TOOL-006-argo-revision-cli specs/archive/TOOL-006-argo-revision-cli` + tick TOOL-006 in `11-tasks.md` with PR link.
+
+## Machine-readable features
+
+Deferred until after first failing test passes — keeps the JSON honest. To be created at `specs/TOOL-006-argo-revision-cli/features.json` with entries for each AC, mapping to actual pytest node IDs or shell commands.

--- a/specs/TOOL-006-argo-revision-cli/verification.md
+++ b/specs/TOOL-006-argo-revision-cli/verification.md
@@ -1,42 +1,51 @@
 ---
-tags: [spec, verification, templates]
-created: "2026-05-13"
+tags: [spec, verification]
+created: "2026-05-18"
 ---
 
 # Verification - TOOL-006-argo-revision-cli
 
 ## Evidence
 
-Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+- [x] AC1 (CLI patches + prints old→new + sync) -> commit `6ec6874`, tests `TestArgoSetRevisionCLI::test_happy_path_prints_old_and_new`, `TestSetRevisionHappyPath::test_returns_old_and_new_revision`. Live smoke output:
 
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+  ```
+  [INFO] targetRevision: fix/dash-ui-cosmetic → master
+  [INFO] sync status: Unknown
+  [SUCCESS] Application patched
+  ```
+
+- [x] AC2 (`make argo-set-revision` exits 0 on success) -> commit `6ec6874`, smoke test executed `make argo-set-revision APP=kubelab-staging REV=master` against hub aws1, exit code 0.
+- [x] AC3 (missing app: clean error + non-zero) -> commit `6ec6874`, tests `TestSetRevisionErrors::test_missing_application_raises` (feature layer) + `TestArgoSetRevisionCLI::test_missing_app_exits_nonzero` (CLI layer).
+- [x] AC4 (missing --app/--rev: typer usage + non-zero) -> commit `6ec6874`, test `TestArgoSetRevisionCLI::test_missing_required_args_exits_nonzero`. Manual: `env -u APP -u REV make argo-set-revision` prints `Usage: make argo-set-revision APP=kubelab-staging REV=master`, exits 1.
+- [x] AC5 (unit tests: happy-path + missing-app + CLI validation) -> 7 tests in `tests/test_argo_manager.py`, all passing.
+- [x] AC6 (smoke test on live hub closes drift) -> executed 2026-05-18 20:43 MDT. Pre-state: `targetRevision=fix/dash-ui-cosmetic`, `sync=Unknown` (5-day drift from PR #171 preview never reverted). Post-state: `targetRevision=master`, `sync=Synced`. Verified via `kubectl ... get application kubelab-staging -o jsonpath='{.spec.source.targetRevision}'`.
+- [x] AC7 (`make help` shows new target) -> commit `6ec6874`. `make help | grep argo-set-revision` returns: `make argo-set-revision APP=x REV=y  Patch Application targetRevision (preview/patch-back)`.
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- Test suite: `poetry run pytest tests/ --ignore=tests/e2e --ignore=tests/infra` -> **91 passed in 1.83s** (84 pre-existing + 7 new for TOOL-006).
+- Manual smoke test: live hub patch executed; closed the inherited drift from PR #171 (`fix/dash-ui-cosmetic` → `master`). Sync state transitioned `Unknown` → `Synced` within ~1s after patch.
+- No regressions: all 84 pre-existing unit tests still pass.
+- Type checks: `mypy toolkit/features/argo_manager.py toolkit/cli/infra.py` -> clean.
+- Lint: `ruff check` -> clean.
 
 ## Decisions made during implementation
 
-Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
-
--
--
+- **2 kubectl calls instead of 3.** The PATCH command with `-o json` returns the updated Application object, so we don't need a separate GET after the patch. Trade-off: the sync status reported in the patch response is the *pre-reconciliation* value (Argo's controller re-evaluates async), so the CLI's printed `sync status: Unknown` may lag the actual state by ~1s. Documented as "expected behavior" rather than fixed — a re-GET would add latency without changing the outcome. Confirmed during smoke test: immediate re-query showed `Synced` while CLI output said `Unknown`.
+- **Dataclass `SetRevisionResult` over plain tuple/dict.** Makes the CLI test pure (no subprocess) by mocking only the feature function. Tradeoff: extra type definition. Justified by testability — CLI test would otherwise duplicate subprocess setup.
+- **Pre-flight `kubectl get` before patch.** Rejected fast-failing on patch error alone — that path produces a generic "exit 1" without an actionable message. The pre-flight costs one extra round-trip but yields `Application 'X' not found in namespace argocd` which is parseable by humans and future automation.
+- **No SSOT pull for kubeconfig path.** Used env var `KUBECONFIG_HUB` with `~/.kube/kubelab-hub-config` default (matches existing `k8s_secrets.py` pattern). Pulling from `common.yaml` would have required loading the full config tree for one path — over-engineered for one wrapper.
 
 ## Promotion candidates
 
-Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+- [x] Lesson for `kubelab/90-lessons.md`? **Yes** — codify the Argo CD targetRevision swap workflow (preview-per-PR + patch-back) now that it has a stable Makefile/toolkit entry point. Future operator should reach for `make argo-set-revision` reflexively rather than `kubectl patch`.
+- [ ] ADR-worthy decision? **No** — operational tooling, not architecture.
+- [ ] New `00_meta/patterns/`? **No** — kubelab-specific (aws1 hub, argocd namespace). General "encapsulate kubectl in CLI" is already implicit in `feedback_no_manual_kubectl`.
 
-- [ ] Lesson for `<area>/90-lessons.md`? <yes / no - one line of what>
-- [ ] ADR-worthy decision for `<area>/30-architecture/adr-XXX.md`? <yes / no - one line of what>
-- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
-
-## Archive checklist
+## Archive checklist (post-merge)
 
 - [ ] `proposal.md` frontmatter set to `status: archived`
 - [ ] Folder moved: `specs/TOOL-006-argo-revision-cli/` -> `specs/archive/TOOL-006-argo-revision-cli/`
 - [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
-- [ ] Promotions above executed (if any)
+- [ ] Lesson added to vault `kubelab/90-lessons.md` (see Promotion candidates)

--- a/specs/TOOL-006-argo-revision-cli/verification.md
+++ b/specs/TOOL-006-argo-revision-cli/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-13"
+---
+
+# Verification - TOOL-006-argo-revision-cli
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for `<area>/90-lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for `<area>/30-architecture/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/TOOL-006-argo-revision-cli/` -> `specs/archive/TOOL-006-argo-revision-cli/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)

--- a/tests/test_argo_manager.py
+++ b/tests/test_argo_manager.py
@@ -1,0 +1,159 @@
+"""Tests for argo_manager — toolkit infra argo set-revision."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from toolkit.features.argo_manager import (
+    ApplicationNotFoundError,
+    SetRevisionResult,
+    set_revision,
+)
+
+
+def _mock_kubectl(*outputs: str) -> MagicMock:
+    """Build a subprocess.run mock that returns each output in order, exit 0."""
+    completed = [MagicMock(stdout=o, stderr="", returncode=0) for o in outputs]
+    m = MagicMock(side_effect=completed)
+    return m
+
+
+class TestSetRevisionHappyPath:
+    def test_returns_old_and_new_revision(self) -> None:
+        before = json.dumps({
+            "spec": {"source": {"targetRevision": "fix/dash-ui-cosmetic"}},
+            "status": {"sync": {"status": "Synced"}},
+        })
+        after = json.dumps({
+            "spec": {"source": {"targetRevision": "master"}},
+            "status": {"sync": {"status": "OutOfSync"}},
+        })
+        with patch("toolkit.features.argo_manager.subprocess.run",
+                   _mock_kubectl(before, after)) as run:
+            result = set_revision(
+                app="kubelab-staging",
+                rev="master",
+                kubeconfig="/tmp/kubeconfig-hub",
+            )
+
+        assert isinstance(result, SetRevisionResult)
+        assert result.old_revision == "fix/dash-ui-cosmetic"
+        assert result.new_revision == "master"
+        assert result.sync_status == "OutOfSync"
+        assert run.call_count == 2
+
+    def test_patch_payload_is_strategic_merge(self) -> None:
+        before = json.dumps({
+            "spec": {"source": {"targetRevision": "old-branch"}},
+            "status": {"sync": {"status": "Synced"}},
+        })
+        after = json.dumps({
+            "spec": {"source": {"targetRevision": "master"}},
+            "status": {"sync": {"status": "Synced"}},
+        })
+        with patch("toolkit.features.argo_manager.subprocess.run",
+                   _mock_kubectl(before, after)) as run:
+            set_revision(
+                app="kubelab-staging",
+                rev="master",
+                kubeconfig="/tmp/kc",
+            )
+
+        patch_call = run.call_args_list[1]
+        argv = patch_call.args[0]
+        assert "patch" in argv
+        assert "--type" in argv
+        idx = argv.index("--type")
+        assert argv[idx + 1] == "merge"
+        payload_idx = argv.index("-p")
+        payload = json.loads(argv[payload_idx + 1])
+        assert payload == {"spec": {"source": {"targetRevision": "master"}}}
+
+    def test_uses_provided_kubeconfig_and_namespace(self) -> None:
+        before = json.dumps({
+            "spec": {"source": {"targetRevision": "x"}},
+            "status": {"sync": {"status": "Synced"}},
+        })
+        after = json.dumps({
+            "spec": {"source": {"targetRevision": "y"}},
+            "status": {"sync": {"status": "Synced"}},
+        })
+        with patch("toolkit.features.argo_manager.subprocess.run",
+                   _mock_kubectl(before, after)) as run:
+            set_revision(app="a", rev="y", kubeconfig="/path/kc", namespace="custom-ns")
+
+        for call in run.call_args_list:
+            argv = call.args[0]
+            assert "--kubeconfig" in argv
+            assert "/path/kc" in argv
+            assert "-n" in argv
+            assert "custom-ns" in argv
+
+
+class TestSetRevisionErrors:
+    def test_missing_application_raises(self) -> None:
+        import subprocess
+        err = subprocess.CalledProcessError(
+            1, ["kubectl"], output="",
+            stderr='Error from server (NotFound): applications.argoproj.io "ghost" not found',
+        )
+        with patch("toolkit.features.argo_manager.subprocess.run",
+                   MagicMock(side_effect=err)):
+            with pytest.raises(ApplicationNotFoundError) as exc:
+                set_revision(app="ghost", rev="master", kubeconfig="/tmp/kc")
+        assert "ghost" in str(exc.value)
+
+
+class TestArgoSetRevisionCLI:
+    def test_happy_path_prints_old_and_new(self) -> None:
+        from typer.testing import CliRunner
+
+        from toolkit.cli.infra import app
+
+        runner = CliRunner()
+        fake_result = SetRevisionResult(
+            old_revision="fix/dash-ui-cosmetic",
+            new_revision="master",
+            sync_status="OutOfSync",
+        )
+        with patch("toolkit.cli.infra.argo_set_revision_feature",
+                   MagicMock(return_value=fake_result)) as feature:
+            result = runner.invoke(
+                app,
+                ["argo", "set-revision", "--app", "kubelab-staging", "--rev", "master"],
+            )
+
+        assert result.exit_code == 0, result.stdout
+        assert "fix/dash-ui-cosmetic" in result.stdout
+        assert "master" in result.stdout
+        assert "OutOfSync" in result.stdout
+        feature.assert_called_once()
+
+    def test_missing_app_exits_nonzero(self) -> None:
+        from typer.testing import CliRunner
+
+        from toolkit.cli.infra import app
+
+        runner = CliRunner()
+        with patch("toolkit.cli.infra.argo_set_revision_feature",
+                   MagicMock(side_effect=ApplicationNotFoundError(
+                       "Application 'ghost' not found in namespace argocd"))):
+            result = runner.invoke(
+                app, ["argo", "set-revision", "--app", "ghost", "--rev", "master"]
+            )
+
+        assert result.exit_code != 0
+        assert "ghost" in result.stdout
+        assert "not found" in result.stdout.lower()
+
+    def test_missing_required_args_exits_nonzero(self) -> None:
+        from typer.testing import CliRunner
+
+        from toolkit.cli.infra import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["argo", "set-revision"])
+        assert result.exit_code != 0

--- a/toolkit/cli/infra.py
+++ b/toolkit/cli/infra.py
@@ -13,6 +13,12 @@ from toolkit.config.constants import MESSAGES, NETWORK_DEFAULTS, PATH_STRUCTURES
 from toolkit.config.settings import get_settings, settings
 from toolkit.core.logging import console, logger
 from toolkit.features import command
+from toolkit.features.argo_manager import (
+    ApplicationNotFoundError,
+)
+from toolkit.features.argo_manager import (
+    set_revision as argo_set_revision_feature,
+)
 from toolkit.features.validation import (
     confirm_dangerous_operation,
     validate_environment_config,
@@ -48,10 +54,53 @@ backup_app = typer.Typer(
     no_args_is_help=True,
 )
 
+argo_app = typer.Typer(
+    name="argo",
+    help="Argo CD hub management (targetRevision swap, etc.)",
+    no_args_is_help=True,
+)
+
 app.add_typer(ansible_app, name="ansible")
 app.add_typer(terraform_app, name="terraform")
 app.add_typer(k8s_app, name="k8s")
 app.add_typer(backup_app, name="backup")
+app.add_typer(argo_app, name="argo")
+
+
+@argo_app.command("set-revision")
+def argo_set_revision(
+    application: Annotated[str, typer.Option("--app", help="Argo CD Application name")],
+    revision: Annotated[str, typer.Option("--rev", help="Git revision (branch, tag, sha)")],
+    kubeconfig: Annotated[
+        str,
+        typer.Option(
+            "--kubeconfig",
+            help="Hub kubeconfig path (env: KUBECONFIG_HUB)",
+            envvar="KUBECONFIG_HUB",
+        ),
+    ] = os.path.expanduser("~/.kube/kubelab-hub-config"),
+    namespace: Annotated[str, typer.Option("--namespace", "-n")] = "argocd",
+) -> None:
+    """Patch an Argo CD Application's spec.source.targetRevision.
+
+    Encapsulates the preview-per-PR and patch-back operations so they
+    stop being manual kubectl calls.
+    """
+    logger.section(f"Argo set-revision — {application} → {revision}")
+    try:
+        result = argo_set_revision_feature(
+            app=application,
+            rev=revision,
+            kubeconfig=kubeconfig,
+            namespace=namespace,
+        )
+    except ApplicationNotFoundError as exc:
+        logger.error(str(exc))
+        raise typer.Exit(1) from exc
+
+    logger.info(f"targetRevision: {result.old_revision} → {result.new_revision}")
+    logger.info(f"sync status: {result.sync_status}")
+    logger.success("Application patched")
 
 
 # =============================================================================

--- a/toolkit/features/argo_manager.py
+++ b/toolkit/features/argo_manager.py
@@ -1,0 +1,76 @@
+"""Argo CD management — targetRevision swap for preview-per-PR and patch-back.
+
+Encapsulates the kubectl patch payload so callers do not shell out by hand
+(see feedback_no_manual_kubectl, feedback_never_adhoc_commands).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from dataclasses import dataclass
+from typing import Any
+
+
+class ApplicationNotFoundError(Exception):
+    """Raised when the Argo CD Application does not exist in the target namespace."""
+
+
+@dataclass(frozen=True)
+class SetRevisionResult:
+    old_revision: str
+    new_revision: str
+    sync_status: str
+
+
+def _kubectl(kubeconfig: str, namespace: str, *args: str) -> list[str]:
+    return ["kubectl", "--kubeconfig", kubeconfig, "-n", namespace, *args]
+
+
+def _run_json(argv: list[str]) -> dict[str, Any]:
+    proc = subprocess.run(argv, capture_output=True, text=True, check=True)
+    return json.loads(proc.stdout)
+
+
+def set_revision(
+    app: str,
+    rev: str,
+    kubeconfig: str,
+    namespace: str = "argocd",
+) -> SetRevisionResult:
+    """Patch the Application's spec.source.targetRevision to ``rev``.
+
+    Returns a snapshot of the revision before/after and the post-patch sync status.
+    Raises ApplicationNotFoundError if the Application does not exist.
+    """
+    get_argv = _kubectl(kubeconfig, namespace, "get", "application", app, "-o", "json")
+    try:
+        before = _run_json(get_argv)
+    except subprocess.CalledProcessError as exc:
+        if "not found" in (exc.stderr or "").lower():
+            raise ApplicationNotFoundError(f"Application '{app}' not found in namespace {namespace}") from exc
+        raise
+
+    old_revision = before["spec"]["source"]["targetRevision"]
+
+    payload = json.dumps({"spec": {"source": {"targetRevision": rev}}})
+    patch_argv = _kubectl(
+        kubeconfig,
+        namespace,
+        "patch",
+        "application",
+        app,
+        "--type",
+        "merge",
+        "-p",
+        payload,
+        "-o",
+        "json",
+    )
+    after = _run_json(patch_argv)
+
+    return SetRevisionResult(
+        old_revision=old_revision,
+        new_revision=after["spec"]["source"]["targetRevision"],
+        sync_status=after.get("status", {}).get("sync", {}).get("status", "Unknown"),
+    )


### PR DESCRIPTION
## Summary

- New `toolkit infra argo set-revision --app X --rev Y` + `make argo-set-revision APP=X REV=Y` wrapper, encapsulating the Argo CD `targetRevision` swap pattern (preview-per-PR + patch-back).
- Removes the need for manual `kubectl patch application` calls that violate `feedback_no_manual_kubectl` / `feedback_never_adhoc_commands`.
- **Closes the inherited 5-day GitOps drift on `kubelab-staging`**: live smoke test executed against hub aws1, `targetRevision` flipped from `fix/dash-ui-cosmetic` (PR #171 preview that was never reverted) back to `master`, sync transitioned `Unknown` → `Synced`.

## Scope (Atomic)

- `toolkit/features/argo_manager.py` — subprocess kubectl GET + PATCH, typed `SetRevisionResult`, `ApplicationNotFoundError`.
- `toolkit/cli/infra.py` — new `argo` Typer subapp with `set-revision`.
- `Makefile` — `argo-set-revision` target + `make help` entry under Hub block.
- `tests/test_argo_manager.py` — 7 tests (3 happy-path + 1 missing-app + 3 CLI).
- `specs/TOOL-006-argo-revision-cli/` — full SDD bundle (proposal + tasks + verification).

Out of scope (deferred to separate tickets per `track_or_fix`):
- `toolkit infra argo status` / `list-apps` subcommands.
- Refactor of pre-existing inline-kubectl Makefile targets (`restart-argocd`, `sync-app`, `register-spoke`) → tracked as TOOL-008.
- Preview-per-PR ApplicationSet automation.

## SDD compliance

Follows the Discipline Gate flow end-to-end:

1. Vault entry: `11-tasks.md` TOOL-006 (line 350).
2. Spec scaffold: commit `6ff8528`.
3. `proposal.md`: Why + What + Out-of-scope + AC (7 testable outcomes).
4. `tasks.md` in TDD order.
5. Implementation: commit `6ec6874` (failing test → pass, 7 tests).
6. `verification.md`: filled, all 7 AC mapped to commits + tests + live smoke.

## Test plan

- [x] `poetry run pytest tests/ --ignore=tests/e2e --ignore=tests/infra` → **91 passed** (84 pre-existing + 7 new).
- [x] `poetry run mypy toolkit/features/argo_manager.py toolkit/cli/infra.py` → clean.
- [x] `poetry run ruff check` → clean.
- [x] `poetry run toolkit infra argo set-revision --help` shows expected options.
- [x] `make help | grep argo-set-revision` shows new target.
- [x] `env -u APP -u REV make argo-set-revision` rejects missing args (exit 1).
- [x] **Live smoke**: `make argo-set-revision APP=kubelab-staging REV=master` on hub aws1. Pre: `targetRevision=fix/dash-ui-cosmetic, sync=Unknown`. Post: `targetRevision=master, sync=Synced`. Drift closed.

## Post-merge

- Archive spec: `git mv specs/TOOL-006-argo-revision-cli specs/archive/TOOL-006-argo-revision-cli`.
- Add lesson to vault `kubelab/90-lessons.md` (Argo CD targetRevision swap workflow).
- Tick TOOL-006 in `11-tasks.md` with PR link.