### PR TITLE
chore(homepage): refresh daily Cloudflare query date

### DIFF
--- a/infra/k8s/base/services/homepage-config/services.yaml
+++ b/infra/k8s/base/services/homepage-config/services.yaml
@@ -48,7 +48,7 @@
             Content-Type: application/json
           requestBody:
             # yamllint disable-line rule:line-length
-            query: '{ viewer { zones(filter: {zoneTag: "a708cb04dd4572e76eb6da42cc09507d"}) { httpRequests1dGroups(limit: 1, filter: {date_gt: "2026-05-21"}) { sum { requests threats } } } } }'
+            query: '{ viewer { zones(filter: {zoneTag: "a708cb04dd4572e76eb6da42cc09507d"}) { httpRequests1dGroups(limit: 1, filter: {date_gt: "2026-05-22"}) { sum { requests threats } } } } }'
           mappings:
             - field: data.viewer.zones.0.httpRequests1dGroups.0.sum.requests
               label: Requests


### PR DESCRIPTION
## Summary

Refresh the Cloudflare GraphQL query `date_gt` literal in `infra/k8s/base/services/homepage-config/services.yaml` from `2026-05-21` to `2026-05-22`. The template `services.yaml.j2` injects yesterday's date at render time, so the committed file drifts every day. Unblocks `make validate-sync ENV=prod`.

This is the orphan commit from AI-001 PR-C smoke (PR #195 was merged before I could push the second commit on that branch).

Root cause tracked as **DASH-DT-010** in vault tasks — the template should be changed so the date is computed at request time, not template render time. This PR is the daily band-aid until that ticket lands.

## Test plan

- [x] `make sync-homepage` produces no diff after this commit.
- [x] CI lint.