### PR TITLE
feat(k8s): rate-limit + in-flight cap for ollama public endpoint (SEC-AI-001 MVP)

### DIFF
--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - backup.yaml
   - traefik-dashboard.yaml
   - headscale.yaml
+  - ollama-throttle.yaml
   # argocd.yaml excluded — has RESOLVE_AWS1_TAILSCALE_IP placeholder,
   # applied by `make deploy-argocd` with dynamic IP resolution (MagicDNS)
   # secrets managed via: toolkit infra k8s apply-secrets --env prod (ADR-014)

--- a/infra/k8s/overlays/prod/ollama-throttle.yaml
+++ b/infra/k8s/overlays/prod/ollama-throttle.yaml
@@ -1,0 +1,54 @@
+---
+# Post-auth abuse protection for ollama.kubelab.live (AI-001 follow-up, SEC-AI-001 MVP).
+#
+# Cadena efectiva en la IngressRoute:
+#   secure-headers -> crowdsec-bouncer -> api-key-ollama -> ollama-ratelimit -> ollama-inflight -> error-pages
+#
+# IMPORTANT: el orden importa. RateLimit + InFlightReq van DESPUÉS de api-key para que
+# la cuota se aplique solo a requests autenticados (un atacante sin key se cae en 403
+# antes y no consume cuota). CrowdSec sigue siendo IP-level genérico (HTTP probing etc.).
+#
+# El plugin api-key-ollama vive fuera de Kustomize (renderizado por
+# `make apply-middleware-secrets ENV=prod`, ADR-035 / AI-001 PR-B). Estas dos
+# middlewares SÍ son declarativas y van en git.
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: ollama-ratelimit
+  namespace: kubelab
+  labels:
+    app.kubernetes.io/name: ollama
+    app.kubernetes.io/component: throttle
+    app.kubernetes.io/part-of: kubelab
+spec:
+  rateLimit:
+    # 60 req/min sostenido por sourceIP. Burst de 10 absorbe ráfagas legítimas
+    # (un script que pida tags + chat + generate inmediatamente).
+    # Cálculo: average / period -> 60 / 1m = 1 req/s sostenido, burst hasta 10.
+    average: 60
+    period: 1m
+    burst: 10
+    sourceCriterion:
+      ipStrategy:
+        # K3s Traefik está detrás del LoadBalancer service. El IP real del cliente
+        # viene en X-Forwarded-For tras 1 hop (el LB de Hetzner / proxy del VPS).
+        depth: 1
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: ollama-inflight
+  namespace: kubelab
+  labels:
+    app.kubernetes.io/name: ollama
+    app.kubernetes.io/component: throttle
+    app.kubernetes.io/part-of: kubelab
+spec:
+  inFlightReq:
+    # Ollama serializa por modelo cargado (OLLAMA_NUM_PARALLEL=1 en ace2). Cap=2
+    # permite que un usuario tenga una inferencia en curso + una peticiön corta
+    # (tags / show) en paralelo sin tirar 429.
+    amount: 2
+    sourceCriterion:
+      ipStrategy:
+        depth: 1

--- a/infra/k8s/overlays/prod/patches.yaml
+++ b/infra/k8s/overlays/prod/patches.yaml
@@ -476,9 +476,11 @@ spec:
   tls:
     certResolver: letsencrypt
 ---
-# Override base ollama IngressRoute — prod host + X-API-Key auth (AI-001 / ADR-035 Stage 1).
-# `api-key-ollama` Middleware is rendered out-of-band by `make apply-middleware-secrets ENV=prod`
+# Override base ollama IngressRoute — prod host + X-API-Key auth + post-auth throttle.
+# `api-key-ollama` Middleware: rendered out-of-band by `make apply-middleware-secrets ENV=prod`
 # (plaintext key from SOPS → kubectl apply stdin; NOT in Kustomize / git).
+# `ollama-ratelimit` + `ollama-inflight`: declarative in `ollama-throttle.yaml` (SEC-AI-001 MVP).
+# Order: auth FIRST (anything unauth dies in 403 before consuming quota), throttle AFTER.
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
@@ -496,6 +498,10 @@ spec:
         - name: crowdsec-bouncer
           namespace: kubelab
         - name: api-key-ollama
