### PR TITLE
feat(tests): AI-002 ollama public endpoint E2E suite

### DIFF
--- a/specs/AI-002-e2e-tests/verification.md
+++ b/specs/AI-002-e2e-tests/verification.md
@@ -1,42 +1,46 @@
 ---
 tags: [spec, verification]
 created: "2026-05-13"
-updated: "2026-05-21"
+updated: "2026-05-23"
 ---
 
 # Verification - AI-002-e2e-tests
 
-> Skeleton — fill at implementation time (AI-002 cannot start until AI-001 PR-C merges and the prod Ollama endpoint is live).
+> Filled at implementation close (PR `feat/ai-002-ollama-e2e`, 2026-05-23). AI-001 PR-C merged 2026-05-22 (#195); prod endpoint live since.
 
 ## Evidence
 
 Map every acceptance criterion from `proposal.md` to concrete proof.
 
-- [ ] `make test-e2e ENV=prod` passes all five ollama cases → CI run `<link>`.
-- [ ] `make test-e2e ENV=staging` skips 4 auth cases with documented reason → captured pytest output `<paste>`.
-- [ ] `test_ollama_rejects_invalid_key` passes as part of the standard `make test-e2e ENV=prod` run → this IS the test-of-the-test (no manual drill, no IngressRoute touched, no SOPS rotated). The wrong-key sentinel is hardcoded in the test, so the assertion is independent of any SOPS state — if the middleware ever stops rejecting arbitrary keys, this test fails automatically on the next CI run.
-- [ ] SOPS rotation demo (positive path): rotate `apps.services.ai.ollama.api_key` to a new valid value, run `make apply-middleware-secrets ENV=prod`, re-run E2E → all five cases still pass (including the wrong-key one, since the sentinel does not change) → SOPS audit clean.
-- [ ] Negative-grep on a fixture run: API key value never appears in pytest output, CI artifacts, assertion messages.
+- [x] `make test-e2e ENV=prod` passes all five ollama cases → run on `feat/ai-002-ollama-e2e` HEAD, 2026-05-23: `5 passed in 1.96s` against `ollama.kubelab.live`. CI link to be appended once PR opens.
+- [x] `make test-e2e ENV=staging` skips 4 auth cases with documented reason → `1 passed, 4 skipped in 0.81s`. Skip reasons: `"staging is VPN-only — no middleware gates the endpoint"` / `"staging is VPN-only — no middleware to reject"` / `"staging is VPN-only — no middleware to honor Bearer"` / `"staging is VPN-only — no middleware emits 403 bodies"`.
+- [x] `test_ollama_rejects_invalid_key` passes as part of the standard `make test-e2e ENV=prod` run → this IS the test-of-the-test. The wrong-key sentinel `"definitely-not-the-real-key"` is hardcoded in `test_ollama_public.py` (module-level constant `_WRONG_KEY_SENTINEL`), so the assertion is independent of any SOPS state. If the middleware ever stops rejecting arbitrary keys, this test fails automatically on the next CI run.
+- [x] Negative-grep on a fixture run: `test_ollama_no_key_leak_in_403_body` asserts the SOPS-resolved key value never appears in the 403 body. Passes against live `ollama.kubelab.live`. Pytest output is grep-clean (the key is read from a session-scoped fixture, never logged, never templated into assertion messages).
+- [ ] SOPS rotation demo (positive path): rotate `apps.services.ai.ollama.api_key`, run `make apply-middleware-secrets ENV=prod`, re-run E2E → expected: all five still pass (sentinel test invariant under rotation by design). Not exercised in this PR; deferred to next scheduled rotation per runbook `40-runbooks/ollama-api-key-rotation.md`.
 
 ## Test status
 
-- E2E suite: `make test-e2e ENV=prod` → `<x passed, y skipped>`.
-- Manual smoke: `<what was exercised, what observed>`.
-- No regressions in existing prod E2E suite: `<yes / no>`.
+- E2E suite: `make test-e2e ENV=prod` → 5 passed, 0 skipped (ollama subset). Full suite: 64 passed, 19 skipped, 3 preexisting failures unrelated to AI-002 (`test_security_headers_present[api|web]`, `test_hsts_header[web]`) — root-caused to prod `infra/k8s/overlays/prod/generated/ingress.yaml` missing `secure-headers` middleware on api/web routes; tracked as SEC-K8S-001 in `kubelab/11-tasks.md`.
+- Manual smoke (2026-05-22 prod cutover, AI-001 closure): X-API-Key 200, no-header 403, wrong-key 403, Bearer 200 — all verified by hand. Now codified.
+- No regressions in existing prod E2E suite: the 3 failures predate this branch (verified by running the same 4 cases on master: same 3 fail).
 
 ## Decisions made during implementation
 
-- `<list any non-obvious trade-offs>`.
+- **New file `test_ollama_public.py` rather than extending `test_health.py`**: ollama in `EXPECTATIONS` has `skip_in_envs=("dev", "prod")` (was staging-only before AI-001). Refactoring `expectations.py` to express "auth-gated in prod" would have rippled into `test_security_headers.py` and `test_tls_routing.py`; out of scope. A dedicated file keeps auth-boundary semantics local.
+- **Hardcoded sentinel as module constant, not fixture**: `_WRONG_KEY_SENTINEL = "definitely-not-the-real-key"` is intentionally a literal string in the test module. Reading it from a fixture would tempt a future refactor to source it from SOPS, breaking the test-of-the-test invariant.
+- **Health test sends `X-API-Key` only in prod**: staging Ollama IngressRoute has no plugin Middleware, so the header is ignored. Sending it anyway would conflate two code paths; conditional header set on `env == "prod"` keeps the staging case a clean liveness probe.
+- **Bearer test asserts 200 (not just "not 403")**: tighter than strict-necessary, but catches plugin misconfiguration that might silently degrade Bearer to 401/403 while X-API-Key still works.
 
 ## Promotion candidates
 
-- [ ] Lesson for `kubelab/lessons.md`? Likely "Negative-regression check before merging auth tests prevents the test from passing trivially (asserting the test asserts)".
+- [x] Lesson for `kubelab/lessons.md`: "Auth-boundary E2E = positive + sentinel-negative + leak-grep triple. Hardcoded sentinel decouples client from SOPS, making the test invariant under rotation." → To capture when this pattern repeats for AI-004 / DT-004.
 - [ ] ADR-worthy? No — implementation of ADR-035 testing strategy, not a new architectural decision.
-- [ ] New pattern for `00_meta/patterns/`? Possibly — "Auth-boundary E2E test = positive + negative + leak-grep triple" if the pattern repeats for AI-004 / DT-004 / future RAG services.
+- [ ] New pattern for `00_meta/patterns/`? Defer — promote only after the pattern repeats in AI-004 (Pollex) or DT-004 (widget-proxy).
 
 ## Archive checklist
 
 - [ ] `proposal.md` frontmatter → `status: archived`.
 - [ ] `mv specs/AI-002-e2e-tests/ → specs/archive/AI-002-e2e-tests/`.
-- [ ] Vault `11-tasks.md` AI-002 ticked with PR link.
+- [ ] Vault `kubelab/11-tasks.md` AI-002 ticked with PR link.
 - [ ] Promotions executed.
+- [ ] SEC-K8S-001 ticket opened in `kubelab/11-tasks.md` (prod `secure-headers` middleware drift for api/web — surfaced during AI-002 verification).

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -208,6 +208,22 @@ def authenticated_client(
     client.close()
 
 
+@pytest.fixture(scope="session")
+def ollama_api_key(e2e_config: dict[str, Any]) -> str | None:
+    """Resolve the public Ollama X-API-Key from SOPS-merged config.
+
+    Path mirrors `MIDDLEWARE_CATALOG["api-key-ollama"].secret_key_path`
+    (toolkit.features.k8s_middlewares) — the same value the Traefik
+    Middleware reads. Returns None when no decrypted key is available
+    (e.g. SOPS unreachable locally); callers must skip in that case.
+    """
+    ai = e2e_config.get("apps", {}).get("services", {}).get("ai", {})
+    key = ai.get("ollama", {}).get("api_key")
+    if not key or (isinstance(key, str) and key.startswith("secrets://")):
+        return None
+    return str(key)
+
+
 # ---------------------------------------------------------------------------
 # Auto-skip if environment unreachable
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_ollama_public.py
+++ b/tests/e2e/test_ollama_public.py
@@ -1,0 +1,157 @@
+"""E2E: Ollama public endpoint — health + auth boundary (AI-002, spec).
+
+Covers the public `ollama.kubelab.live` surface introduced by AI-001 / ADR-035
+Stage 1: a Traefik `api-key` plugin Middleware gates `/api/*` behind an
+X-API-Key header. Staging hosts the same backend without the plugin (VPN-only).
+
+The auth-boundary tests are prod-only (staging has no middleware). The
+"wrong key" test uses a hardcoded sentinel — independent of any SOPS
+rotation — so it acts as an automated test-of-the-test: if the middleware
+ever accepts arbitrary keys, this case fails.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from toolkit.features.health_check import ServiceHealthConfig
+
+pytestmark = pytest.mark.e2e
+
+# Hardcoded sentinel — deliberately NOT from SOPS, so the test is invariant
+# under key rotation and proves the middleware validates the *value*, not just
+# header presence. If anyone ever wants to "fix" this by reading from SOPS,
+# they break the whole point — see AI-002 proposal.md.
+_WRONG_KEY_SENTINEL = "definitely-not-the-real-key"
+
+
+def _ollama(services_by_name: dict[str, ServiceHealthConfig]) -> ServiceHealthConfig:
+    svc = services_by_name.get("ollama")
+    if not svc:
+        pytest.skip("ollama not registered in this env's config")
+    return svc
+
+
+def _tags_url(svc: ServiceHealthConfig) -> str:
+    return f"https://{svc.domain}/api/tags"
+
+
+def test_ollama_health_authenticated(
+    services_by_name: dict[str, ServiceHealthConfig],
+    http_client: httpx.Client,
+    ollama_api_key: str | None,
+    env: str,
+) -> None:
+    """`/api/tags` returns 200 with a non-empty `models` array.
+
+    prod: requires `X-API-Key` header (middleware-gated).
+    staging: VPN-only, no middleware — header is ignored if sent.
+    """
+    svc = _ollama(services_by_name)
+    headers = {}
+    if env == "prod":
+        if not ollama_api_key:
+            pytest.skip("ollama_api_key fixture returned None — SOPS unavailable?")
+        headers["X-API-Key"] = ollama_api_key
+
+    r = http_client.get(_tags_url(svc), headers=headers)
+    assert r.status_code == 200, f"expected 200, got {r.status_code}: {r.text[:200]}"
+
+    body = r.json()
+    models = body.get("models")
+    assert isinstance(models, list) and len(models) > 0, (
+        f"expected non-empty models list, got: {body!r}"
+    )
+
+
+def test_ollama_auth_boundary_rejects_anon(
+    services_by_name: dict[str, ServiceHealthConfig],
+    http_client: httpx.Client,
+    env: str,
+) -> None:
+    """Without any auth header, prod returns 403 (plugin enforces presence)."""
+    if env != "prod":
+        pytest.skip("staging is VPN-only — no middleware gates the endpoint")
+
+    svc = _ollama(services_by_name)
+    r = http_client.get(_tags_url(svc))
+    assert r.status_code == 403, f"expected 403, got {r.status_code}: {r.text[:200]}"
+
+    body_lower = r.text.lower()
+    for leak in ("models", "ollama/", "qwen", "llama"):
+        assert leak not in body_lower, (
+            f"403 body leaks internal data ({leak!r}): {r.text[:300]}"
+        )
+
+
+def test_ollama_rejects_invalid_key(
+    services_by_name: dict[str, ServiceHealthConfig],
+    http_client: httpx.Client,
+    env: str,
+) -> None:
+    """Automated test-of-the-test: a key the client KNOWS is wrong returns 403.
+
+    Uses a hardcoded sentinel — independent of any SOPS value — so this case
+    proves the middleware validates the key value (not just header presence).
+    """
+    if env != "prod":
+        pytest.skip("staging is VPN-only — no middleware to reject")
+
+    svc = _ollama(services_by_name)
+    r = http_client.get(_tags_url(svc), headers={"X-API-Key": _WRONG_KEY_SENTINEL})
+    assert r.status_code == 403, (
+        f"middleware accepted a known-bad key (expected 403, got {r.status_code}): "
+        f"{r.text[:200]}"
+    )
+
+
+def test_ollama_bearer_forward_compat(
+    services_by_name: dict[str, ServiceHealthConfig],
+    http_client: httpx.Client,
+    ollama_api_key: str | None,
+    env: str,
+) -> None:
+    """`Authorization: Bearer <key>` returns 200 — plugin Bearer mode enabled.
+
+    Forward-compat guard for ADR-035 Stage 2 (OIDC/JWT migration). If a future
+    Middleware drift disables Bearer mode, this test breaks intentionally to
+    force the lockstep update (Middleware + ADR-035 anchored decisions).
+    """
+    if env != "prod":
+        pytest.skip("staging is VPN-only — no middleware to honor Bearer")
+    if not ollama_api_key:
+        pytest.skip("ollama_api_key fixture returned None — SOPS unavailable?")
+
+    svc = _ollama(services_by_name)
+    headers = {"Authorization": f"Bearer {ollama_api_key}"}
+    r = http_client.get(_tags_url(svc), headers=headers)
+    assert r.status_code == 200, (
+        f"Bearer mode appears disabled (expected 200, got {r.status_code}): "
+        f"{r.text[:200]}"
+    )
+
+
+def test_ollama_no_key_leak_in_403_body(
+    services_by_name: dict[str, ServiceHealthConfig],
+    http_client: httpx.Client,
+    ollama_api_key: str | None,
+    env: str,
+) -> None:
+    """The 403 response from a rejected request never echoes the real API key.
+
+    Paranoia guard: plugin shouldn't ever include the candidate key value in
+    its error body, but verify on a known-bad request — sending the wrong
+    sentinel and asserting the SOPS-resolved real key is absent from output.
+    """
+    if env != "prod":
+        pytest.skip("staging is VPN-only — no middleware emits 403 bodies")
+    if not ollama_api_key:
+        pytest.skip("ollama_api_key fixture returned None — SOPS unavailable?")
+
+    svc = _ollama(services_by_name)
+    r = http_client.get(_tags_url(svc), headers={"X-API-Key": _WRONG_KEY_SENTINEL})
+    assert r.status_code == 403
+    assert ollama_api_key not in r.text, (
+        "403 body echoes the real SOPS API key — plugin is leaking secrets"
+    )


### PR DESCRIPTION
## Summary

Locks the AI-001 auth boundary on `ollama.kubelab.live` with 5 E2E cases against the live Traefik api-key plugin Middleware. Closes spec **AI-002-e2e-tests** (proposal/tasks/verification in `specs/AI-002-e2e-tests/`).

- `tests/e2e/test_ollama_public.py` — 5 cases (health, anon-403, wrong-key-403 with hardcoded sentinel, Bearer-200, no-leak)
- `tests/e2e/conftest.py` — session-scoped `ollama_api_key` fixture reading the SOPS-merged config at `apps.services.ai.ollama.api_key` (same path as `MIDDLEWARE_CATALOG["api-key-ollama"].secret_key_path`)
- `specs/AI-002-e2e-tests/verification.md` — filled with concrete evidence

## Why the wrong-key sentinel is hardcoded

`_WRONG_KEY_SENTINEL = "definitely-not-the-real-key"` is a module constant, **not** read from SOPS. The middleware reads its accepted-key set from SOPS; the test sends a value it KNOWS is wrong. That decoupling makes the test invariant under key rotation and proves the middleware validates the *value*, not just header presence. If anyone "improves" the test by sourcing the wrong key from SOPS, they break the test-of-the-test guarantee.

## Test plan

- [x] `make test-e2e ENV=prod` → `5 passed in 1.96s` against `ollama.kubelab.live`
- [x] `make test-e2e ENV=staging` → `1 passed, 4 skipped in 0.81s` (health probes `ollama.staging.kubelab.live`, 4 auth cases skip with documented "VPN-only" reasons)
- [x] No regressions in pre-existing E2E suite (3 unrelated failures predate this branch and are tracked separately, see below)

## Surfaced during verification (out of scope, tracked separately)

The full prod E2E suite still has 3 pre-existing failures unrelated to AI-002: `test_security_headers_present[api|web]` and `test_hsts_header[web]`. Root cause: `infra/k8s/overlays/prod/generated/ingress.yaml` is missing the `secure-headers` middleware on the api/web IngressRoutes (staging has both, prod has only `error-pages`). The generator's `_build_middlewares()` always emits `["secure-headers", "error-pages"]`, so the prod generated file is stale relative to the current generator code. Tracking as **SEC-K8S-001** in `kubelab/11-tasks.md`; fix is a separate small PR after this lands.

## Spec link

- `specs/AI-002-e2e-tests/proposal.md` (acceptance criteria)
- `specs/AI-002-e2e-tests/verification.md` (evidence)