### PR TITLE
chore(spec): replace SOPS mutation drill with wrong-key E2E test (Codex P1 on PR #191)

### DIFF
--- a/specs/AI-002-e2e-tests/proposal.md
+++ b/specs/AI-002-e2e-tests/proposal.md
@@ -27,12 +27,13 @@ Vault refs: `kubelab/11-tasks.md` AI-002 entry, ADR-035, sister spec AI-001.
 Add E2E test cases under `tests/e2e/` that, when run against `ENV=staging` or `ENV=prod`, exercise:
 
 1. **Health**: `GET https://ollama.<env-domain>/api/tags` returns 200 with at least one model in the JSON response.
-2. **Auth boundary (prod only)**: `GET https://ollama.kubelab.live/api/tags` WITHOUT any auth header returns 403. Body contains no Ollama-internal data. Plugin `dtomlinson91/traefik-api-key-middleware` emits `403` (not `401`) for all unauthenticated cases per its README — assert on `403` exactly.
-3. **Auth happy path (prod only)**: same request WITH `X-API-Key: <key from SOPS>` returns 200 + model list.
-4. **Bearer forward-compat (prod only)**: same request WITH `Authorization: Bearer <key from SOPS>` returns 200 (proves the plugin's Bearer mode is enabled — guards against future Middleware drift breaking Stage 2 migration).
-5. **No leakage**: response body of the 403 contains no Beelink/ace2 hostname, no model list, no internal error stack.
+2. **Auth boundary — no header (prod only)**: `GET https://ollama.kubelab.live/api/tags` WITHOUT any auth header returns 403. Body contains no Ollama-internal data.
+3. **Auth boundary — wrong key (prod only)**: same request WITH `X-API-Key: definitely-not-the-real-key` returns 403. This is the **automated "test of the test"**: it proves the middleware actually validates the key value (not just header presence), without needing any manual drill or SOPS tampering — client sends a string it KNOWS is wrong, middleware (whose real key is sourced from SOPS, independent of the client) rejects. Plugin `dtomlinson91/traefik-api-key-middleware` emits `403` (not `401`) for all unauthenticated/wrong-keyed cases per its README — assert on `403` exactly.
+4. **Auth happy path (prod only)**: same request WITH `X-API-Key: <key from SOPS>` returns 200 + model list.
+5. **Bearer forward-compat (prod only)**: same request WITH `Authorization: Bearer <key from SOPS>` returns 200 (proves the plugin's Bearer mode is enabled — guards against future Middleware drift breaking Stage 2 migration).
+6. **No leakage**: response body of the 403 contains no Beelink/ace2 hostname, no model list, no internal error stack.
 
-Tests read the API key from SOPS via the existing fixture pattern (no key in repo, no key in test code). Tests skip with a clear reason when `ENV=staging` (staging is VPN-only, no auth needed there) for cases #2/#3/#4.
+Tests read the API key from SOPS via the existing fixture pattern (no key in repo, no key in test code). The wrong-key case (#3) deliberately uses a hardcoded sentinel string, NOT a SOPS-rotated value — so the client and the middleware do not share a moving source of truth. Tests skip with a clear reason when `ENV=staging` (staging is VPN-only, no auth needed there) for cases #2-#5.
 
 ## Out of scope
 
@@ -52,10 +53,10 @@ No remaining open questions.
 
 ## Acceptance criteria
 
-- [ ] `make test-e2e ENV=prod` runs and passes all four ollama cases (health + 3 auth variants).
-- [ ] `make test-e2e ENV=staging` runs and skips the 3 auth cases with a clear "staging is VPN-only" reason; health case still runs and passes.
-- [ ] **Mutation drill (test-of-the-test) via SOPS tampering, NOT IngressRoute removal**: temporarily rotate `apps.services.ai.ollama.api_key` in SOPS to a known-wrong value, run `make apply-middleware-secrets ENV=prod`, then re-run `make test-e2e ENV=prod` — `test_ollama_health_authenticated` MUST fail with 403 (proves the happy-path test actually exercises the middleware and would catch a real auth break). Restore the real key + re-apply + re-run → passes again. This replaces the original "remove middleware from IngressRoute" drill because that approach exposes `ollama.kubelab.live` to anonymous traffic during validation (security/cost risk on a public endpoint).
-- [ ] Rotating the SOPS `apps.services.ai.ollama.api_key` and re-applying produces a passing test on the new value (proves SOPS fixture pickup works end-to-end).
+- [ ] `make test-e2e ENV=prod` runs and passes all five ollama cases (health + no-header 403 + wrong-key 403 + happy-path 200 + Bearer 200).
+- [ ] `make test-e2e ENV=staging` runs and skips the 4 auth cases with a clear "staging is VPN-only" reason; health case still runs and passes.
+- [ ] **Automated test-of-the-test**: `test_ollama_rejects_invalid_key` (case #3) passes — the middleware rejects `X-API-Key: definitely-not-the-real-key` with 403. Because the wrong-key sentinel is hardcoded in the test (not read from SOPS), it remains a true mutation oracle even if the SOPS value is rotated: the test will fail iff the middleware ever accepts arbitrary keys. No manual drill, no IngressRoute removal, no SOPS tampering needed.
+- [ ] Rotating the SOPS `apps.services.ai.ollama.api_key` and re-applying still leaves all five cases passing (proves SOPS fixture pickup is end-to-end and the wrong-key sentinel survives rotation).
 - [ ] No API key value ever appears in test output, CI logs, or assertion messages (negative-grep on a fixture run).
 
 ## References

--- a/specs/AI-002-e2e-tests/tasks.md
+++ b/specs/AI-002-e2e-tests/tasks.md
@@ -18,6 +18,7 @@ updated: "2026-05-21"
 - [ ] Add fixture: `ollama_api_key` in `tests/e2e/conftest.py` — resolves `apps.services.ai.ollama.api_key` from SOPS via existing SOPS-loader fixture pattern. Skip with reason if missing in env.
 - [ ] Write failing test `test_ollama_health_authenticated` — `GET /api/tags` with `X-API-Key` returns 200 + JSON `models` array non-empty. Run on `staging` (no auth used, header ignored) AND `prod` (auth required).
 - [ ] Write failing test `test_ollama_auth_boundary_rejects_anon` — `GET /api/tags` with NO auth headers returns 403. Skip in staging (VPN-only, no auth required). Negative-assert body does not contain "ollama", "models", or any host name.
+- [ ] Write failing test `test_ollama_rejects_invalid_key` — `GET /api/tags` with `X-API-Key: definitely-not-the-real-key` (hardcoded sentinel, NOT read from SOPS) returns 403. This is the test-of-the-test: client sends a value it KNOWS is wrong, so the assertion is independent of any SOPS rotation. If the middleware ever accepts arbitrary keys, this fails.
 - [ ] Write failing test `test_ollama_bearer_forward_compat` — `GET /api/tags` with `Authorization: Bearer <key>` returns 200. Skip in staging. Proves plugin Bearer mode is enabled (Stage 2 OIDC migration prerequisite).
 - [ ] Write failing test `test_ollama_no_key_leak_in_403_body` — full text of the 403 response is grep-clean for the actual API key value (extra paranoia — plugin shouldn't echo, but verify).
 - [ ] Implement: tests are mostly httpx/requests calls against the fixture URL + auth header — minimal logic. Move shared assertions to a helper if duplication grows.
@@ -25,9 +26,9 @@ updated: "2026-05-21"
 
 ## Closing
 
-- [ ] All four E2E tests pass on `make test-e2e ENV=prod`.
-- [ ] `make test-e2e ENV=staging` passes the health case; 3 auth cases skipped with documented reason ("staging is VPN-only").
-- [ ] Mutation drill executed once via SOPS tampering (NOT IngressRoute removal — keeps prod auth always on): set `apps.services.ai.ollama.api_key` to a known-wrong value in SOPS, `make apply-middleware-secrets ENV=prod`, re-run tests → `test_ollama_health_authenticated` fails with 403 → restore real key + re-apply + re-run → all pass.
+- [ ] All five E2E tests pass on `make test-e2e ENV=prod`.
+- [ ] `make test-e2e ENV=staging` passes the health case; 4 auth cases skipped with documented reason ("staging is VPN-only").
+- [ ] `test_ollama_rejects_invalid_key` is part of the standard `make test-e2e ENV=prod` run — passes by default, would fail iff middleware ever accepts arbitrary keys (this is the automated test-of-the-test; no manual drill required).
 - [ ] No API key value in any test output / pytest captured stdout / CI artifact.
 - [ ] `verification.md` filled with concrete CI run links.
 - [ ] PR opened referencing `specs/AI-002-e2e-tests/`.

--- a/specs/AI-002-e2e-tests/verification.md
+++ b/specs/AI-002-e2e-tests/verification.md
@@ -12,10 +12,10 @@ updated: "2026-05-21"
 
 Map every acceptance criterion from `proposal.md` to concrete proof.
 
-- [ ] `make test-e2e ENV=prod` passes all four ollama cases → CI run `<link>`.
-- [ ] `make test-e2e ENV=staging` skips 3 auth cases with documented reason → captured pytest output `<paste>`.
-- [ ] Mutation drill demo via SOPS tampering (prod IngressRoute untouched): temporarily set `apps.services.ai.ollama.api_key` to a wrong value in SOPS → `make apply-middleware-secrets ENV=prod` → re-run E2E → `test_ollama_health_authenticated` fails (403) → restore real key + re-apply + re-run → all pass. Captures the "test of the test" without ever exposing `ollama.kubelab.live` to anonymous traffic.
-- [ ] SOPS rotation demo (positive path): rotate `apps.services.ai.ollama.api_key` to a new valid value, run `make apply-middleware-secrets ENV=prod`, re-run E2E → all auth cases still pass → SOPS audit clean.
+- [ ] `make test-e2e ENV=prod` passes all five ollama cases → CI run `<link>`.
+- [ ] `make test-e2e ENV=staging` skips 4 auth cases with documented reason → captured pytest output `<paste>`.
+- [ ] `test_ollama_rejects_invalid_key` passes as part of the standard `make test-e2e ENV=prod` run → this IS the test-of-the-test (no manual drill, no IngressRoute touched, no SOPS rotated). The wrong-key sentinel is hardcoded in the test, so the assertion is independent of any SOPS state — if the middleware ever stops rejecting arbitrary keys, this test fails automatically on the next CI run.
+- [ ] SOPS rotation demo (positive path): rotate `apps.services.ai.ollama.api_key` to a new valid value, run `make apply-middleware-secrets ENV=prod`, re-run E2E → all five cases still pass (including the wrong-key one, since the sentinel does not change) → SOPS audit clean.
 - [ ] Negative-grep on a fixture run: API key value never appears in pytest output, CI artifacts, assertion messages.
 
 ## Test status


### PR DESCRIPTION
## Summary

Addresses Codex's P1 finding on PR #191 (\`chatgpt-codex-connector\` inline on \`specs/AI-002-e2e-tests/proposal.md:57\`, 2026-05-23 01:02 UTC). The mutation drill introduced in PR #191 cannot reliably detect regressions because the test fixture and the middleware both read from the same SOPS source — a coordinated rotation is not a mutation, it's a consistent update.

## The bug Codex caught

PR #191's acceptance criterion #3 asked implementers to:
1. Rotate \`apps.services.ai.ollama.api_key\` in SOPS to a wrong value.
2. \`make apply-middleware-secrets ENV=prod\` (middleware now has wrong value).
3. Re-run E2E. Expectation: \`test_ollama_health_authenticated\` fails with 403.

But step #3 fails because the test fixture (\`ollama_api_key\` per \`proposal.md:35\`) ALSO reads from SOPS — so the client sends the same wrong value the middleware expects. The middleware accepts it. Test returns 200, not 403. The drill cannot satisfy "MUST fail" under normal conditions.

## The fix

Replace the manual drill with an **automated E2E case**: \`test_ollama_rejects_invalid_key\` sends \`X-API-Key: definitely-not-the-real-key\` — a sentinel hardcoded in the test, **not** read from SOPS. The client and the middleware no longer share a moving source of truth, so the assertion (status_code == 403) holds independently of any SOPS rotation. The test fails iff the middleware ever accepts arbitrary keys.

## Architectural lesson (will be promoted to vault pattern if it recurs)

Mutation testing requires an **independent oracle**. If the actor (client) and the system-under-test (middleware) consult the same source of truth, a coordinated change is not a mutation. The wrong-key sentinel breaks that coupling at zero operational cost: no SOPS tampering, no IngressRoute removal, no manual drill, runs on every CI pass.

## Diff

- \`specs/AI-002-e2e-tests/proposal.md\` — What section rewritten (now 5 cases, wrong-key inserted as #3); acceptance criteria rewritten to assert on the automated test instead of the manual drill.
- \`specs/AI-002-e2e-tests/tasks.md\` — TDD task for \`test_ollama_rejects_invalid_key\` added; closing checkbox updated.
- \`specs/AI-002-e2e-tests/verification.md\` — evidence reframed around the automated test.

## Test plan
- [x] Pre-commit hooks pass (markdownlint, json check, secret detector).
- [x] No residual "mutation drill" or "401" mentions in either spec folder (repo-wide grep returns only contextual references documenting the rejected alternative).
- [x] CI Validate passes.

## What this PR is NOT
- Not implementation work. Zero code touched. Spec edits only.
- Not blocking AI-001 PR-B (toolkit + Ansible plumbing) — PR-B is staged in worktree \`.worktrees/ai-001-toolkit\` waiting for this spec to land so it doesn't inherit the flawed drill.
- Not a spec-revision-cycle event. AI-002 is still in \`draft\` state — normal pre-implementation editing.

## References
- Codex P1: https://github.com/mlorentedev/kubelab/pull/191 inline comment on \`specs/AI-002-e2e-tests/proposal.md:57\` (2026-05-23 01:02 UTC).
- Plugin source of truth: https://github.com/dtomlinson91/traefik-api-key-middleware (unchanged, still emits 403).
- Prior fix that introduced the flawed drill: PR #191 (merged 2026-05-23).
- Vault refs: \`30-architecture/adrs/adr-035-api-auth-strategy.md\`, \`10_projects/kubelab/11-tasks.md\` AI-002 entry.

After merge: AI-001 PR-B starts (or rebases) from this clean spec baseline.