### PR TITLE
fix(ansible): ace2 ollama host networking + UFW (ANSIBLE-025)

### DIFF
--- a/infra/ansible/playbooks/provision-ace2.yml
+++ b/infra/ansible/playbooks/provision-ace2.yml
@@ -149,6 +149,8 @@
       vars:
         restart_policy: "{{ config.global.restart_policy }}"
         tailscale_ip: "{{ config.networking.nodes.ace2.tailscale_ip }}"
+        tailscale_cidr: "{{ config.networking.tailscale_cidr }}"
+        lan_cidr: "{{ config.networking.lan_cidr }}"
         ollama_image: "{{ config.apps.services.ai.ollama.image }}"
         ollama_port: "{{ config.apps.services.ai.ollama.default_port }}"
         ollama_keep_alive: "{{ config.apps.services.ai.ollama.keep_alive }}"

--- a/infra/ansible/roles/ace2_services/tasks/main.yml
+++ b/infra/ansible/roles/ace2_services/tasks/main.yml
@@ -46,6 +46,32 @@
     mode: "0644"
   notify: Restart ace2 services
 
+# --- Firewall (ANSIBLE-025 fix companion) ---
+# With `network_mode: host` in compose.yml.j2, ollama listens on 0.0.0.0.
+# UFW restricts ingress on ollama_port to Tailscale + LAN CIDRs only — the
+# public internet cannot reach the host port even though the listener is open.
+# Public access only via K3s Traefik on the VPS (AI-001 X-API-Key gated).
+#
+# base_system role already configures UFW: install + default-deny-incoming +
+# SSH allow + enable. We only add ollama-specific allow rules here.
+- name: UFW — allow ollama port from Tailscale CIDR
+  community.general.ufw:
+    rule: allow
+    port: "{{ ollama_port | string }}"
+    proto: tcp
+    src: "{{ tailscale_cidr }}"
+    comment: "ollama LLM API — Tailscale (ANSIBLE-025)"
+  become: true
+
+- name: UFW — allow ollama port from LAN CIDR
+  community.general.ufw:
+    rule: allow
+    port: "{{ ollama_port | string }}"
+    proto: tcp
+    src: "{{ lan_cidr }}"
+    comment: "ollama LLM API — LAN (ANSIBLE-025)"
+  become: true
+
 - name: Pull Ollama image
   command: docker compose -f {{ ace2_deploy_dir }}/compose.yml pull
   register: _pull

--- a/infra/ansible/roles/ace2_services/templates/compose.yml.j2
+++ b/infra/ansible/roles/ace2_services/templates/compose.yml.j2
@@ -1,14 +1,31 @@
 # {{ ansible_managed }}
 # ace2 LLM Services — Ollama (ADR-028: on-demand compute)
+#
+# Networking model (ANSIBLE-025 fix):
+#   - `network_mode: host` ELIMINATES the Docker port-binding dependency on
+#     tailscale0 being up at restart time. With the previous
+#     `ports: ["{tailscale_ip}:11434:11434"]` model, a `tailscaled` flap that
+#     dropped {{ tailscale_ip }} from tailscale0 caused dockerd to fail
+#     re-binding on container restart with `cannot assign requested address`,
+#     leaving the container in a death loop until manual recreate. With host
+#     networking, ollama listens directly on the kernel's port table — the bind
+#     survives interface flaps and re-attaches as tailscale0 comes back up.
+#   - Security: UFW rules (in tasks/main.yml) restrict {{ ollama_port }}/tcp
+#     ingress to `networking.tailscale_cidr` + `networking.lan_cidr` only.
+#     World cannot reach 0.0.0.0:{{ ollama_port }} directly even though the
+#     listener accepts on all interfaces. AI-001 X-API-Key auth still gates
+#     the public path through K3s Traefik on the VPS — defense in depth.
+#   - No `kubelab` custom network needed: per ADR-028, ace2 is "Ollama only",
+#     no cross-container comms expected on this host.
 services:
   ollama:
     image: {{ ollama_image }}
     container_name: ollama
     restart: {{ restart_policy }}
-    ports:
-      - "{{ tailscale_ip }}:{{ ollama_port }}:11434"
+    network_mode: host
     environment:
