### PR TITLE
fix(tests): Codex P1 on #201 — fail-closed prod when ollama_api_key missing

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -209,17 +209,29 @@ def authenticated_client(
 
 
 @pytest.fixture(scope="session")
-def ollama_api_key(e2e_config: dict[str, Any]) -> str | None:
+def ollama_api_key(e2e_config: dict[str, Any], env: str) -> str | None:
     """Resolve the public Ollama X-API-Key from SOPS-merged config.
 
     Path mirrors `MIDDLEWARE_CATALOG["api-key-ollama"].secret_key_path`
     (toolkit.features.k8s_middlewares) — the same value the Traefik
-    Middleware reads. Returns None when no decrypted key is available
-    (e.g. SOPS unreachable locally); callers must skip in that case.
+    Middleware reads.
+
+    In prod the key MUST resolve — SOPS decrypt failure or config drift is
+    a hard failure, not a skip (a missing key would otherwise silently
+    let CI pass while the positive-auth path goes unverified). In
+    non-prod envs (staging/dev) a missing key returns None; auth-gated
+    tests already skip themselves out via the `env != "prod"` check.
     """
     ai = e2e_config.get("apps", {}).get("services", {}).get("ai", {})
     key = ai.get("ollama", {}).get("api_key")
     if not key or (isinstance(key, str) and key.startswith("secrets://")):
+        if env == "prod":
+            pytest.fail(
+                "ollama_api_key not resolved in prod — SOPS decrypt failure or "
+                "config drift at apps.services.ai.ollama.api_key. Refusing to "
+                "skip auth-boundary tests in prod (would mask a broken secret "
+                "pipeline as a green CI run)."
+            )
         return None
     return str(key)
 

--- a/tests/e2e/test_ollama_public.py
+++ b/tests/e2e/test_ollama_public.py
@@ -51,8 +51,9 @@ def test_ollama_health_authenticated(
     svc = _ollama(services_by_name)
     headers = {}
     if env == "prod":
-        if not ollama_api_key:
-            pytest.skip("ollama_api_key fixture returned None — SOPS unavailable?")
+        # Fixture fails hard in prod when key is missing (see conftest.py);
+        # by the time we get here, `ollama_api_key` is guaranteed non-None.
+        assert ollama_api_key is not None
         headers["X-API-Key"] = ollama_api_key
 
     r = http_client.get(_tags_url(svc), headers=headers)
@@ -120,8 +121,7 @@ def test_ollama_bearer_forward_compat(
     """
     if env != "prod":
         pytest.skip("staging is VPN-only — no middleware to honor Bearer")
-    if not ollama_api_key:
-        pytest.skip("ollama_api_key fixture returned None — SOPS unavailable?")
+    assert ollama_api_key is not None  # fixture fails in prod if missing
 
     svc = _ollama(services_by_name)
     headers = {"Authorization": f"Bearer {ollama_api_key}"}
@@ -146,8 +146,7 @@ def test_ollama_no_key_leak_in_403_body(
     """
     if env != "prod":
         pytest.skip("staging is VPN-only — no middleware emits 403 bodies")
-    if not ollama_api_key:
-        pytest.skip("ollama_api_key fixture returned None — SOPS unavailable?")
+    assert ollama_api_key is not None  # fixture fails in prod if missing
 
     svc = _ollama(services_by_name)
     r = http_client.get(_tags_url(svc), headers={"X-API-Key": _WRONG_KEY_SENTINEL})


### PR DESCRIPTION
## Summary

Codex P1 follow-up on #201. The original `ollama_api_key` fixture returned `None` when SOPS decryption failed or the config path drifted, which caused three prod auth-path tests (`health_authenticated`, `bearer_forward_compat`, `no_key_leak_in_403_body`) to `pytest.skip` instead of failing. A broken secret pipeline would therefore go undetected as a green CI run — defeating the whole point of the AI-002 suite as an auth-boundary guard.

This PR moves the policy into the fixture itself:

- **prod**: `pytest.fail(...)` when the key is missing or still a `secrets://` placeholder. Hard, loud, and impossible to mistake for "no work to do."
- **staging / dev**: keep returning `None`. The auth-gated tests already skip themselves out via the `env != \"prod\"` check, so a missing key in non-prod stays a non-event.

Tests drop the redundant `if not ollama_api_key: pytest.skip(...)` guards and `assert ollama_api_key is not None` instead — by the time the test body runs in prod, the fixture has already enforced the invariant.

## Why fail-closed at the fixture (not at each test)

Centralizing the invariant at the fixture means:
1. Future auth-gated ollama tests (AI-004 Pollex, DT-004 widget-proxy if they follow the same pattern) inherit the policy automatically.
2. There's no chance of a future contributor writing `if not key: pytest.skip(...)` and re-introducing the fail-open behavior — the fixture refuses to return None in prod, period.

## Test plan

- [x] `make test-e2e ENV=prod` → `5 passed in 2.61s`
- [x] `make test-e2e ENV=staging` → `1 passed, 4 skipped in 0.53s` (4 auth cases skip via env check, fixture returns None gracefully)
- [x] Manual sanity: temporarily forcing the SOPS path to a stub returns the expected hard failure with the exact error message.

## Codex thread

Replied + resolved at https://github.com/mlorentedev/kubelab/pull/201#discussion_r3293700879