### PR TITLE
chore(docs): fix vault path references (02-runbooks → 40-runbooks)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ KubeLab is one piece of a larger product ecosystem organized in 4 layers:
 
 **Master index**: vault `10_projects/kubelab/portfolio.md`
 **Product specs**: vault `10_projects/<product>/_index.md`
-**Template**: vault `10_projects/kubelab/06-products/product-template.md`
+**Template**: vault `00_meta/templates/product-template.md`
 
 ### Product lifecycle
 
@@ -188,12 +188,14 @@ versioning.md              — Versioning strategy
 architecture-diagram.md    — Detailed architecture diagrams
 portfolio.md               — Product portfolio master index
 service-catalog.md         — Service catalog
-01-adrs/                   — Architecture Decision Records
-02-runbooks/               — Operational runbooks
-03-troubleshooting/        — Troubleshooting guides
-04-infra/                  — Infrastructure docs (DNS, networking)
-05-hardware/               — Hardware allocation and topology
-06-products/               — Product template
+30-architecture/adrs/      — Architecture Decision Records
+30-architecture/components/ — Component-level architecture docs
+30-architecture/infra/     — Infrastructure docs (DNS, networking)
+30-architecture/hardware/  — Hardware allocation and topology
+30-architecture/plans/     — Implementation plans
+40-runbooks/               — Operational runbooks
+50-troubleshooting/        — Troubleshooting guides
+20-business/               — Positioning, offers, funnel, competitor analysis
 changelog.md               — Project changelog
 ```
 

--- a/infra/ansible/README.md
+++ b/infra/ansible/README.md
@@ -130,4 +130,4 @@ ansible -i inventories/homelab.yml kubelab-jet1 -m raw -a "grep vpn.kubelab.live
 - `-K` required: most nodes need sudo password for `/etc/hosts` (RPi3 has NOPASSWD).
 - The inventory uses Tailscale IPs. If a node is already disconnected from Tailscale, fix it manually via SSH over LAN (`ssh <host>-lan`), then run this playbook to prevent recurrence.
 - Jetson Nano uses `raw` module (Python 3.6 too old for Ansible modules). Flagged with `legacy_python: true` in inventory.
-- Full operational docs: vault `02-runbooks/dns-homelab.md` → "DNS Resilience" section.
+- Full operational docs: vault `40-runbooks/dns-homelab.md` → "DNS Resilience" section.

--- a/infra/ansible/playbooks/provision-rpi4.yml
+++ b/infra/ansible/playbooks/provision-rpi4.yml
@@ -8,7 +8,7 @@
 #
 # Prerequisites:
 #   - Ubuntu Server flashed on SD card with netplan configured
-#   - See vault runbook: 02-runbooks/rpi4-bootstrap.md
+#   - See vault runbook: 40-runbooks/rpi4-bootstrap.md
 #
 # Usage:
 #   make provision NODE=rpi4 ENV=prod

--- a/infra/ansible/roles/gateway/tasks/main.yml
+++ b/infra/ansible/roles/gateway/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # Gateway role: IP forwarding, nftables NAT, dnsmasq DHCP, DNS resilience
-# Assumes netplan was configured pre-boot (see vault runbook: 02-runbooks/rpi4-bootstrap.md)
+# Assumes netplan was configured pre-boot (see vault runbook: 40-runbooks/rpi4-bootstrap.md)
 
 - name: Enable IP forwarding
   sysctl:


### PR DESCRIPTION
## Summary

- Vault runbooks directory is `40-runbooks/` (not `02-runbooks/`). CLAUDE.md and a handful of in-repo references were pointing at the wrong path.
- Two-pass fix: first commit covers CLAUDE.md (path map for AI agents); second commit catches three Ansible files the initial `*.md`-scoped grep missed.

## Changes

- `CLAUDE.md` — vault path map (committed in df64097)
- `infra/ansible/README.md` — DNS resilience runbook link
- `infra/ansible/playbooks/provision-rpi4.yml` — bootstrap reference
- `infra/ansible/roles/gateway/tasks/main.yml` — netplan reference

## Verification

- `git grep "02-runbooks"` — no remaining references in tracked files
- Pre-commit hooks pass (markdownlint, yamllint, trailing whitespace, etc.)
- No runtime impact — comment/documentation only

## Test plan

- [x] `git grep "02-runbooks"` returns empty
- [x] Pre-commit hooks green
- [ ] CI green (markdownlint, yamllint)