### PR TITLE
fix(secrets): seed ollama api_key in prod SOPS to unblock deploy-k8s (Codex P1 on #193)

### DIFF
--- a/infra/config/secrets/prod.enc.yaml
+++ b/infra/config/secrets/prod.enc.yaml
@@ -38,6 +38,9 @@ apps:
                 oidc_client_secret: ENC[AES256_GCM,data:2k5b596V5UohWz5m6sIxDD8bHSCfn2zwQyv6GFheC+k5HujBQ7xmlbUtMVwTlIx+yO4hCHDpo0yFc7/KlrJ42vChNsBObNt9TPlI7cOama0VEPoTEAA=,iv:f3Of/Vs5ofRaNwsQ2BIx6rT6OuWC+xH+H/mR6VLi06I=,tag:2DAShbr0GLu4vuALHd27EA==,type:str]
             n8n:
                 encryption_key: ENC[AES256_GCM,data:z6qUKaVvxAIiu4r9Brde/jIXsT3AFs3SlY4zj6rknaLX4r8Vc32IBY8FKxM4haJvsE/IuSSPufCiWczqZijzgg==,iv:RlWKrDOk9yQmwGdQ4O6QyqQMzEM+HLhpdV/7yS3Zebs=,tag:KiklTJM1hkP2B70LhuBykQ==,type:str]
+        ai:
+            ollama:
+                api_key: ENC[AES256_GCM,data:DI8ltVMQJKl/Jg2xnzB9NaNvb62q4sDCD2tL7W6f8gUxeGpnUju0TcF0tw==,iv:pgv853PyJBPYv66OVgFEwytpYxkJMxb7+vCYk71em2s=,tag:nX3CV7NQNXxwUlzBcXm4CQ==,type:str]
     testing:
         authelia_test_password: ENC[AES256_GCM,data:6EYTv1Qq5/jQujZ+e5YTdH4MqhQd1N6RiGmyMUpXZXI=,iv:7GTM+x1VF/cAeVrT6FYBNSEC9wEpihPWOX+oiev7Sdk=,tag:wC8Wdk3Uq84IWTvcC0sjjg==,type:str]
 sops:
@@ -60,7 +63,7 @@ sops:
             dE9pM0xMYjhZTXpCVks1Q1g1amRjZlEKcp9EnB+MK9Arp3P7bgEHBrF6nFG2xVXs
             edaRJZOBOjYCB0YKXl7Yal9JaNmLgfpRsXe2ZcpnZDd9NOrkslpsYA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-03-27T21:11:17Z"
-    mac: ENC[AES256_GCM,data:Q+BY2k/3ONeo2JvkJxMnOckLW2z9oC6d1JDQhkve+fl5JIgzJYup3219N/C+2JsOJNDigp9R2DfeKjOPwaHgIm0PM5vrWQEhQNnycrVGagM1XlSNxlVt3RiabBMQQBXXcWXMm8RlxjWC5t/G4Oas7t9KruQb/q5vBxTwe+TaOE0=,iv:DZAYBSqQmBoa/rK8e+ci70MoQKOZqiNN5XoNrh7GnnQ=,tag:GF7kiXWCrt/I1rcJwllOUQ==,type:str]
+    lastmodified: "2026-05-23T02:19:40Z"
+    mac: ENC[AES256_GCM,data:8iDuTF00b81sc+v45r26RM2GpgK+Ybz4mXXuxOWktjV0KSpDvKTWXw2v/5JngdW5diNQEhPECQIXssznhpDhx6erhgWl0TdfdBFQs+AEYJ05Ipv5di8krOHWPMwI2JEwnK9byY4HWPrndhLwlxc31U4nWP6e2ok/GBE4VaL1Vps=,iv:wUhelsWX4KMmIKjwfCdh6UHKvMbkBjCJSKODGBwD2UQ=,tag:pGtZnFTqM5Li6jjCeuVSmw==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0


### PR DESCRIPTION
## Summary

- Closes [Codex P1 on #193](https://github.com/mlorentedev/kubelab/pull/193#discussion_r-codex-bot-comment): `apply-middleware-secrets` is a prerequisite of `deploy-k8s` (`Makefile:778`), but `apps.services.ai.ollama.api_key` was deferred to PR-C. `apply_middleware_secrets()` returns `False` on missing-key (`toolkit/features/k8s_middlewares.py:126-128`), so every `make deploy-k8s ENV=prod` would hard-fail before touching the cluster — blocking unrelated prod deploys.
- Seeds a single 32-byte urlsafe random token in `prod.enc.yaml` for `apps.services.ai.ollama.api_key`. Same primitive `_generate_secret()` uses (`secrets.token_urlsafe(32)`), written via the canonical `toolkit secrets set ... --env prod` — single-key write, no other SOPS values touched.
- No code changes. Only `infra/config/secrets/prod.enc.yaml` (encrypted diff: 1 new key block + SOPS metadata update).

## Why this approach (vs alternatives)

- **Adopted**: seed-now hotfix. Smallest possible diff; immediate unblock; PR-C just adds the IngressRoute + smoke. Trade-off: key unused at runtime until PR-C — inocuous, auto-generated by toolkit.
- Rejected: remove `api-key-ollama` from `MIDDLEWARE_CATALOG` (catalog would not reflect intent; risk of forgetting to restore in PR-C).
- Rejected: refactor to `MiddlewareSpec.required_in_envs` opt-in soft-fail. Worth doing later when a 2nd/3rd middleware adopts the pattern (DT-004, AI-004) — premature for one entry.

## Test plan

- [x] `make secrets-audit` — prod missing 8 → 7. Only pre-existing external API tokens remain (beehiiv/zoho/email); `apps.services.ai.ollama.api_key` no longer reported.
- [x] `git diff` — only encrypted SOPS ciphertext + metadata changed. No plaintext leak.
- [x] Pre-commit hooks pass (`detect private key`, `Detect hardcoded secrets`, yaml/json validators).
- [ ] CI: lint + tests.
- [ ] (Deferred to PR-C, requires homelab on): `make apply-secrets ENV=prod && make apply-middleware-secrets ENV=prod` — verify the chain completes and `kubectl get middleware -n kubelab api-key-ollama` shows the rendered CRD.

## Follow-ups

- PR-C (`feat/ai-001-ollama-public-impl`): add the prod IngressRoute patch for `ollama.kubelab.live` referencing this middleware, then run the smoke trio (`/api/tags` → 403, with `X-API-Key` → 200, with `Authorization: Bearer` → 200).