### PR TITLE
chore(spec): address Codex P1+P2 review on PR #190 (AI-001/AI-002)

### DIFF
--- a/specs/AI-001-ollama-public/features.json
+++ b/specs/AI-001-ollama-public/features.json
@@ -7,9 +7,9 @@
     "evidence": ""
   },
   {
-    "id": "ai-001-f2-tags-401-edge",
-    "behavior": "GET /api/tags without (or with wrong) X-API-Key returns 401 at Traefik edge",
-    "verification": "test \"$(curl -s -o /dev/null -w '%{http_code}' https://ollama.kubelab.live/api/tags)\" = \"401\"",
+    "id": "ai-001-f2-tags-403-edge",
+    "behavior": "GET /api/tags without (or with wrong) X-API-Key returns 403 at Traefik edge (per dtomlinson91/traefik-api-key-middleware default)",
+    "verification": "test \"$(curl -s -o /dev/null -w '%{http_code}' https://ollama.kubelab.live/api/tags)\" = \"403\"",
     "state": "pending",
     "evidence": ""
   },

--- a/specs/AI-001-ollama-public/proposal.md
+++ b/specs/AI-001-ollama-public/proposal.md
@@ -29,7 +29,7 @@ Add a new IngressRoute on the prod K3s Traefik:
 - Backend: existing `ollama` external Service in K3s (already pointing at Beelink LAN IP)
 - Auth: a Traefik middleware that requires a valid credential on every request (auth choice TBD — see Risks)
 
-After this PR: `https://ollama.kubelab.live/api/*` is reachable from anywhere, returns 401 without auth, 200 with auth.
+After this PR: `https://ollama.kubelab.live/api/*` is reachable from anywhere, returns 403 without auth, 200 with auth.
 
 ## Out of scope
 
