### PR TITLE
fix(toolkit): SEC-AI-002 — server-side apply for Middlewares (no API key leak in annotation)

### DIFF
--- a/tests/test_k8s_middlewares.py
+++ b/tests/test_k8s_middlewares.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -162,7 +163,11 @@ class TestApplyMiddlewareSecrets:
 
     def test_kubectl_apply_uses_stdin_with_rendered_yaml(self, fake_project: Path) -> None:
         cm = self._patch_targets(self._SOPS_OK)
-        run_mock = _mock_kubectl("middleware.traefik.io/api-key-ollama configured")
+        # Two outputs: apply + legacy-annotation scrub (SEC-AI-002).
+        run_mock = _mock_kubectl(
+            "middleware.traefik.io/api-key-ollama serverside-applied",
+            "middleware.traefik.io/api-key-ollama annotated",
+        )
 
         with patch(
             "toolkit.features.k8s_middlewares.ConfigurationManager", return_value=cm
@@ -170,19 +175,66 @@ class TestApplyMiddlewareSecrets:
             ok = apply_middleware_secrets(env="prod", project_root=fake_project)
 
         assert ok is True
-        assert run_mock.call_count == 1
-        call = run_mock.call_args_list[0]
-        argv = call.args[0]
-        assert "kubectl" in argv
-        assert "apply" in argv
-        assert "-f" in argv and "-" in argv, "Must apply via stdin (-f -)"
-        stdin = call.kwargs.get("input", "")
+        assert run_mock.call_count == 2, "apply + post-apply annotation scrub"
+
+        apply_call = run_mock.call_args_list[0]
+        apply_argv = apply_call.args[0]
+        assert "kubectl" in apply_argv
+        assert "apply" in apply_argv
+        assert "-f" in apply_argv and "-" in apply_argv, "Must apply via stdin (-f -)"
+        # SEC-AI-002 invariant: never client-side apply for Middlewares whose
+        # body embeds a plaintext secret (would leak into the
+        # last-applied-configuration annotation).
+        assert "--server-side" in apply_argv
+        assert "--force-conflicts" in apply_argv, (
+            "Required for first-time migration from client-side managed fields"
+        )
+        assert "--field-manager" in apply_argv
+        fm_idx = apply_argv.index("--field-manager")
+        assert apply_argv[fm_idx + 1] == "kubelab-toolkit", (
+            "Owner tag must be traceable in metadata.managedFields"
+        )
+        stdin = apply_call.kwargs.get("input", "")
         assert "PROD_KEY_42" in stdin
         assert "api-key-ollama" in stdin
 
+        scrub_call = run_mock.call_args_list[1]
+        scrub_argv = scrub_call.args[0]
+        assert "annotate" in scrub_argv
+        assert "middleware" in scrub_argv
+        assert "api-key-ollama" in scrub_argv
+        assert "kubectl.kubernetes.io/last-applied-configuration-" in scrub_argv, (
+            "Must strip the legacy annotation that pre-SEC-AI-002 client-side "
+            "applies left behind (it embeds the plaintext API key)"
+        )
+
+    def test_scrub_failure_does_not_fail_the_apply(self, fake_project: Path) -> None:
+        """The legacy-annotation scrub is best-effort. A failure (RBAC,
+        missing resource on first apply, …) must not flip a successful
+        apply into a False return — the secret-injection contract is the
+        apply, not the cleanup."""
+        cm = self._patch_targets(self._SOPS_OK)
+
+        apply_ok = MagicMock(stdout="serverside-applied", stderr="", returncode=0)
+        scrub_err = subprocess.CalledProcessError(
+            returncode=1, cmd=["kubectl", "annotate"], stderr="forbidden"
+        )
+        run_mock = MagicMock(side_effect=[apply_ok, scrub_err])
+
+        with patch(
+            "toolkit.features.k8s_middlewares.ConfigurationManager", return_value=cm
+        ), patch("toolkit.features.k8s_middlewares.subprocess.run", run_mock):
+            ok = apply_middleware_secrets(env="prod", project_root=fake_project)
+
+        assert ok is True, "apply succeeded; scrub failure is non-fatal"
+        assert run_mock.call_count == 2
+
     def test_audit_copy_written_to_generated_dir(self, fake_project: Path) -> None:
         cm = self._patch_targets(self._SOPS_OK)
-        run_mock = _mock_kubectl("middleware.traefik.io/api-key-ollama configured")
+        run_mock = _mock_kubectl(
+            "middleware.traefik.io/api-key-ollama serverside-applied",
+            "middleware.traefik.io/api-key-ollama annotated",
+        )
 
         with patch(
             "toolkit.features.k8s_middlewares.ConfigurationManager", return_value=cm

--- a/toolkit/features/k8s_middlewares.py
+++ b/toolkit/features/k8s_middlewares.py
@@ -176,7 +176,24 @@ def _kubeconfig_for(env: str) -> str:
 
 
 def _kubectl_apply(env: str, namespace: str, rendered: str, spec_name: str) -> bool:
-    """`kubectl apply -f -` with rendered YAML on stdin. Returns True on success."""
+    """Server-side apply of the rendered Middleware + scrub legacy annotation.
+
+    SEC-AI-002. Client-side `kubectl apply` persists the request body into the
+    `kubectl.kubernetes.io/last-applied-configuration` annotation — for a
+    Middleware whose body embeds a plaintext API key, that leaks the key into
+    cluster state and any `kubectl get -o yaml` output. Server-side apply
+    tracks managed fields via the API server instead, so the rendered body
+    (with the key) is never echoed back into an annotation.
+
+    `--force-conflicts` is required for the first apply when migrating a
+    resource previously managed client-side: the legacy annotation still
+    claims ownership of every field, so server-side rejects the apply as a
+    conflict unless we explicitly take over. Subsequent applies stay clean.
+
+    `--field-manager kubelab-toolkit` makes ownership traceable in
+    `metadata.managedFields[*].manager` so other operators (Argo CD, hand
+    edits) are distinguishable from this toolkit at audit time.
+    """
     cmd = [
         "kubectl",
         "--kubeconfig",
@@ -184,6 +201,10 @@ def _kubectl_apply(env: str, namespace: str, rendered: str, spec_name: str) -> b
         "-n",
         namespace,
         "apply",
+        "--server-side",
+        "--force-conflicts",
+        "--field-manager",
+        "kubelab-toolkit",
         "-f",
         "-",
     ]
@@ -196,7 +217,36 @@ def _kubectl_apply(env: str, namespace: str, rendered: str, spec_name: str) -> b
             check=True,
         )
         logger.success(f"  {result.stdout.strip() or spec_name + ' applied'}")
+        _scrub_legacy_annotation(env, namespace, spec_name)
         return True
     except subprocess.CalledProcessError as exc:
         logger.error(f"  kubectl apply failed for '{spec_name}': {exc.stderr.strip()}")
         return False
+
+
+def _scrub_legacy_annotation(env: str, namespace: str, spec_name: str) -> None:
+    """Strip `kubectl.kubernetes.io/last-applied-configuration` from a Middleware.
+
+    Legacy from any pre-SEC-AI-002 client-side apply that embedded the
+    plaintext API key into the annotation. Idempotent: `kubectl annotate
+    name key-` succeeds with a warning when the annotation is absent.
+    """
+    cmd = [
+        "kubectl",
+        "--kubeconfig",
+        _kubeconfig_for(env),
+        "-n",
+        namespace,
+        "annotate",
+        "middleware",
+        spec_name,
+        "kubectl.kubernetes.io/last-applied-configuration-",
+        "--overwrite=true",
+    ]
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as exc:
+        # Non-fatal — the apply already succeeded; scrub is a best-effort
+        # cleanup. Surface the reason so a real failure (RBAC, missing
+        # resource) is still visible.
+        logger.warning(f"  legacy annotation scrub skipped for '{spec_name}': {exc.stderr.strip()}")


### PR DESCRIPTION
## Summary

Closes the API-key leak via `kubectl.kubernetes.io/last-applied-configuration` annotation. Confirmed leak in prod:

\`\`\`bash
$ kubectl --kubeconfig ~/.kube/kubelab-prod-config get middleware -n kubelab api-key-ollama \
    -o jsonpath='{.metadata.annotations.kubectl\.kubernetes\.io/last-applied-configuration}' | head -c 200
{"apiVersion":"traefik.io/v1alpha1","kind":"Middleware","metadata":{...},"spec":{"plugin":{"api-key":{...keys: [PLAINTEXT_KEY]...}}}}
\`\`\`

Anyone with read on `middlewares.traefik.io` in `kubelab` namespace could lift the API key from the annotation — entirely bypassing SOPS and the rendering pipeline ADR-035 was supposed to gate.

## Fix

Two-part in `toolkit/features/k8s_middlewares.py:_kubectl_apply`:

1. **Server-side apply** with `--server-side --force-conflicts --field-manager kubelab-toolkit`.
   - `--server-side` stops kubectl from echoing the rendered manifest into the annotation.
   - `--force-conflicts` required for the first migration apply (legacy annotation still owns every field).
   - `--field-manager` traceable owner in `metadata.managedFields`.
2. **Legacy annotation scrub** — post-successful-apply, `kubectl annotate <md> kubectl.kubernetes.io/last-applied-configuration-`. Idempotent (no-op on clean resources), non-fatal on failure.

## Tests

`tests/test_k8s_middlewares.py` — 15/15 pass.
- Updated `test_kubectl_apply_uses_stdin_with_rendered_yaml` to assert on the 3 new flags + the 2-call pattern (apply + scrub).
- New `test_scrub_failure_does_not_fail_the_apply` pins the contract that the scrub is best-effort.

## Verification

Pre-merge (run from this PR's worktree to validate against prod cluster):

\`\`\`bash
cd .worktrees/sec-ai-002    # the new code is here
make apply-middleware-secrets ENV=prod
# Confirm leak gone:
kubectl get middleware api-key-ollama -n kubelab -o yaml | grep -c 'last-applied-configuration'
# expect: 0
\`\`\`

Post-merge: Argo CD does not run the toolkit; the next `make deploy-k8s ENV=prod` or `make apply-middleware-secrets ENV=prod` triggers the migration.

## Follow-ups (out of scope)

- Future Middleware specs (AI-004 Pollex, DT-004 widget-proxy) inherit this automatically — no spec changes needed.
- Consider a CI check that asserts `kubectl get middleware -o yaml | grep -L last-applied-configuration` across all Middleware names in `MIDDLEWARE_CATALOG`.