### PR TITLE
fix(ansible): revert always-tag on provision-vps Pre-flight (PR #181 regression)

### DIFF
--- a/infra/ansible/playbooks/provision-vps.yml
+++ b/infra/ansible/playbooks/provision-vps.yml
@@ -27,7 +27,15 @@
   hosts: kubelab-vps
   gather_facts: false
   become: false
-  tags: [always, preflight]   # always: run regardless of --tags filter; preflight: explicit invocation
+  # NOTE: unlike the other provision-*.yml Pre-flight Plays, this one is
+  # designed for ONE-TIME first K3s install on VPS (Pattern C migration).
+  # It asserts "K3s not yet installed" and "Docker Compose Traefik running"
+  # — assumptions that DO NOT hold once the cutover is complete. Therefore
+  # it intentionally does NOT carry the [always] tag that PR #181 added to
+  # the other Pre-flight Plays; keep [preflight] so it only runs on
+  # explicit `--tags preflight` invocation. Play 4 (Glances) has its own
+  # config-loading pre_tasks tagged [always], so monitoring runs work.
+  tags: [preflight]
 
   tasks:
     - name: Verify SSH + Python connectivity


### PR DESCRIPTION
## Summary

PR #181 (Pre-flight \`tags: [always]\` cleanup) inadvertently broke \`make provision NODE=vps ENV=prod TAGS=monitoring\` (which was the path for PR #182 to migrate VPS Glances).

Unlike the other 6 provision-*.yml Pre-flight Plays (generic SSH / sudo / internet checks safe to run on every apply), the VPS Pre-flight Play is **designed for ONE-TIME first K3s install** (Pattern C migration). It asserts:

- "K3s not yet installed" (fails if \`/usr/local/bin/k3s\` exists)
- "Docker Compose Traefik is running" (pre-cutover assumption)

Both invariants stop holding after the Pattern C cutover completed. With \`[always]\`, every \`--tags monitoring\` (or any selective tag) invocation crashed on the second check.

Fix: revert to \`tags: [preflight]\` — keeps the explicit invocation path via \`--tags preflight\`, drops the global always-fire. Comment block explains *why* this Play diverges from the rest.

Play 4 (Glances, added in PR #182) carries its own config-loading pre_tasks tagged \`[always]\`, so monitoring-scoped runs work unaffected.

## Verified post-fix

- \`make provision NODE=vps ENV=prod TAGS=monitoring\` runs cleanly.
- Glances live on \`http://100.64.0.2:61208/api/4/quicklook\` → HTTP 200, bind \`100.64.0.2:61208\` (tailscale_ip), \`RestartCount=0\`.
- Re-apply reports \`changed=0\` (true idempotency).
- All 6 nodes (ace1, ace2, beelink, rpi3, rpi4, vps) now run Glances via the shared role.

## Lesson reinforced

The "tag everything Pre-flight \`[always]\`" pattern works because most Pre-flight Plays are generic. The VPS case is a counter-example worth documenting in the inline comment so future tag audits don't sweep it back in.