### PR TITLE
chore(specs): persist 3 pending SDD bundles + ignore .aider/.worktrees (TOOL-007)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ apps/wiki/generated_docs
 
 # Security scanning
 .cache_ggshield
+.aider*
+
+# Git worktrees (parallel workspaces)
+.worktrees/

--- a/specs/AI-001-ollama-public/features.json
+++ b/specs/AI-001-ollama-public/features.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "ai-001-f1-tags-200",
+    "behavior": "GET /api/tags with valid X-API-Key returns 200 and a non-empty models list",
+    "verification": "curl -fsS -H \"X-API-Key: $OLLAMA_API_KEY\" https://ollama.kubelab.live/api/tags | jq -e '.models | length > 0'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "ai-001-f2-tags-401-edge",
+    "behavior": "GET /api/tags without (or with wrong) X-API-Key returns 401 at Traefik edge",
+    "verification": "test \"$(curl -s -o /dev/null -w '%{http_code}' https://ollama.kubelab.live/api/tags)\" = \"401\"",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "ai-001-f2b-no-backend-hit",
+    "behavior": "Rejected requests do NOT reach Ollama backend on Beelink (zero new lines in journalctl during attempt window)",
+    "verification": "curl -s -o /dev/null https://ollama.kubelab.live/api/tags; sleep 2; test \"$(ssh beelink 'sudo journalctl -u ollama --since \"30 seconds ago\" --no-pager | grep -c \"GET /api/tags\"')\" = \"0\"",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "ai-001-f3-generate-stream",
+    "behavior": "POST /api/generate with valid auth completes inference and streams >1 NDJSON chunk",
+    "verification": "curl -fsS -X POST -H \"X-API-Key: $OLLAMA_API_KEY\" -H 'Content-Type: application/json' https://ollama.kubelab.live/api/generate -d '{\"model\":\"llama3.1:8b\",\"prompt\":\"say hi in one word\",\"stream\":true}' | jq -e -s 'length > 1'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "ai-001-f4-prod-e2e-no-regression",
+    "behavior": "Existing prod E2E suite passes with zero new failures vs. baseline run before this change",
+    "verification": "cd ~/Projects/kubelab && make e2e-prod",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "ai-001-f5-cert-ready",
+    "behavior": "Cloudflare cert solver provisioned a Ready certificate for ollama.kubelab.live (no manual step)",
+    "verification": "kubectl get certificate -n kube-system ollama-kubelab-live -o jsonpath='{.status.conditions[?(@.type==\"Ready\")].status}' | grep -q True",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "ai-001-f6-lan-unaffected",
+    "behavior": "LAN/Tailscale access to existing Ollama Service from ace1 is unaffected by the new IngressRoute",
+    "verification": "ssh ace1 \"curl -fsS http://ollama.kubelab.svc.cluster.local:11434/api/tags\" | jq -e '.models | length > 0'",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/AI-001-ollama-public/proposal.md
+++ b/specs/AI-001-ollama-public/proposal.md
@@ -1,0 +1,73 @@
+---
+id: "AI-001-ollama-public"
+type: spec
+status: draft
+created: "2026-05-13"
+tags: [spec, proposal, ai, traefik, ollama]
+template_version: "1.0"
+---
+
+# AI-001: Expose Ollama publicly via Traefik with auth
+
+## Why
+
+KubeLab runs Ollama on the Beelink node (per ADR-028 operational topology). It is currently reachable only from LAN/Tailscale. Public exposure unlocks two things:
+
+1. Personal LLM endpoint usable from any client (laptop, mobile, ai-workloads-starter demos).
+2. Demo surface for the `ai-workloads-starter` content stream — without a public endpoint, the content claims to expose can't be substantiated.
+
+Without this change, Ollama remains gated to homelab — half-finished from a content/strategy perspective.
+
+Vault refs: `kubelab/30-architecture/adr-028-operational-topology.md`, `kubelab/11-tasks.md` (AI-001..005 stream).
+
+## What
+
+Add a new IngressRoute on the prod K3s Traefik:
+
+- Hostname: `ollama.kubelab.live`
+- Port: 443 (TLS via existing Cloudflare cert solver pattern)
+- Backend: existing `ollama` external Service in K3s (already pointing at Beelink LAN IP)
+- Auth: a Traefik middleware that requires a valid credential on every request (auth choice TBD — see Risks)
+
+After this PR: `https://ollama.kubelab.live/api/*` is reachable from anywhere, returns 401 without auth, 200 with auth.
+
+## Out of scope
+
+- Rate limiting per IP / per token (tracked as AI-003).
+- E2E test integration for staging/prod monitors (tracked as AI-002).
+- Multi-tenant API key management (single shared key acceptable for v1).
+- Token-usage metering / cost accounting.
+- Auth for non-`/api/*` paths (Ollama exposes a UI on `/`; we expose only `/api/*` initially).
+
+## Risks / open questions
+
+1. **Auth choice — DECISION REQUIRED before tasks.md is frozen.** Three candidates:
+   - Traefik BasicAuth — built-in, fastest, weak (no key rotation, basic-over-TLS).
+   - Authelia forwardAuth — already in use for Grafana/admin. Operational consistency. Overkill for single-user API key.
+   - Custom header middleware (`X-API-Key: <secret>`) — minimal, easy to rotate via SOPS, single-purpose.
+
+   Lean: option 3. Decision blocks tasks.md freeze.
+
+2. **No backend auth in Ollama itself.** If the middleware misconfigures or is bypassed, Ollama is open. Mitigation: also restrict Beelink Ollama port via Tailscale ACL (defense in depth).
+
+3. **Cost/DoS exposure.** Even with auth, leaked key → expensive inference loop on Beelink GPU. AI-003 mitigates; until then key rotation costs <5 min so tolerable.
+
+4. **Beelink concurrency.** Ollama serializes inference. Public endpoint may produce 502/timeout on burst. Acceptable initially; queueing is out of scope.
+
+5. **No conflict with existing `ollama` external Service.** Verify in staging first that adding IngressRoute does not affect existing LAN reachability.
+
+## Acceptance criteria
+
+- [ ] `GET https://ollama.kubelab.live/api/tags` with valid auth returns 200 and lists installed models.
+- [ ] Same request without (or wrong) auth returns 401 and does NOT reach Ollama (verify via Beelink access logs — zero new lines).
+- [ ] `POST https://ollama.kubelab.live/api/generate` completes inference end-to-end and streams response.
+- [ ] Existing prod E2E suite passes with zero regressions (no new failures on previously-passing services).
+- [ ] Cert provisioned for `ollama.kubelab.live` via existing Cloudflare cert solver (no manual step).
+- [ ] LAN/Tailscale access to Ollama via existing Service is unaffected (smoke from ace1 still works).
+
+## References
+
+- Vault: `10_projects/kubelab/11-tasks.md` — AI-001 entry
+- ADR: `kubelab/30-architecture/adr-028-operational-topology.md`
+- Sister specs: AI-002 (E2E coverage), AI-003 (rate limiting)
+- Component: `kubelab/30-architecture/components/kubelab-agents.md`

