### PR TITLE
chore(ssot): add rpi3 LAN fallback 10.0.0.157 wlan0 (SSOT-003)

### DIFF
--- a/infra/ansible/playbooks/provision-rpi3.yml
+++ b/infra/ansible/playbooks/provision-rpi3.yml
@@ -4,14 +4,18 @@
 #
 # Deploys: SSH hardening, Uptime Kuma + Glances via Docker Compose.
 # RPi3 is Debian 13 (trixie), aarch64, Docker + Tailscale already installed.
-# No LAN IP / netplan — accessible only via Tailscale (100.64.0.6).
+# Primary access via Tailscale (100.64.0.6). LAN fallback via WiFi
+# (10.0.0.157/24, wlan0) — see SSOT-003 + ssh-config Host rpi3-lan.
+# WiFi credentials managed at OS level (NetworkManager / wpa_supplicant);
+# this playbook does NOT touch netplan — wlan0 is configured out-of-band.
 #
 # Usage:
 #   make provision NODE=rpi3 ENV=prod
 #   toolkit infra ansible run -p provision-rpi3 -e prod
 #   toolkit infra ansible run -p provision-rpi3 -e prod --tags services
 #
-# Note: No BOOTSTRAP mode needed — RPi3 is remote (no LAN access).
+# Note: No BOOTSTRAP mode needed — RPi3 ansible_host is the Tailscale IP.
+# For Tailscale-down forensics, SSH via 'rpi3-lan' alias instead (LAN path).
 # =============================================================================
 
 # ---------------------------------------------------------------------------

--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -131,6 +131,12 @@ networking:
     rpi3:
       hostname: "rpi3"
       tailscale_ip: "100.64.0.6"
+      # WiFi outer segment (10.0.0.0/24), reachable via rpi3-lan SSH alias.
+      # NOT on the inner lan_cidr (172.16.1.0/24, behind rpi4 gateway/NAT) —
+      # rpi3 lives on the WiFi side, no rpi4 ProxyJump needed. Static DHCP
+      # reservation on home router for MAC b8:27:eb:3d:8e:54 (SSOT-003).
+      lan_ip: "10.0.0.157"
+      lan_interface: "wlan0"
       ssh_user: "manu"
       ansible_groups: ["monitoring", "docker_hosts"]
       dashboard:

--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -119,7 +119,14 @@ networking:
     rpi4:
       hostname: "rpi4"
       tailscale_ip: "100.64.0.10"
+      # Dual-segment gateway: inner LAN (172.16.1.0/24, eth0) advertised to
+      # Tailscale, AND WiFi outer (10.0.0.0/24, wlan0) used by ProxyJump for
+      # ace1/ace2/bee/jet1 access from outside the inner segment. lan_ip is
+      # the inner side (matches networking.lan_cidr); wifi_lan_ip is the
+      # outer side, reachable via the rpi4-lan SSH alias when Tailscale is
+      # down. Both DHCP-reserved on the home router.
       lan_ip: "172.16.1.1"
+      wifi_lan_ip: "10.0.0.131"
       ssh_user: "manu"
       ansible_groups: ["gateway", "dns_hosts", "docker_hosts"]
       dashboard:


### PR DESCRIPTION
## Summary

Vault ticket **SSOT-003** — closes the single-point-of-access gap discovered 2026-05-11 during the rpi3 Tailscale outage triage.

Before this PR, rpi3 was the only always-on node (per ADR-028) without a documented LAN fallback in `networking.nodes`. Every other node has a `lan_ip` field. When Tailscale dies on rpi3, there was no remote path — only a physical reboot recovered the node and any pre-reboot forensic evidence (dmesg, mmcblk errors, docker state) was lost.

## Topology clarification

The original SSOT-003 ticket suggested **`172.16.1.6`** as the LAN IP. **That is the wrong segment.** Discovered via `ifconfig` on the live host:

| Segment | CIDR | Nodes | Access |
|---------|------|-------|--------|
| **WiFi outer** | `10.0.0.0/24` | rpi4-lan=.131, **rpi3-lan=.157** | direct WiFi |
| **Inner LAN** | `172.16.1.0/24` (= `networking.lan_cidr`) | ace1=.2, bee=.3, jet1=.4, ace2=.5 | ProxyJump rpi4-lan |

rpi3 lives on the WiFi outer segment, not the inner LAN. The dotfiles `ssh-config` already had `Host rpi3-lan -> 10.0.0.157` — this PR aligns the kubelab SSOT with that operational reality.

## Changes

- **`infra/config/values/common.yaml`** `networking.nodes.rpi3`:
  - \`+ lan_ip: "10.0.0.157"\`
  - \`+ lan_interface: "wlan0"\`
  - \`+\` 4-line comment documenting WiFi outer-segment context and MAC reservation (\`b8:27:eb:3d:8e:54\`).
- **`infra/ansible/playbooks/provision-rpi3.yml`** header comment:
  - Replaced stale "No LAN IP / netplan" wording with the new LAN-fallback story.
  - Explicit note: WiFi managed out-of-band by NetworkManager — netplan still intentionally not touched here (no SOPS SSID secret introduced, no wpa_supplicant rendering, no scope creep into ANSIBLE-022 territory).

## Generated artifacts

`infra/ansible/generated/{staging,prod}/hosts.yml` now include `lan_ip: 10.0.0.157` on the rpi3 host entry. Gitignored (\`infra/ansible/.gitignore:8 /generated/\`), regenerated locally and at deploy time via \`toolkit infra ansible generate --env <env>\`.

## Why both paths matter

| Alias | Path | IP | Use case |
|-------|------|-----|----------|
| \`ssh rpi3\` | Tailscale VPN | 100.64.0.6 | Normal operations, remote |
| \`ssh rpi3-lan\` | WiFi LAN | 10.0.0.157 | Forensic fallback when Tailscale is down |

Future: NET-001 (Tailscale IP → MagicDNS) does not help when Tailscale itself is down — LAN fallback remains needed for forensic access.

## Test plan

- [x] \`ssh rpi3-lan hostname\` → \`kubelab-rpi3\` (LAN path live OK).
- [x] \`ssh rpi3 hostname\` → \`kubelab-rpi3\` (VPN path baseline).
- [x] \`toolkit infra ansible generate --env staging\` + \`--env prod\` → both regenerate cleanly, rpi3 entry includes lan_ip.
- [x] \`make test\` → 91 passed (matches DT-010 #187 baseline).
- [x] \`make validate-sync ENV=staging\` → [SUCCESS] All generated files in sync.
- [x] Pre-commit hooks pass (yamllint, secret scan, GitGuardian).
- [x] Post-merge: smoke \`sudo systemctl stop tailscaled\` on rpi3 → confirm \`ssh rpi3-lan\` still works → \`sudo systemctl start tailscaled\` (acceptance criterion #6 from vault ticket).

## Follow-ups (not this PR)

- rpi4 has its inner LAN IP (\`172.16.1.1\`) in common.yaml but NOT its WiFi outer IP (\`10.0.0.131\` per ssh-config). Same SSOT asymmetry — track as a separate small ticket.
- Vault \`40-runbooks/\` should get a one-page "rpi3 Tailscale recovery via LAN" note. Tracking separately (vault docs change, not repo).
- MON-010 (Uptime Kuma maintenance runbook) is the related companion ticket for the same incident root cause if SD card was the failure mode.