### PR TITLE
feat(makefile): add make worktree-init to bootstrap new git worktrees (TOOL-010)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,6 +140,7 @@ ON-DEMAND (homelab, powered when working):
 
 - **Commits**: User commits manually or via Claude when explicitly requested. Never commit autonomously.
 - **Branching**: Trunk-based development. `master` only. PRs with squash merge. See CI workflows.
+- **New git worktree**: run `make worktree-init` once in every new worktree under `.worktrees/`. Installs the per-worktree `.venv` via Poetry (~30s first run, ~1s no-op afterwards). Pre-commit hooks are shared automatically via `core.hooksPath` set at `make setup` time — no per-worktree re-install needed.
 - **IaC-first**: Version-controlled config > declarative > automated > manual.
 - **Source of truth**: `infra/config/values/*.yaml` (never .env files)
 - **VPS is ARM**: Multi-arch Docker builds (amd64+arm64) required.

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ help:
 	@echo "Bootstrap:"
 	@echo "  make setup              Install Poetry, dependencies, toolkit, and Ansible collections"
 	@echo "  make setup-local-dns    Add local DNS entries to /etc/hosts"
+	@echo "  make worktree-init      Bootstrap a new git worktree (poetry install only; idempotent)"
 	@echo ""
 	@echo "Development:"
 	@echo "  make up-dev             Start all dev services"
@@ -182,6 +183,25 @@ setup-local-dns:
 	else \
 		echo "✓ Added $$added DNS entries to /etc/hosts"; \
 	fi
+
+# worktree-init bootstraps a fresh git worktree to first-class status:
+# poetry install populates `.venv` (per-worktree); pre-commit hooks are NOT
+# reinstalled because the repo already has `core.hooksPath = main/.git/hooks`
+# (one-time set during `make setup`), which all worktrees share automatically.
+# Idempotent: re-running in an already-bootstrapped worktree is ~1s no-op.
+# Discovered as TOOL-010 after Wave 1 DT-010 PR hit `make sync-homepage`
+# failures in a fresh worktree (no .venv -> toolkit package not importable).
+.PHONY: worktree-init
+worktree-init:
+	@echo "=== Bootstrapping worktree: $$(pwd) ==="
+	@$(POETRY) install --no-interaction
+	@hookspath=$$(git config --get core.hooksPath 2>/dev/null || echo ""); \
+	if [ -n "$$hookspath" ] && [ -x "$$hookspath/pre-commit" ]; then \
+		echo "✓ pre-commit hooks shared from $$hookspath (no re-install needed)"; \
+	else \
+		echo "⚠ core.hooksPath not set or pre-commit hook missing — run from main worktree: $(POETRY) run pre-commit install"; \
+	fi
+	@echo "✓ Worktree ready. Test: make validate-sync ENV=staging"
 
 # -----------------------------------------------------------------------------
 # Development Shortcuts


### PR DESCRIPTION
## Summary

Vault ticket **TOOL-010** — codifies the per-worktree venv setup so future parallel-branch sessions don't repeat the ñapa from Wave 1 (DT-010 PR #187 prep, where \`make sync-homepage\` crashed in a fresh worktree until \`poetry install\` was run manually).

## Discovery refinement during impl

Originally the ticket assumed \`pre-commit install\` would be needed per worktree. **It is not.** \`make setup\` (one-time) sets \`core.hooksPath = main/.git/hooks\` in repo-local git config. Every worktree inherits this automatically (\`git config\` is per-repo, shared across worktrees via the gitdir indirection). So only \`.venv\` is genuinely per-worktree state. The target reflects this — \`poetry install\` only, plus a sanity print confirming the shared hooks path is set.

## Target behavior

\`\`\`makefile
.PHONY: worktree-init
worktree-init:
    @echo "=== Bootstrapping worktree: $$(pwd) ==="
    @$(POETRY) install --no-interaction
    @hookspath=$$(git config --get core.hooksPath 2>/dev/null || echo ""); \
    if [ -n "$$hookspath" ] && [ -x "$$hookspath/pre-commit" ]; then \
        echo "✓ pre-commit hooks shared from $$hookspath (no re-install needed)"; \
    else \
        echo "⚠ core.hooksPath not set or pre-commit hook missing — run from main worktree: $(POETRY) run pre-commit install"; \
    fi
    @echo "✓ Worktree ready. Test: make validate-sync ENV=staging"
\`\`\`

Idempotent: ~30s first run, ~1s no-op afterwards (Poetry detects nothing to do).

## Files

- \`Makefile\` — new target + entry in \`make help\` Bootstrap section.
- \`CLAUDE.md\` — one-line Workflow rule documenting \"on new worktree: \`make worktree-init\`\".

## Dogfood verification

This PR's own worktree was bootstrapped by running \`make worktree-init\` from a fresh checkout:

- **First run**: poetry resolved + installed every dep + the toolkit editable package. Sanity print confirmed shared hooks path \`/home/manu/Projects/kubelab/.git/hooks\`.
- **Re-run**: 0.82s, \"No dependencies to install or update\" (idempotent).
- **Downstream**: \`make validate-sync ENV=staging\` → SUCCESS All generated files in sync. \`make test\` → 91 passed (matches SSOT-003 #188 baseline). Pre-commit hooks fired on commit (ruff, mypy, yamllint, secret scan, GitGuardian).

## Acceptance criteria (vault ticket TOOL-010)

- [x] (1) \`make worktree-init\` in any worktree produces working \`.venv\` + hooks operative.
- [x] (2) Idempotent (re-run is no-op, ~1s).
- [x] (3) Main worktree behavior unchanged (target is callable from anywhere; main re-run = no-op).
- [x] (4) One-line note in CLAUDE.md Workflow rules.
- [x] (5, bonus) \`make help\` lists the new target under Bootstrap.

## Why a \`feat\` not \`chore\`

Genuinely new developer-facing capability (Makefile public API). \`feat\` aligns with release-please semantic versioning — earns a minor bump on next release. No production behavior changes; CI baseline unaffected.

## Follow-up

- AI track Wave 3 (AI-001 Ollama public, ~M-size PR) can now create its worktree with one command instead of repeating the manual \`poetry install\`.
- DT-004 implementation Wave 4 (5 atomic PRs T1..T5) will be the first real stress test of multi-worktree paralellism; this target unblocks that workflow.