### PR TITLE
docs(spec): scaffold DT-004 widget-proxy SDD bundle (server-side health checks)

### DIFF
--- a/specs/DT-004-widget-proxy/proposal.md
+++ b/specs/DT-004-widget-proxy/proposal.md
@@ -1,0 +1,59 @@
+---
+id: "DT-004-widget-proxy"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-05-20"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# DT-004-widget-proxy
+
+> **Naming**: file lives at `<repo>/specs/DT-004-widget-proxy/proposal.md`. `DT-004-widget-proxy` is `YYYY-MM-DD-<slug>` or `<TICKET-NN>`.
+
+## Why
+
+<!-- from 11-tasks.md: Server-side health checks — evaluate Homepage `/api/ping` or proxy. Current `fetch(no-cors)` can't distinguish 200 from 500. -->
+
+The Homepage cockpit uses `fetch(..., {mode: 'no-cors'})` to ping services from the browser. The response is `opaque` — the browser cannot read the status code, so HTTP 200, 500, and timeouts all render identically as "up". Tiles show green even when the service is broken, and any service behind Authelia is doubly unreachable because the browser cannot traverse the auth redirect. Result: the cockpit is unreliable for daily operation; we cannot trust it as a signal during incidents, which defeats its purpose.
+
+## What
+
+After this PR, three things exist that did not before:
+
+1. **`widget-proxy` microservice** running in the `kubelab` namespace on K3s — a minimal Go (or Python aiohttp) HTTP server (~target ≤200 LOC) that performs server-side health checks against a curated list of internal services. Reads target list from a ConfigMap generated from `common.yaml` SSOT.
+
+2. **HTTP API `GET /health?target=<service-name>`** that returns JSON
+   `{ "status": "up" | "down" | "degraded", "code": <http-status-int>, "latency_ms": <int> }`.
+   `up` = 2xx, `degraded` = 3xx/4xx (excluding 401/403 if expected behind auth), `down` = 5xx / timeout / connection refused. Server-side fetch reads the real status code (no `no-cors` opacity). Auth-protected services are reached via internal cluster DNS so Authelia is bypassed end-to-end between proxy and service.
+
+3. **Homepage cockpit migration** — `infra/k8s/base/services/homepage-templates/services.yaml.j2` switches the affected tiles from `ping:` (browser-side `fetch(no-cors)`) to `widget: { type: customapi, url: https://widgets.staging.kubelab.live/health?target=... }`. Tile color now reflects the real upstream status.
+
+## Out of scope
+
+- **Prometheus + `node_exporter` migration** — [[DASH-DT-015]] covers the durable enterprise observability path. `widget-proxy` is the tactical bridge that fixes the cockpit signal while DT-015 is in flight; it gets replaced (not extended) when Prometheus lands.
+- **Advanced widget semantics** — latency histograms, SLO burn-rate, alert routing, multi-target aggregation (`/health/all`), batched requests. v1 emits `up | down | degraded` + status code + latency_ms. Anything richer goes to DT-015 / Grafana.
+- **Auth federation / OIDC client inside the proxy** — v1 reaches auth-protected services via internal cluster DNS (Authelia is bypassed end-to-end between proxy and the service pod). The proxy does not implement OIDC client credentials or token exchange. If a target requires real auth (rare), it gets a `degraded` status with a documented `auth_required` note instead of a passing tile.
+
+## Risks / open questions
+
+- **[RESOLVED 2026-05-20] Language choice → Go**. Repo is already polyglot (`apps/api` is Go + Gin + zerolog with Dockerfile multistage `golang:1.25-alpine`). Use case (lightweight HTTP proxy) is a sweet spot for Go stdlib `net/http`. Image ~5 MB scratch + static binary. Sets precedent that new microservices live under `apps/*` and pick the language that fits the service (vs forcing everything Python). Toolkit Python stays for CLI / generators / orchestration.
+- **[RESOLVED 2026-05-20] Target list source → ConfigMap generated from `common.yaml` SSOT**. A new toolkit script (sibling of `sync_homepage_config.py`) renders `apps.services.*` into a `widget-proxy-targets` ConfigMap. Proxy mounts the ConfigMap at startup and refreshes via filesystem watch (or restart on rollout). No K8s API runtime coupling, no hardcoded YAML in the image. Adding a target = edit `common.yaml`, run `make sync-widget-proxy-targets`, redeploy.
+- **[OPEN, non-blocking] Auth-protected target semantics**: when a target returns 401 from an Authelia ForwardAuth layer (rare — proxy uses internal cluster DNS to bypass), do we report `degraded` with a `auth_required` flag (yellow tile) or `down` (red tile)? Default to `degraded` and refine after first live smoke; the choice is reversible and does not block the spec.
+
+## Acceptance criteria
+
+- [ ] **AC1**: `widget-proxy` deploys to K3s as Deployment + Service + IngressRoute in the `kubelab` namespace. `kubectl get pods -n kubelab -l app=widget-proxy` shows ≥1 replica `Running` with `Ready 1/1`. Liveness/readiness probes pass.
+- [ ] **AC2**: `curl -s https://widgets.staging.kubelab.live/health?target=grafana` returns valid JSON matching the schema `{status: "up"|"down"|"degraded", code: <int>, latency_ms: <int>}`. The reported status matches K8s reality — scaling the upstream pod to 0 replicas flips the response to `down` within one health-check interval; scaling back to 1 returns to `up`.
+- [ ] **AC3**: Homepage cockpit `services.yaml.j2` migrates ≥3 representative tiles from `ping:` to `widget: { type: customapi, ... }`. After `make sync-homepage` + `make deploy-k8s ENV=staging`, the visual cockpit shows green / red / yellow tiles that match each target's actual state (manual browser check on `home.staging.kubelab.live`). Refresh interval ≤ current `ping` interval.
+- [ ] **AC4**: Toolchain stays green — `make sync-homepage` regenerates `services.yaml` byte-equal to the manually-replicated output (only Cloudflare `date_gt:` may auto-bump). `make test` reports 91+ tests passing. `make lint` clean. No regression in any existing widget.
+- [ ] **AC5**: **Incident drill** — `kubectl scale -n kubelab deploy/<target> --replicas=0`; within 60 s (or the configured refresh interval, whichever is larger) the corresponding cockpit tile turns red. Scaling back to 1 returns it to green within the same window. Validates end-to-end signal correctness, not just the HTTP path.
+- [ ] **AC6**: **TLS + Let's Encrypt cert** — the IngressRoute at `widgets.staging.kubelab.live` uses `certResolver: letsencrypt` (same pattern as every other public service per CLAUDE.md gotcha). `curl -v` shows a valid LE chain, no self-signed fallback.
+- [ ] **AC7**: **CrowdSec bouncer + rate limit** — the IngressRoute attaches the `crowdsec-bouncer` middleware (Traefik plugin, same pattern as `grafana` / `gitea` IngressRoutes) and a per-IP rate limit middleware. `widget-proxy` is read-only and tiny but it is on the public edge; abuse protection is non-negotiable. Verified by hammering `/health?target=...` with `hey -n 1000 -c 100`: 200s under the limit, 429s above it.
+
+## References
+
+- Vault: `10_projects/kubelab/11-tasks.md` — DASH-DT-004 (this spec) + DASH-DT-015 (Prometheus migration, supersedes this work eventually).
+- Related ADR: ADR-032 (observability stack execution) for the broader context of how cockpit / Glances / Prometheus fit together.
+- Related patterns: `00_meta/patterns/pattern-spec-driven-development.md` (this spec follows it); CrowdSec bouncer + LE cert patterns are documented in CLAUDE.md gotchas.
+- Sister specs in `specs/archive/` for tone — `DT-014-glances-coverage/` (Ansible role pattern), `TOOL-006-argo-revision-cli/` (toolkit CLI pattern).

