### PR TITLE
feat(ci): SEC-SCAN-001 — restore Trivy image scanning (pinned + non-blocking soak)

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -118,8 +118,28 @@ jobs:
             org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
             org.opencontainers.image.tag-type=${{ steps.docker_tags.outputs.tag_type }}
 
-      # TODO: Re-enable Trivy scanning when action version stabilizes
-      # Removed: aquasecurity/trivy-action kept breaking CI across versions
+      # SEC-SCAN-001: pinned to v0.36.0 (commit SHA, not floating tag, to avoid CI breakage).
+      # continue-on-error during a 4-week soak so findings surface in GitHub Security
+      # without blocking ships; flip to blocking after baseline is established.
+      - name: Trivy vulnerability scan
+        id: trivy_scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        continue-on-error: true
+        with:
+          image-ref: ${{ steps.docker_tags.outputs.full_image }}
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Upload Trivy SARIF to GitHub Security
+        if: always() && hashFiles('trivy-results.sarif') != ''
+        uses: github/codeql-action/upload-sarif@v3
+        continue-on-error: true
+        with:
+          sarif_file: trivy-results.sarif
+          category: trivy-${{ inputs.app }}
 
       - name: Log build summary
         run: |


### PR DESCRIPTION
## Summary

- Pin `aquasecurity/trivy-action` to v0.36.0 commit SHA (`ed142fd0673e97e23eac54620cfb913e5ce36c25`), not the floating tag, to avoid the recurring breakage that motivated its previous removal.
- `continue-on-error: true` during a 4-week soak so findings surface in the GitHub Security tab without blocking ships. After the soak, flip to blocking and tighten severities based on observed baseline.
- SARIF upload via `github/codeql-action/upload-sarif@v3` with per-app category, gated on `hashFiles()` so missing reports do not fail jobs.
- Severity scope: `CRITICAL,HIGH` + `ignore-unfixed: true` to focus signal.

Refs: vault `10_projects/kubelab/11-tasks.md` SEC-SCAN-001 (HIGH, MED size). Pre-work for the SLSA supply-chain ticket.

## Test plan

- [ ] CI green on this PR (Build & Push job for affected apps)
- [ ] Trivy step runs to completion and produces `trivy-results.sarif`
- [ ] SARIF appears in repo `Security > Code scanning alerts` under category `trivy-<app>`
- [ ] No build job marked `failure` because of Trivy (continue-on-error honored)
- [ ] Schedule reminder to flip `continue-on-error: false` after 4 weeks (~2026-06-21)