### PR TITLE
chore(docs): fix CLAUDE.md vault paths to match actual structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ KubeLab is one piece of a larger product ecosystem organized in 4 layers:
 
 **Master index**: vault `10_projects/kubelab/portfolio.md`
 **Product specs**: vault `10_projects/<product>/_index.md`
-**Template**: vault `10_projects/kubelab/06-products/product-template.md`
+**Template**: vault `00_meta/templates/product-template.md`
 
 ### Product lifecycle
 
@@ -188,12 +188,14 @@ versioning.md              — Versioning strategy
 architecture-diagram.md    — Detailed architecture diagrams
 portfolio.md               — Product portfolio master index
 service-catalog.md         — Service catalog
-01-adrs/                   — Architecture Decision Records
-02-runbooks/               — Operational runbooks
-03-troubleshooting/        — Troubleshooting guides
-04-infra/                  — Infrastructure docs (DNS, networking)
-05-hardware/               — Hardware allocation and topology
-06-products/               — Product template
+30-architecture/adrs/      — Architecture Decision Records
+30-architecture/components/ — Component-level architecture docs
+30-architecture/infra/     — Infrastructure docs (DNS, networking)
+30-architecture/hardware/  — Hardware allocation and topology
+30-architecture/plans/     — Implementation plans
+40-runbooks/               — Operational runbooks
+50-troubleshooting/        — Troubleshooting guides
+20-business/               — Positioning, offers, funnel, competitor analysis
 changelog.md               — Project changelog
 ```
 


### PR DESCRIPTION
## Summary

The *Vault paths for this project* block in `CLAUDE.md` listed numeric prefixes (`01-adrs/`, `02-runbooks/`, `03-troubleshooting/`, `04-infra/`, `05-hardware/`, `06-products/`) that **no longer match the vault layout** — every one of those paths is broken if you `cd` into the vault.

Real layout under `10_projects/kubelab/`:

| Block said | Actually lives at |
|---|---|
| `01-adrs/` | `30-architecture/adrs/` |
| `02-runbooks/` | `40-runbooks/` |
| `03-troubleshooting/` | `50-troubleshooting/` |
| `04-infra/` | `30-architecture/infra/` |
| `05-hardware/` | `30-architecture/hardware/` |
| `06-products/product-template.md` | `00_meta/templates/product-template.md` (cross-project) |

Also added the previously-undocumented `30-architecture/components/`, `30-architecture/plans/`, and `20-business/` since they hold real content the agent needs to know about.

Surfaced during the MON-010 runbook write — author needed to know whether to drop the file under `02-runbooks/` or `40-runbooks/`. The real directory is `40-runbooks/`.

## Test plan

- [x] Manual: `cd` to each path listed in the new block and verify it exists.
- [x] Manual: open `vault://10_projects/kubelab/30-architecture/adrs/` in Obsidian, confirm ADR files there.
- [ ] Read the block end-to-end and confirm no other CLAUDE.md sections reference the old paths.