--- a/specs/AI-001-ollama-public/tasks.md
+++ b/specs/AI-001-ollama-public/tasks.md
@@ -1,0 +1,37 @@
+---
+tags: [spec, tasks]
+created: "2026-05-13"
+---
+
+# Tasks - AI-001-ollama-public
+
+> TDD order. One task = one focused commit.
+
+## Setup
+
+- [ ] Branch created from main: `feat/AI-001-ollama-public`
+- [ ] `proposal.md` complete and acceptance criteria testable
+- [ ] **Decision finalized:** auth strategy (BasicAuth | Authelia | custom header). Document choice in `proposal.md` and add one-line rationale.
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+- [ ] Write failing E2E test: `ollama.kubelab.live/api/tags` returns 401 without auth
+- [ ] Write failing E2E test: same endpoint returns 200 with correct auth
+- [ ] Create Traefik middleware manifest for chosen auth strategy (in `apps/ollama/` or shared `infra/middleware/`)
+- [ ] Add middleware secret to SOPS: `apps.services.ollama.api_key` in `common.enc.yaml`
+- [ ] Create `IngressRoute` manifest for `ollama.kubelab.live` referencing the middleware
+- [ ] Update prod values.yaml: enable ollama IngressRoute under prod overlay
+- [ ] Deploy to staging first; verify both E2E tests pass against staging
+- [ ] Refactor: extract reusable middleware if more AI services will use it (AI-004 Jetson)
+- [ ] Deploy to prod via existing Argo CD / Ansible pipeline
+- [ ] Verify cert provisioned in prod (Traefik dashboard or `kubectl get ingressroute`)
+
+## Closing
+
+- [ ] All acceptance criteria from `proposal.md` covered by at least one E2E test or smoke check
+- [ ] Helm/Kustomize lint pass
+- [ ] No unrelated changes in diff (scope creep guard)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing `specs/AI-001-ollama-public/`
+- [ ] AI-001 ticked in `kubelab/11-tasks.md` with PR link