-      - OLLAMA_HOST=0.0.0.0
+      # 0.0.0.0:{{ ollama_port }} — UFW restricts who can actually reach it.
+      - OLLAMA_HOST=0.0.0.0:{{ ollama_port }}
       - OLLAMA_KEEP_ALIVE={{ ollama_keep_alive }}
     volumes:
       - {{ ace2_ollama_data_dir }}:/root/.ollama
@@ -16,10 +33,3 @@ services:
       resources:
         limits:
           memory: {{ ollama_memory_limit }}
-    networks:
-      - kubelab
-
-networks:
-  kubelab:
-    name: kubelab
-    external: true


### PR DESCRIPTION
## Summary

Closes **ANSIBLE-025**. Root cause confirmed live during AI-001 PR-C smoke 2026-05-23: ace2 ollama container died at 04:57 UTC, dockerd looped restarting with `cannot assign requested address` because `tailscaled` had flapped and removed `100.64.0.5` from `tailscale0`. Linux IP-specific binds DO NOT auto-rebind after interface recovery; the container needs full recreation. Meanwhile public path through K3s Traefik returned 502.

## Fix

- `compose.yml.j2`: `network_mode: host` + ollama listens on `0.0.0.0:{ollama_port}`. The bind lives in the kernel's global port table, decoupled from any single interface. tailscaled flaps no longer break the listener.
- `tasks/main.yml`: two new UFW rules — allow `ollama_port/tcp` from `tailscale_cidr` + `lan_cidr`. `base_system` role already enforces default-deny-incoming + SSH allow + UFW enable; we only add the ollama-specific allows.
- `provision-ace2.yml`: pass `tailscale_cidr` + `lan_cidr` from `config.networking.*` SSOT.

Drops the unused `networks: [kubelab]` block — `network_mode: host` bypasses Docker networks, and per ADR-028 ace2 is "Ollama only".

## Security analysis

Before: ollama bound to `100.64.0.5:11434` only (interface-restricted) — implicit "VPN only" via bind constraint.

After: ollama bound to `0.0.0.0:11434` + UFW restricts to `100.64.0.0/10` (Tailscale) + `172.16.1.0/24` (LAN). Same effective external reachability (VPN + LAN only), but **resilient to interface flaps**. The host has no public IP — even without UFW the public internet couldn't reach `0.0.0.0:11434` directly. UFW adds defense in depth.

Public access continues to flow ONLY through K3s Traefik on the VPS → EndpointSlice `100.64.0.5:11434` → ace2 (AI-001 X-API-Key middleware + post-auth throttle from #198).

## Verification live (executed on ace2 after `make provision NODE=ace2 ENV=staging TAGS=services`)

- [x] `ss -ltnp | grep 11434` → `LISTEN *:11434 ollama` (was `dockerd 100.64.0.5:11434`).
- [x] `docker inspect ollama --format '{{.HostConfig.NetworkMode}}'` → `host`.
- [x] `sudo ufw status | grep 11434` → both ALLOW rules present (`100.64.0.0/10` + `172.16.1.0/24`).
- [x] Smoke trio still passes from public path: no-auth → 403, X-API-Key → 200, Bearer → 200, wrong-key → 403.
- [x] Rate-limit (PR #198) still fires: 15 simultaneous X-API-Key'd requests → 2 × 200 + 13 × 429 (bucket draining + refill at 1/s as configured).
- [x] After 90s cooldown: single request → 200 (bucket refilled).
- [x] Direct LAN path `100.64.0.5:11434` → 200 (Tailscale CIDR UFW rule covers our workstation IP `100.64.0.1`).

## Test plan

- [x] `make provision NODE=ace2 ENV=staging TAGS=services` succeeds (ok=24 changed=5 failed=0).
- [x] Smoke trio + burst test live verified.
- [x] CI: ansible-lint / yamllint on touched files.
- [ ] (Follow-up): if tailscaled flaps recur, monitor `journalctl -u tailscaled` on ace2 to confirm flaps actually decreased in symptom frequency. The fix removes the FAILURE MODE; it doesn't fix the upstream Tailscale flapping itself.

## Related

- Triggered by AI-001 PR-C (#195) being the first feature to exercise the public ace2 path end-to-end.
- Glances container in restart loop on ace2 (apparmor ptrace denied) is a separate residual issue — not addressed here. May warrant its own ticket if Glances is intended to stay on ace2 (ADR-028 lists Glances only on Beelink).