--- a/specs/DT-004-widget-proxy/tasks.md
+++ b/specs/DT-004-widget-proxy/tasks.md
@@ -1,0 +1,122 @@
+---
+tags: [spec, tasks, kubelab, observability]
+created: "2026-05-20"
+---
+
+# Tasks - DT-004-widget-proxy
+
+> Atomic implementation breakdown. Each task = one focused commit when feasible; T3 may span a few commits because K8s manifests are interdependent. Targeting ≤300 net LOC across the PR per Atomic PR discipline.
+
+## Setup
+
+- [ ] Branch created from master: `feat/DT-004-widget-proxy`
+- [x] `proposal.md` complete, AC1–AC7 testable
+- [x] Both BLOCKERS resolved (language = Go; target list = ConfigMap from `common.yaml`)
+- [ ] `make sync-homepage` clean baseline on master (no surprise diffs)
+
+## T1 — Go service skeleton + health check core (~120 LOC)
+
+- [ ] `apps/widget-proxy/` created with Go module
+  - `go.mod` (`module github.com/mlorentedev/kubelab/widget-proxy`, Go 1.25 matching `apps/api`)
+  - `cmd/widget-proxy/main.go` (HTTP server on `:8080`, graceful shutdown, structured logging via `log/slog`)
+  - `internal/health/check.go` — `Check(ctx, target Target) Result` doing one HTTP GET with 5 s timeout; classifies status: 2xx = `up`, 3xx/4xx (except documented auth codes) = `degraded`, 5xx / timeout / refused = `down`. Returns `{status, code, latency_ms}`.
+  - `internal/targets/loader.go` — reads `/etc/widget-proxy/targets.yaml` at startup, supports `SIGHUP` reload (cheap; pod restart on ConfigMap change is also fine).
+- [ ] Unit tests with `httptest.NewServer` for each branch (up / degraded / down / timeout).
+- [ ] `make -C apps/widget-proxy test` exits 0.
+
+## T2 — Toolkit generator for target ConfigMap (~50 LOC)
+
+- [ ] `toolkit/scripts/sync_widget_proxy_targets.py` — sibling of `sync_homepage_config.py`. Reads `infra/config/values/common.yaml`, walks `apps.services.*`, emits ConfigMap YAML to `infra/k8s/base/services/widget-proxy-targets.yaml` with one entry per target: `{ name, url, expect_status: <int|null>, auth_protected: <bool> }`.
+- [ ] Wired into `toolkit/cli/sync.py` as a sub-command (`toolkit sync widget-proxy-targets`) and Makefile target `sync-widget-proxy-targets`.
+- [ ] `make test` covers the generator (1 happy-path test with fixture common.yaml fragment).
+- [ ] Regenerated ConfigMap is byte-stable across runs (no timestamps / random ordering).
+
+## T3 — K3s manifests (~80 LOC)
+
+- [ ] `infra/k8s/base/services/widget-proxy.yaml` — Deployment (1 replica, resource limits 50m CPU / 64Mi mem, scratch image), Service (ClusterIP, port 8080), IngressRoute (host `widgets.staging.kubelab.live`, `certResolver: letsencrypt`, middlewares `crowdsec-bouncer` + a new `widget-proxy-ratelimit`), Middleware (rate limit average 50 rps, burst 100, per IP).
+- [ ] ConfigMap mount: target list from T2 → `/etc/widget-proxy/targets.yaml`.
+- [ ] Add the service to `infra/k8s/base/kustomization.yaml` `resources:` list.
+- [ ] Generated `widget-proxy-targets.yaml` (T2 output) is committed; deploy script regenerates and diffs it before apply (no drift).
+- [ ] Prod overlay decision deferred to a follow-up — staging-only for v1 (proxy lives next to its cockpit consumer; prod adds the same manifests once smoke is green).
+
+## T4 — Homepage cockpit migration to `customapi` (~30 LOC)
+
+- [ ] `infra/k8s/base/services/homepage-templates/services.yaml.j2` — migrate at least three representative tiles from `ping:` to `widget: { type: customapi, url: https://widgets.staging.kubelab.live/health?target=<name>, mappings: [...] }`. Suggested: Grafana, Gitea, n8n (services currently rendered with a misleading "up").
+- [ ] `make sync-homepage` regenerates `services.yaml`; diff shows only the migrated tiles + Cloudflare auto-bump.
+- [ ] No regression in other widgets (Glances tiles unaffected).
+
+## T5 — Verification (live smoke + incident drill)
+
+- [ ] `make deploy-k8s ENV=staging` rolls out `widget-proxy` Deployment cleanly. `kubectl get pods -n kubelab -l app=widget-proxy` shows `Running 1/1`.
+- [ ] `curl -s https://widgets.staging.kubelab.live/health?target=grafana | jq .` returns the expected JSON, real status code visible.
+- [ ] Browser check on `home.staging.kubelab.live`: the three migrated tiles render real colors (green / red as their backend dictates).
+- [ ] **Incident drill**: `kubectl scale -n kubelab deploy/grafana --replicas=0`; cockpit tile turns red within the refresh window; scale back to 1; tile turns green. Capture screenshot or log line as evidence in `verification.md`.
+- [ ] Rate-limit verification: `hey -n 1000 -c 100 https://widgets.staging.kubelab.live/health?target=grafana` — 200s under the configured threshold, 429s above. Document numbers.
+
+## Closing
+
+- [ ] Every AC from `proposal.md` (AC1–AC7) covered by at least one task above.
+- [ ] `make test` 91+ passing.
+- [ ] `make lint` clean (Go vet + ruff + yamllint + ansible-lint).
+- [ ] No unrelated changes (audit `git diff master --stat` before push).
+- [ ] `verification.md` filled with evidence (HTTP captures, drill logs, rate-limit numbers).
+- [ ] PR opened referencing this spec folder.
+- [ ] Beelink / aws1 status unchanged (this PR does not touch their tiles).
+
+## Machine-readable features
+
+Spec emits a sibling `features.json`. Each AC maps to ≥1 feature; the harness verifies and sets `state: passing`.
+
+```json
+[
+  {
+    "id": "DT-004-widget-proxy-f1",
+    "behavior": "widget-proxy Deployment healthy in kubelab namespace",
+    "verification": "kubectl get pod -n kubelab -l app=widget-proxy -o json | jq -e '.items[0].status.containerStatuses[0].ready'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DT-004-widget-proxy-f2",
+    "behavior": "/health?target=<svc> returns JSON with real status code matching K8s reality",
+    "verification": "curl -sf https://widgets.staging.kubelab.live/health?target=grafana | jq -e '.status == \"up\" and (.code | tostring | startswith(\"2\"))'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DT-004-widget-proxy-f3",
+    "behavior": "Homepage cockpit renders 3+ tiles via customapi widget with real colors",
+    "verification": "grep -c 'type: customapi' infra/k8s/base/services/homepage-config/services.yaml | awk '$1 >= 3 {exit 0} {exit 1}'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DT-004-widget-proxy-f4",
+    "behavior": "Generated ConfigMap is byte-stable across consecutive sync runs",
+    "verification": "make sync-widget-proxy-targets && cp infra/k8s/base/services/widget-proxy-targets.yaml /tmp/a.yaml && make sync-widget-proxy-targets && diff -q infra/k8s/base/services/widget-proxy-targets.yaml /tmp/a.yaml",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DT-004-widget-proxy-f5",
+    "behavior": "Incident drill: scaling target to 0 flips tile red within refresh window",
+    "verification": "manual / scripted via kubectl + curl; evidence in verification.md (screenshot or log capture).",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DT-004-widget-proxy-f6",
+    "behavior": "IngressRoute serves valid Let's Encrypt cert chain",
+    "verification": "curl -vI https://widgets.staging.kubelab.live/health 2>&1 | grep -q \"issuer.*Let's Encrypt\"",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DT-004-widget-proxy-f7",
+    "behavior": "Rate limiting middleware returns 429 above threshold",
+    "verification": "hey -n 1000 -c 100 https://widgets.staging.kubelab.live/health?target=grafana | grep -q '429'",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/DT-004-widget-proxy/verification.md
+++ b/specs/DT-004-widget-proxy/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-05-13"
+---
+
+# Verification - DT-004-widget-proxy
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for `<area>/90-lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for `<area>/30-architecture/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/DT-004-widget-proxy/` -> `specs/archive/DT-004-widget-proxy/`
+- [ ] Backlog entry in vault `11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Summary

Pre-implementation SDD bundle for **DASH-DT-004** — the server-side health check proxy that lets the Homepage cockpit distinguish HTTP 200 from 500 (today's browser \`fetch(no-cors)\` returns opaque responses, so broken services show green).

This PR is **doc-only** — the spec bundle (proposal + tasks + verification). No code yet. Implementation lands in a sibling PR following \`tasks.md\` T1..T5.

## What's inside

\`\`\`
specs/DT-004-widget-proxy/
├── proposal.md     # Why, What, Out of scope, Risks (2 BLOCKERS resolved), 7 ACs
├── tasks.md        # 5 atomic tasks + features.json skeleton
└── verification.md # template, fills during T5
\`\`\`

### Decisions captured in proposal.md

| Risk | Resolution |
|------|------------|
| Language | **Go** — repo is already polyglot (\`apps/api\` is Go + Gin), use case (HTTP proxy) fits stdlib \`net/http\`, ~5 MB scratch image. New service lives at \`apps/widget-proxy/\`. |
| Target list source | **ConfigMap generated from \`common.yaml\` SSOT** — new toolkit script (sibling of \`sync_homepage_config.py\`), mounted into the proxy at startup. No K8s API runtime coupling, no hardcoded YAML in image. |

### 7 acceptance criteria

- AC1: Deployment + Service + IngressRoute healthy in \`kubelab\` namespace
- AC2: \`/health?target=<svc>\` returns real status (matches K8s scale-to-0 reality)
- AC3: Cockpit migrates ≥3 tiles from \`ping:\` to \`customapi\` with real colors
- AC4: Toolchain green (\`make sync-homepage\` byte-stable, tests, lint)
- AC5: Incident drill — scaling target to 0 flips tile red within refresh window
- AC6: TLS via \`certResolver: letsencrypt\`
- AC7: CrowdSec bouncer + per-IP rate limit (\`hey -n 1000 -c 100\` returns 429s above threshold)

### Implementation roadmap (5 tasks ≤300 LOC total)

| # | Task | LOC est. |
|---|------|---------|
| T1 | Go service skeleton + health check core | ~120 |
| T2 | Toolkit generator for target ConfigMap | ~50 |
| T3 | K3s manifests (Deployment + Service + IngressRoute + middlewares) | ~80 |
| T4 | Homepage cockpit migration to \`customapi\` | ~30 |
| T5 | Verification (live smoke + incident drill + rate-limit) | n/a (evidence) |

## Vault context

- **DASH-DT-004** ticket exists in \`10_projects/kubelab/11-tasks.md\`.
- **DASH-DT-010** (originally a second \`DT-004\` for topology Mermaid update) was renamed during this prep — duplicate ticket ID resolved in vault.
- References: ADR-032 (observability execution), DT-015 (Prometheus migration that eventually supersedes this work), sister specs in \`specs/archive/\` (DT-014, TOOL-006) for tone.

## Test plan

- [x] \`init-spec.sh\` ran clean; vault context auto-injected in \`## Why\`.
- [x] Both BLOCKERS in Risks marked \`[RESOLVED]\` (language, target source). \`tasks.md\` is now frozen-able.
- [x] No code touched — pure doc bundle. No CI risk.
- [ ] Implementation PR (separate) executes T1..T5 against this spec.

## Why a doc-only PR

SDD pattern (\`00_meta/patterns/pattern-spec-driven-development.md\`): for PRs ≥50 LOC with public contract or multi-PR sequence, the spec ships **first** as its own PR so reviewers can argue scope without code distractions. Implementation PR cites this spec folder, has narrower scope, and can fail review without losing the planning work.