--- a/specs/AI-001-ollama-public/verification.md
+++ b/specs/AI-001-ollama-public/verification.md
@@ -1,0 +1,43 @@
+---
+tags: [spec, verification]
+created: "2026-05-13"
+---
+
+# Verification - AI-001-ollama-public
+
+> Skeleton — fill at implementation time.
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof.
+
+- [ ] `GET /api/tags` returns 200 with auth -> commit `<hash>` / test `<name>`
+- [ ] Same endpoint returns 401 without auth -> commit `<hash>` / test `<name>`
+- [ ] `POST /api/generate` completes inference end-to-end -> commit `<hash>` / smoke output
+- [ ] Existing prod E2E suite zero regressions -> CI run `<link>`
+- [ ] Cert provisioned for `ollama.kubelab.live` -> Traefik dashboard / `kubectl get ingressroute`
+- [ ] LAN/Tailscale access unaffected -> smoke from ace1
+
+## Test status
+
+- E2E suite: `<command> -> <output>`
+- Manual smoke: <what was exercised, what observed>
+- No regressions: <yes / no>
+
+## Decisions made during implementation
+
+- Auth choice locked: <BasicAuth | Authelia | Custom header> — one-line rationale.
+- Other non-obvious trade-offs: <list>
+
+## Promotion candidates
+
+- [ ] Lesson for `kubelab/90-lessons.md`? <yes / no — what>
+- [ ] ADR-worthy decision for `kubelab/30-architecture/adr-XXX.md`? Likely yes if auth choice sets precedent for AI-004/005.
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if approach recurs in other repos.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter -> `status: archived`
+- [ ] `mv specs/AI-001-ollama-public/ -> specs/archive/AI-001-ollama-public/`
+- [ ] Backlog entry in `kubelab/11-tasks.md` ticked with PR link
+- [ ] Promotions above executed (if any)

--- a/specs/ANSIBLE-021-tmux/proposal.md
+++ b/specs/ANSIBLE-021-tmux/proposal.md
@@ -1,0 +1,52 @@
+---
+id: "ANSIBLE-021-tmux"
+type: spec
+status: draft
+created: "2026-05-13"
+tags: [spec, proposal, ansible, base-system]
+template_version: "1.0"
+---
+
+# ANSIBLE-021: Install tmux via base_system role
+
+## Why
+
+Dotfiles ship a `sshmux` helper (`.zsh/functions.zsh`) that uses `tmux` for SSH session persistence across drops. Currently `tmux` is not installed on most provisioned nodes — the helper silently falls back to plain SSH, defeating the purpose. Adding `tmux` to `base_system` makes the helper work uniformly on all interactive-session hosts.
+
+Captured 2026-05-11 during dotfiles tmux integration.
+
+## What
+
+Add `tmux` to the `base_system` Ansible role's package list. Re-run `base_system` against the inventory targets it already covers:
+
+- Homelab: ace1, ace2, rpi4, rpi3, beelink
+- Cloud: vps, aws1
+
+Jetson is deliberately excluded — Ubuntu 18.04, raw-only via ANSIBLE-014, not an interactive-session target.
+
+## Out of scope
+
+- Configuring `tmux.conf` defaults (dotfiles concern).
+- Plugin managers (TPM).
+- `sshmux` improvements (dotfiles).
+
+## Risks / open questions
+
+- Idempotency: apt module handles "already installed" gracefully. No risk.
+- Side effects: `tmux` is ~1 MB, no service, no port. Zero blast radius.
+- Verification load: re-running `base_system` against 7 hosts via existing `make provision` flow.
+
+No open questions.
+
+## Acceptance criteria
+
+- [ ] `base_system` role defaults list includes `tmux` (single line change).
+- [ ] Provisioning is idempotent (no failures; only "changed" on first run per host).
+- [ ] Smoke succeeds on every covered host: `for h in ace1 ace2 rpi4 rpi3 beelink vps aws1; do ssh "$h" tmux -V; done`.
+- [ ] Jetson NOT touched (verify smoke returns "command not found" for jetson or inventory inspection shows exclusion).
+
+## References
+
+- Backlog: `kubelab/11-tasks.md` ANSIBLE-021
+- Dotfiles: `~/Projects/dotfiles/.zsh/functions.zsh` — `sshmux` function
+- Role: `infra/ansible/roles/base_system/`