+          namespace: kubelab
+        - name: ollama-ratelimit
+          namespace: kubelab
+        - name: ollama-inflight
           namespace: kubelab
         - name: error-pages
           namespace: kubelab


### PR DESCRIPTION
## Summary

AI-001 (#190-#196) closed the **auth boundary** for `ollama.kubelab.live` — the X-API-Key Traefik plugin returns 403 to unauthenticated requests. But **post-auth, no throttle existed**: a valid key could pin ace2 ollama to 100% CPU until the 10G memory cap OOM'd the container.

MVP of SEC-AI-001 (vault ticket): two declarative Traefik Middlewares scoped to the prod ollama route.

## Changes

- **`infra/k8s/overlays/prod/ollama-throttle.yaml`** (+54 LOC, new): two Middleware CRDs.
  - `ollama-ratelimit`: 60 req/min per sourceIP, burst 10 (average 1 req/s with headroom for natural script burst).
  - `ollama-inflight`: cap 2 concurrent requests per sourceIP (matches ace2 ollama's `OLLAMA_NUM_PARALLEL=1` + 1 fast meta request).
- **`infra/k8s/overlays/prod/kustomization.yaml`** (+1 LOC): include the new file.
- **`infra/k8s/overlays/prod/patches.yaml`** (+8 / -2 LOC): add the two refs to the ollama IngressRoute middleware chain.

## Middleware chain order (matters)

```
secure-headers → crowdsec-bouncer → api-key-ollama → ollama-ratelimit → ollama-inflight → error-pages
```

Auth **FIRST** so unauthenticated requests die in 403 before consuming per-IP quota. Throttle **AFTER** so only authenticated traffic is metered. CrowdSec stays generic IP-level (HTTP probing, brute-force, bad UA) — unchanged. These two add **LLM-aware** abuse defense.

## sourceCriterion.ipStrategy.depth = 1

K3s Traefik sits behind the Hetzner LB / VPS network. The client's real IP comes in `X-Forwarded-For` 1 hop back. Without `depth: 1`, Traefik would meter by the LB's IP and effectively merge all traffic into one bucket.

## What this does NOT protect against

(Tracked as SEC-AI-001 follow-ups — not in this PR's scope.)

- **Single shared API key** — same key on every request, no per-user accounting. If quota is hit, ALL users see 429 (noisy neighbor).
- **No custom CrowdSec scenario** for LLM patterns (>N gen/min, oversize prompts, etc.).
- **No prompt-size limit** — `/api/generate` with a 100K-token prompt still consumes 1 of the 2 in-flight slots for its full duration.
- **Cloudflare proxy still off** (deliberate, breaks streaming).

These come in subsequent iterations: multi-key + per-key quota, CrowdSec scenario, ingest-side prompt validation.

## Verification done locally

- [x] `kubectl kustomize infra/k8s/overlays/prod/` clean. Both Middlewares render with correct spec. IngressRoute middleware list in correct order: `[secure-headers, crowdsec-bouncer, api-key-ollama, ollama-ratelimit, ollama-inflight, error-pages]`.
- [x] No conflict with `api-key-ollama` Middleware (which lives out-of-band per ADR-035).
- [x] Pre-commit: yamllint, markdownlint, hardcoded-secret scan, all pass.

## Smoke (deferred to post-merge → Argo CD sync)

- [ ] `kubectl get middleware -n kubelab ollama-ratelimit ollama-inflight` exists after Argo sync.
- [ ] Burst test: 20 X-API-Key'd requests in <1s. Expected: ~10 → 200, ~10 → 429. After 1m cooldown: full quota restored.
- [ ] Concurrency test: 3 parallel `/api/generate` requests with long prompts. Expected: 2 active, 3rd → 429 in-flight.
- [ ] LAN/Tailscale direct path (`100.64.0.5:11434`) unaffected (bypasses Traefik entirely).

## Test plan

- [x] Local Kustomize render.
- [x] CI: lint.
- [ ] Post-merge: smoke trio above.