@@ -68,7 +68,7 @@ PR-A merges first (paves architecture); PR-B before PR-C (toolkit + plugin must 
 ## Acceptance criteria
 
 - [ ] `GET https://ollama.kubelab.live/api/tags` with valid auth returns 200 and lists installed models.
-- [ ] Same request without (or wrong) auth returns 401 and does NOT reach Ollama (verify via Beelink access logs — zero new lines).
+- [ ] Same request without (or wrong) auth returns 403 and does NOT reach Ollama (verify via Beelink access logs — zero new lines). Status code rationale: plugin `dtomlinson91/traefik-api-key-middleware` emits `403` for missing, invalid, or wrong-keyed requests per its README.
 - [ ] `POST https://ollama.kubelab.live/api/generate` completes inference end-to-end and streams response.
 - [ ] Existing prod E2E suite passes with zero regressions (no new failures on previously-passing services).
 - [ ] Cert provisioned for `ollama.kubelab.live` via existing Cloudflare cert solver (no manual step).

--- a/specs/AI-002-e2e-tests/proposal.md
+++ b/specs/AI-002-e2e-tests/proposal.md
@@ -27,7 +27,7 @@ Vault refs: `kubelab/11-tasks.md` AI-002 entry, ADR-035, sister spec AI-001.
 Add E2E test cases under `tests/e2e/` that, when run against `ENV=staging` or `ENV=prod`, exercise:
 
 1. **Health**: `GET https://ollama.<env-domain>/api/tags` returns 200 with at least one model in the JSON response.
-2. **Auth boundary (prod only)**: `GET https://ollama.kubelab.live/api/tags` WITHOUT any auth header returns 403 (or 401 if the plugin emits that). Body contains no Ollama-internal data.
+2. **Auth boundary (prod only)**: `GET https://ollama.kubelab.live/api/tags` WITHOUT any auth header returns 403. Body contains no Ollama-internal data. Plugin `dtomlinson91/traefik-api-key-middleware` emits `403` (not `401`) for all unauthenticated cases per its README — assert on `403` exactly.
 3. **Auth happy path (prod only)**: same request WITH `X-API-Key: <key from SOPS>` returns 200 + model list.
 4. **Bearer forward-compat (prod only)**: same request WITH `Authorization: Bearer <key from SOPS>` returns 200 (proves the plugin's Bearer mode is enabled — guards against future Middleware drift breaking Stage 2 migration).
 5. **No leakage**: response body of the 403 contains no Beelink/ace2 hostname, no model list, no internal error stack.
@@ -54,8 +54,8 @@ No remaining open questions.
 
 - [ ] `make test-e2e ENV=prod` runs and passes all four ollama cases (health + 3 auth variants).
 - [ ] `make test-e2e ENV=staging` runs and skips the 3 auth cases with a clear "staging is VPN-only" reason; health case still runs and passes.
-- [ ] Removing the `api-key-ollama` middleware from the prod IngressRoute and re-running `make test-e2e ENV=prod` produces a failing test (proves the auth-boundary test actually catches the regression).
-- [ ] Rotating the SOPS `apps.services.ai.ollama.api_key` and re-applying produces a passing test on the new value (proves SOPS fixture pickup works).
+- [ ] **Mutation drill (test-of-the-test) via SOPS tampering, NOT IngressRoute removal**: temporarily rotate `apps.services.ai.ollama.api_key` in SOPS to a known-wrong value, run `make apply-middleware-secrets ENV=prod`, then re-run `make test-e2e ENV=prod` — `test_ollama_health_authenticated` MUST fail with 403 (proves the happy-path test actually exercises the middleware and would catch a real auth break). Restore the real key + re-apply + re-run → passes again. This replaces the original "remove middleware from IngressRoute" drill because that approach exposes `ollama.kubelab.live` to anonymous traffic during validation (security/cost risk on a public endpoint).
+- [ ] Rotating the SOPS `apps.services.ai.ollama.api_key` and re-applying produces a passing test on the new value (proves SOPS fixture pickup works end-to-end).
 - [ ] No API key value ever appears in test output, CI logs, or assertion messages (negative-grep on a fixture run).
 
 ## References

--- a/specs/AI-002-e2e-tests/tasks.md
+++ b/specs/AI-002-e2e-tests/tasks.md
@@ -27,7 +27,7 @@ updated: "2026-05-21"
 
 - [ ] All four E2E tests pass on `make test-e2e ENV=prod`.
 - [ ] `make test-e2e ENV=staging` passes the health case; 3 auth cases skipped with documented reason ("staging is VPN-only").
-- [ ] Negative-regression check executed manually once: remove `api-key-ollama` middleware from prod IngressRoute, re-run tests → 403/Bearer/no-leak cases fail as expected → restore middleware.
+- [ ] Mutation drill executed once via SOPS tampering (NOT IngressRoute removal — keeps prod auth always on): set `apps.services.ai.ollama.api_key` to a known-wrong value in SOPS, `make apply-middleware-secrets ENV=prod`, re-run tests → `test_ollama_health_authenticated` fails with 403 → restore real key + re-apply + re-run → all pass.
 - [ ] No API key value in any test output / pytest captured stdout / CI artifact.
 - [ ] `verification.md` filled with concrete CI run links.
 - [ ] PR opened referencing `specs/AI-002-e2e-tests/`.

--- a/specs/AI-002-e2e-tests/verification.md
+++ b/specs/AI-002-e2e-tests/verification.md
@@ -14,8 +14,8 @@ Map every acceptance criterion from `proposal.md` to concrete proof.
 
 - [ ] `make test-e2e ENV=prod` passes all four ollama cases → CI run `<link>`.
 - [ ] `make test-e2e ENV=staging` skips 3 auth cases with documented reason → captured pytest output `<paste>`.
-- [ ] Negative-regression demo: remove `api-key-ollama` middleware from prod IngressRoute → `test_ollama_auth_boundary_rejects_anon` fails → restore → passes again → commit log of the temp revert + restore.
-- [ ] SOPS rotation demo: rotate `apps.services.ai.ollama.api_key`, run `make apply-middleware-secrets ENV=prod`, re-run E2E → all auth cases still pass → SOPS audit clean.
+- [ ] Mutation drill demo via SOPS tampering (prod IngressRoute untouched): temporarily set `apps.services.ai.ollama.api_key` to a wrong value in SOPS → `make apply-middleware-secrets ENV=prod` → re-run E2E → `test_ollama_health_authenticated` fails (403) → restore real key + re-apply + re-run → all pass. Captures the "test of the test" without ever exposing `ollama.kubelab.live` to anonymous traffic.
+- [ ] SOPS rotation demo (positive path): rotate `apps.services.ai.ollama.api_key` to a new valid value, run `make apply-middleware-secrets ENV=prod`, re-run E2E → all auth cases still pass → SOPS audit clean.
 - [ ] Negative-grep on a fixture run: API key value never appears in pytest output, CI artifacts, assertion messages.
 
 ## Test status


### PR DESCRIPTION
## Summary

Closes the two unresolved Codex findings on PR #190 (merged 2026-05-22) **before** AI-001 PR-B implementation starts — so the toolkit/Ansible work in PR-B inherits clean, internally-consistent specs instead of propagating drift downstream.

## Findings addressed

### P1 — Security/cost exposure (was the orange badge)
Codex flagged ([inline comment](https://github.com/mlorentedev/kubelab/pull/190#discussion_r-codex-p1)) that `specs/AI-002-e2e-tests/proposal.md:57` asked implementers to **remove the api-key-ollama middleware from the prod IngressRoute** to validate the auth-boundary E2E test catches a regression. That intentionally drops auth on a public endpoint during validation — billing/abuse risk on Beelink/ace2 inference.

**Fix:** replaced with a **SOPS-tampering mutation drill** that keeps the prod IngressRoute untouched and prod auth always on:

1. Temporarily rotate \`apps.services.ai.ollama.api_key\` in SOPS to a known-wrong value.
2. \`make apply-middleware-secrets ENV=prod\` propagates the wrong key.
3. Re-run E2E: \`test_ollama_health_authenticated\` MUST fail with 403 (proves the test actually exercises the middleware end-to-end).
4. Restore real key + re-apply + re-run → all pass.

Same "test of the test" guarantee, no anonymous traffic ever exposed.

### P2 — Doc consistency (was the yellow badge)
Codex flagged ([inline comment](https://github.com/mlorentedev/kubelab/pull/190#discussion_r-codex-p2)) drift between AI-001 proposal (said \`401\`) and AI-002 / AI-001 tasks (said \`403\`). Implementers reading different docs would assert different status codes → false failures.

**Source of truth confirmed:** the plugin \`dtomlinson91/traefik-api-key-middleware\` [README](https://github.com/dtomlinson91/traefik-api-key-middleware) states it returns **403** unconditionally for missing, invalid, or wrong-keyed requests. Not 401.

**Fix:** unified all spec mentions to \`403\` exactly:

- \`specs/AI-001-ollama-public/proposal.md\` L32, L71 — \`401\` → \`403\` (with plugin-README rationale inline).
- \`specs/AI-001-ollama-public/features.json\` — feature ID \`ai-001-f2-tags-401-edge\` → \`ai-001-f2-tags-403-edge\`, behavior + verification updated. ID not referenced elsewhere (verified via repo-wide grep).
- \`specs/AI-002-e2e-tests/proposal.md\` L30 — removed the "(or 401 if the plugin emits that)" hedge.

## What this PR is NOT
- Not an implementation change. Zero code touched.
- Not a spec-revision-cycle event. Both specs are still in \`draft\` status — this is normal pre-implementation editing per the SDD pattern, before they freeze.
- Not blocking AI-001 PR-A (already merged in #190). PR-B starts from this PR's merged master.

## Test plan
- [x] Pre-commit hooks pass (markdownlint, json schema check, secret detector, no large files).
- [x] Repo-wide grep for residual \`401\` and "remove api-key-ollama middleware" mentions returns only the new contextual references that explicitly document the rejected alternative.
- [x] \`features.json\` is valid JSON (json check hook passed).
- [x] CI Validate passes.

## References
- Original PR: #190
- Codex inline comments on PR #190 (\`specs/AI-002-e2e-tests/proposal.md:57\` P1, \`specs/AI-001-ollama-public/tasks.md:57\` P2)
- Plugin source of truth: https://github.com/dtomlinson91/traefik-api-key-middleware
- ADR: \`30-architecture/adrs/adr-035-api-auth-strategy.md\` (vault)
- Sister specs: \`specs/AI-001-ollama-public/\`, \`specs/AI-002-e2e-tests/\`

After merge: AI-001 PR-B (toolkit \`apply_middleware_secrets()\` + Ansible plugin registration) starts from a clean baseline.