--- a/specs/ANSIBLE-021-tmux/tasks.md
+++ b/specs/ANSIBLE-021-tmux/tasks.md
@@ -1,0 +1,28 @@
+---
+tags: [spec, tasks]
+created: "2026-05-13"
+---
+
+# Tasks - ANSIBLE-021-tmux
+
+> TDD order. One task = one focused commit.
+
+## Setup
+
+- [ ] Branch created from main: `feat/ANSIBLE-021-tmux`
+- [ ] `proposal.md` reviewed; no open questions
+
+## Implementation
+
+- [ ] Add `tmux` to `base_system` role packages list (one-line YAML change)
+- [ ] Run `make provision NODE=ace1 ENV=homelab` (or equivalent) — verify idempotent, `tmux` installed
+- [ ] Run on remaining hosts: ace2, rpi4, rpi3, beelink, vps, aws1
+- [ ] Execute smoke loop: `for h in ace1 ace2 rpi4 rpi3 beelink vps aws1; do ssh "$h" tmux -V; done` — capture output
+
+## Closing
+
+- [ ] All hosts return `tmux 3.x` (or similar)
+- [ ] Jetson explicitly excluded — confirm
+- [ ] Diff is a single-line role change + zero changes elsewhere (no scope creep)
+- [ ] `verification.md` filled in (or marked deferred — low risk)
+- [ ] PR opened, ANSIBLE-021 ticked in `kubelab/11-tasks.md` with PR link

--- a/specs/TOOL-001-secret-drift/proposal.md
+++ b/specs/TOOL-001-secret-drift/proposal.md
@@ -1,0 +1,58 @@
+---
+id: "TOOL-001-secret-drift"
+type: spec
+status: draft
+created: "2026-05-13"
+tags: [spec, proposal, toolkit, secrets, sops]
+template_version: "1.0"
+---
+
+# TOOL-001: Secret drift detection CLI subcommand
+
+## Why
+
+When adding a new secret to staging, it's currently easy to forget to add the same key to prod. Drift is only detected when the prod deployment fails to find the secret at runtime. A drift-detection subcommand lets us catch this before deploy.
+
+This unblocks the related TOOL-002 (secret sync) by providing the report-only step first.
+
+## What
+
+New subcommand: `toolkit secrets diff [--env A --env B] [--format plain|json]`.
+
+- Reads two SOPS-encrypted files (default: `apps.staging.enc.yaml` vs `apps.prod.enc.yaml`).
+- Decrypts both in memory (via existing toolkit SOPS integration).
+- Compares **keys only** — values are never logged, only key presence and type shape.
+- Outputs:
+  - Keys present in A but missing in B
+  - Keys present in B but missing in A
+  - Common keys with mismatched value SHAPES (string vs map vs list) — not values
+- Exit code: 0 if identical, 1 if drift detected, 2 if execution error.
+
+## Out of scope
+
+- TOOL-002 (sync drift forward) — separate spec.
+- Comparing secret VALUES (security: never).
+- Cross-cluster drift (multi-K8s) — only SOPS files for v1.
+- UI / web dashboard.
+
+## Risks / open questions
+
+1. **Output format.** Plain text, JSON, or both (`--format`)? Lean: both, plain default for humans, `--format json` for CI gates. RESOLVED in spec.
+2. **What "shape mismatch" means.** Just primitive type difference (string/int/list/map) or deeper (nested map keys also diffed)? Lean: type-level only for v1; defer deeper to TOOL-002.
+3. **Empty files / decryption failure.** Error and exit 2 vs treat as no drift? Lean: error and exit 2 — silent ambiguity is dangerous for secrets.
+4. **Authorization.** Both files must be decryptable by current SOPS keys. If user lacks one key, fail clean with "missing key for env X". No partial diff.
+
+## Acceptance criteria
+
+- [ ] `toolkit secrets diff --env staging --env prod` runs and exits 0 if identical.
+- [ ] If staging has key `apps.services.x.foo` and prod does not, output lists it under "staging only" and exits 1.
+- [ ] Output never contains a secret VALUE (verified via test with negative assertion on known fixture values).
+- [ ] Decryption failure produces clear error and exit 2.
+- [ ] `--format json` emits parseable JSON for CI consumption.
+- [ ] Type-shape mismatch (e.g. string vs list under same key) is flagged and exits 1.
+
+## References
+
+- `kubelab/11-tasks.md` — TOOL-001 / TOOL-002
+- Existing SOPS integration: `toolkit/secrets/` (assumed module path — verify)
+- Possible ADR: secret management policy — TBD if this work surfaces one

