### PR TITLE
feat(dns): add ollama.kubelab.live A record (AI-001 follow-up)

### DIFF
--- a/infra/terraform/dns/services.json
+++ b/infra/terraform/dns/services.json
@@ -76,5 +76,11 @@
     "zone": "kubelab",
     "proxied": false,
     "environments": ["prod"]
+  },
+  {
+    "name": "ollama",
+    "zone": "kubelab",
+    "proxied": false,
+    "environments": ["prod"]
   }
 ]


### PR DESCRIPTION
## Summary

Follow-up to #195 (AI-001 PR-C). The Ollama prod IngressRoute is live on `ollama.kubelab.live`, but the Cloudflare A record was missing — smoke trio against the host returned DNS NXDOMAIN. Add the entry to the Terraform SSOT.

Should have been part of PR-C scope; was missed during planning.

## Change

`infra/terraform/dns/services.json`: append one entry mirroring the other prod services.

```json
{ "name": "ollama", "zone": "kubelab", "proxied": false, "environments": ["prod"] }
```

`proxied: false` because Cloudflare's free-tier proxy enforces ~100s response timeouts that break Ollama streaming inference responses (`/api/generate`). Direct A record to VPS public IP; ACME http-01/dns-01 still works via standard `letsencrypt` resolver on K3s Traefik.

## Test plan

- [x] CI lint.
- [ ] After merge: `make tf-dns-apply` from master → Cloudflare creates the A record (~1 min propagation).
- [ ] `dig +short ollama.kubelab.live A` → returns VPS public IP.
- [ ] Smoke trio (in AI-001 PR-C deferred list): 403 / 200 X-API-Key / 200 Bearer.