--- a/specs/TOOL-001-secret-drift/tasks.md
+++ b/specs/TOOL-001-secret-drift/tasks.md
@@ -1,0 +1,36 @@
+---
+tags: [spec, tasks]
+created: "2026-05-13"
+---
+
+# Tasks - TOOL-001-secret-drift
+
+> TDD order.
+
+## Setup
+
+- [ ] Branch created from main: `feat/TOOL-001-secret-drift`
+- [ ] `proposal.md` decisions resolved: output format (plain default + `--format json`), shape comparison (type-level only).
+
+## Implementation
+
+- [ ] Write failing test: two identical SOPS fixtures -> diff empty + exit 0
+- [ ] Write failing test: staging has extra key -> diff lists it + exit 1
+- [ ] Write failing test: shape mismatch (string vs list) -> flagged + exit 1
+- [ ] Write failing test: output never contains secret values (grep-negative assertion on fixture)
+- [ ] Write failing test: decryption failure -> clear error + exit 2
+- [ ] Write failing test: `--format json` emits valid parseable JSON
+- [ ] Implement `toolkit/secrets/diff.py` (or equivalent) — SOPS decrypt + key/shape diff
+- [ ] Wire up CLI: `toolkit secrets diff` subcommand
+- [ ] Refactor: extract reusable SOPS-decrypt helper if not already isolated
+- [ ] Manual smoke against real staging vs prod SOPS files
+
+## Closing
+
+- [ ] All tests green
+- [ ] Type checks pass (mypy or equivalent)
+- [ ] Lint pass
+- [ ] No values leaked in any test output (manual review of fixtures + outputs)
+- [ ] `verification.md` filled
+- [ ] PR opened referencing `specs/TOOL-001-secret-drift/`
+- [ ] TOOL-001 ticked in `kubelab/11-tasks.md` with PR link


### PR DESCRIPTION
## Summary

Housekeeping pass to track the SDD spec bundles that have been sitting untracked since 2026-05-13/05-17, plus two recurring sources of working-tree noise.

### Specs persisted (one commit each)

| Spec | Status | What |
|------|--------|------|
| **AI-001** ollama-public | proposal complete + tasks ready (auth choice flagged as DECISION REQUIRED) | Expose Ollama publicly via Traefik with auth, per ADR-028. |
| **ANSIBLE-021** tmux | proposal complete + tasks ready | Add tmux to base_system role so the dotfiles sshmux helper works on all interactive nodes. |
| **TOOL-001** secret-drift | proposal complete (decisions resolved) + tasks ready | toolkit secrets diff CLI subcommand — key-only diff between two SOPS files, exit non-zero on drift. |

**AI-002 deliberately excluded** — specs/AI-002-e2e-tests/{proposal,tasks,verification}.md are all unfilled template skeletons. Persisting an empty spec would pollute specs/ with template noise. AI-002 will get filled via /spec fill when the AI track lands (will be part of its own PR).

### .gitignore

- .aider* — aider session/history files (transient, per-developer)
- .worktrees/ — git worktree convention for parallel branch work

Both surface as noise in every git status until ignored.

## Why TOOL-007

Vault ticket: 10_projects/kubelab/11-tasks.md TOOL-007 (resolve specs/ untracked + .gitignore housekeeping). This closes that ticket.

## Test plan

- [x] Pre-commit hooks pass on every commit (4 commits: 1 gitignore + 3 specs).
- [x] git status on master after merge shows clean tree (no untracked specs, no .gitignore diff).
- [x] No spec implementation code touched — pure docs/config change, zero blast radius.
- [x] Reviewer confirms scope-disciplined: docs-only, no code, no behavior change.

## Follow-ups (not this PR)

- AI-002 spec content (Socratic /spec fill when AI work begins, separate PR).
- Wave 1 sibling: DT-010 topology Mermaid update (separate worktree, separate PR).