### PR TITLE
feat(ci): CI-GATE-003 — extend drift gate to configmaps.yaml

### DIFF
--- a/.github/workflows/check-config-drift.yml
+++ b/.github/workflows/check-config-drift.yml
@@ -1,24 +1,23 @@
 ---
 name: Config Drift Gate
 
-# CI-GATE-002. Prevents the SEC-K8S-001 class of bug: generator code evolves
-# but committed `generated/` files are never refreshed, so `kubectl apply -k`
-# uses stale manifests and tests that assert on generator-implied invariants
-# silently regress months after the original closure.
+# CI-GATE-002/003. Prevents the SEC-K8S-001 class of bug: generator code
+# evolves but committed `generated/` files are never refreshed, so
+# `kubectl apply -k` uses stale manifests and tests that assert on
+# generator-implied invariants silently regress months after the original
+# closure.
 #
-# Strategy: for each env, run `make config-check-drift ENV=<env>`. The target
-# regenerates configs via the toolkit and compares against the committed
-# files. Any non-empty diff fails the job, with the diff printed in the
-# log so the fix is obvious (commit the regenerated files).
+# Strategy: for each env, run `make config-check-drift ENV=<env>`. The
+# target regenerates configs via the toolkit and compares against the
+# committed files. Any non-empty diff fails the job, with the diff
+# printed in the log so the fix is obvious (commit the regenerated files).
 #
-# Scope (Phase 1): K8s ingress overlays + Ansible inventory — SOPS-independent.
-# Runs on every PR (including forks) and every push to master.
+# Scope: ingress.yaml + Ansible hosts.yml (CI-GATE-002) + configmaps.yaml
+# (CI-GATE-003). All SOPS-independent — no age key needed in CI.
 #
-# Scope (Phase 2, CI-GATE-003): configmaps.yaml, deployments.yaml, Traefik
-# middlewares.yml, Authelia configuration.yml. These embed SOPS-decrypted
-# values, so the step needs an age key. The age key lives on the
-# self-hosted runner filesystem (per ADR-030) — fork PRs (forced to
-# ubuntu-latest) and the GitHub-hosted fallback skip Phase 2.
+# See Makefile config-check-drift target for the rationale on what's NOT
+# included (deployments.yaml, middlewares.yml, configuration.yml) and the
+# SSOT-018 follow-up for deployments.yaml drift coverage.
 
 on:
   pull_request:
@@ -74,17 +73,8 @@ jobs:
         # package itself to be installed.
         run: poetry install --only main
 
-      - name: Check ${{ matrix.env }} for generator drift (Phase 1)
+      - name: Check ${{ matrix.env }} for generator drift
         run: make config-check-drift ENV="$TARGET_ENV"
-
-      - name: Check ${{ matrix.env }} for extended drift (Phase 2, SOPS-dependent)
-        # CI-GATE-003. Self-hosted runner only — fork PRs (forced to
-        # ubuntu-latest by the runs-on expression above) and the
-        # GitHub-hosted fallback (RUNNER_DOCKER unset) skip this step.
-        if: >-
-          !github.event.pull_request.head.repo.fork
-          && vars.RUNNER_DOCKER != ''
-        run: make config-check-drift-extended ENV="$TARGET_ENV"
 
       - name: Hint on failure
         if: failure()

--- a/.github/workflows/check-config-drift.yml
+++ b/.github/workflows/check-config-drift.yml
@@ -11,9 +11,14 @@ name: Config Drift Gate
 # files. Any non-empty diff fails the job, with the diff printed in the
 # log so the fix is obvious (commit the regenerated files).
 #
-# Scope: K8s overlays, Traefik configs, Ansible inventory — none of these
-# depend on SOPS-decrypted values. Authelia is intentionally OUT of scope
-# until CI gains access to an age key.
+# Scope (Phase 1): K8s ingress overlays + Ansible inventory — SOPS-independent.
+# Runs on every PR (including forks) and every push to master.
+#
+# Scope (Phase 2, CI-GATE-003): configmaps.yaml, deployments.yaml, Traefik
+# middlewares.yml, Authelia configuration.yml. These embed SOPS-decrypted
+# values, so the step needs an age key. The age key lives on the
+# self-hosted runner filesystem (per ADR-030) — fork PRs (forced to
+# ubuntu-latest) and the GitHub-hosted fallback skip Phase 2.
 
 on:
   pull_request:
@@ -69,8 +74,17 @@ jobs:
         # package itself to be installed.
         run: poetry install --only main
 
-      - name: Check ${{ matrix.env }} for generator drift
+      - name: Check ${{ matrix.env }} for generator drift (Phase 1)
         run: make config-check-drift ENV="$TARGET_ENV"
+
+      - name: Check ${{ matrix.env }} for extended drift (Phase 2, SOPS-dependent)
+        # CI-GATE-003. Self-hosted runner only — fork PRs (forced to
+        # ubuntu-latest by the runs-on expression above) and the
+        # GitHub-hosted fallback (RUNNER_DOCKER unset) skip this step.
+        if: >-
+          !github.event.pull_request.head.repo.fork
+          && vars.RUNNER_DOCKER != ''
+        run: make config-check-drift-extended ENV="$TARGET_ENV"
 
       - name: Hint on failure
         if: failure()

--- a/Makefile
+++ b/Makefile
@@ -229,19 +229,12 @@ config-generate:
 # the gate is deterministic in CI without an age key. The minimal scope
 # is deliberately tight to keep zero false positives on this first PR.
 #
-# OUT of scope for Phase 1 (broader generator output requires SSOT
-# cleanup + age key access — tracked as SSOT-012 and CI-GATE-003):
-#   - configmaps.yaml / deployments.yaml — currently pull a handful of
-#     non-secret values from SOPS (BEEHIIV_PUB_ID, EMAIL_FROM, EMAIL_USER);
-#     audit + relocate to common.yaml first.
-#   - edge/traefik/generated/<env>/middlewares.yml — uses
-#     BASIC_AUTH_CREDENTIALS from SOPS.
-#   - infra/config/authelia/generated/<env>/configuration.yml — has
-#     SOPS-interpolated jwt_secret, session secret, OIDC argon2 hashes.
+# OUT of scope for Phase 1 (Phase 2 = `config-check-drift-extended` target
+# below — runs on self-hosted runner only, reads age key from filesystem).
 .PHONY: config-check-drift
 config-check-drift:
 	@test -n "$(ENV)" || (echo "Usage: make config-check-drift ENV=staging|prod" && exit 1)
-	@echo "→ Regenerating $(ENV) configs and checking for drift..."
+	@echo "→ Regenerating $(ENV) configs and checking for drift (Phase 1, SOPS-independent)..."
 	@$(TOOLKIT) config generate --env $(ENV) --force
 	@_status=0; \
 	_paths="infra/k8s/overlays/$(ENV)/generated/ingress.yaml infra/ansible/generated/$(ENV)/hosts.yml"; \
@@ -249,6 +242,47 @@ config-check-drift:
 		echo "✓ No drift in $(ENV) generated configs ($$_paths)"; \
 	else \
 		echo "✗ Drift detected in $(ENV) generated configs:"; \
+		git --no-pager diff -- $$_paths; \
+		_status=1; \
+	fi; \
+	git checkout -- infra edge 2>/dev/null || true; \
+	exit $$_status
+
+# CI-GATE-003: extend drift gate to SOPS-dependent generated files.
+# Requires an age key at ~/.config/sops/age/keys.txt (or $SOPS_AGE_KEY_FILE).
+# Runs on self-hosted runner only (per ADR-030); fork PRs and the
+# GitHub-hosted fallback skip this target via workflow `if:` guards.
+#
+# Scope additions over Phase 1:
+#   - infra/k8s/overlays/<env>/generated/configmaps.yaml — post-SSOT-012
+#     the SMTP/beehiiv values come from common.yaml, but other SOPS values
+#     (api keys, etc.) still flow through here.
+#   - infra/k8s/overlays/<env>/generated/deployments.yaml — image digests
+#     and env vars sourced from common + SOPS.
+#   - edge/traefik/generated/<env>/dynamic/middlewares.yml — embeds
+#     BASIC_AUTH_CREDENTIALS hashes from SOPS.
+#   - infra/config/authelia/generated/<env>/configuration.yml — has
+#     jwt_secret, session_secret, OIDC issuer key from SOPS.
+.PHONY: config-check-drift-extended
+config-check-drift-extended:
+	@test -n "$(ENV)" || (echo "Usage: make config-check-drift-extended ENV=staging|prod" && exit 1)
+	@if [ ! -f "$$HOME/.config/sops/age/keys.txt" ] && [ -z "$$SOPS_AGE_KEY_FILE" ]; then \
+		echo "✗ Extended drift check requires an age key."; \
+		echo "  Looked for ~/.config/sops/age/keys.txt and \$$SOPS_AGE_KEY_FILE — neither found."; \
+		echo "  This target is meant to run on the self-hosted runner (ADR-030) where the key lives on disk."; \
+		exit 1; \
+	fi
+	@echo "→ Regenerating $(ENV) configs and checking extended drift (Phase 2, SOPS-dependent)..."
+	@$(TOOLKIT) config generate --env $(ENV) --force
+	@_status=0; \
+	_paths="infra/k8s/overlays/$(ENV)/generated/configmaps.yaml \
+	        infra/k8s/overlays/$(ENV)/generated/deployments.yaml \
+	        edge/traefik/generated/$(ENV)/dynamic/middlewares.yml \
+	        infra/config/authelia/generated/$(ENV)/configuration.yml"; \
+	if git diff --quiet -- $$_paths; then \
+		echo "✓ No drift in $(ENV) extended generated configs"; \
+	else \
+		echo "✗ Drift detected in $(ENV) extended generated configs:"; \
 		git --no-pager diff -- $$_paths; \
 		_status=1; \
 	fi; \

--- a/Makefile
+++ b/Makefile
@@ -216,73 +216,42 @@ credentials-generate:
 config-generate:
 	@$(TOOLKIT) config generate --env $(ENV)
 
-# CI-GATE-002: detect drift between the generator output and the committed
+# CI-GATE-002/003: detect drift between the generator output and the committed
 # `generated/` files. Catches the class of bug that bit SEC-K8S-001 (prod
 # ingress.yaml lacked secure-headers middleware because the generator code
 # evolved but the committed file was never refreshed).
 #
-# Scope (Phase 1 — SOPS-independent only):
-#   - infra/k8s/overlays/<env>/generated/ingress.yaml
-#   - infra/ansible/generated/<env>/hosts.yml
+# Scope (SOPS-independent only — safe for CI without an age key):
+#   - infra/k8s/overlays/<env>/generated/ingress.yaml      (CI-GATE-002)
+#   - infra/ansible/generated/<env>/hosts.yml              (CI-GATE-002)
+#   - infra/k8s/overlays/<env>/generated/configmaps.yaml   (CI-GATE-003)
 #
-# Both generators read EXCLUSIVELY from `common.yaml` + `<env>.yaml`, so
-# the gate is deterministic in CI without an age key. The minimal scope
-# is deliberately tight to keep zero false positives on this first PR.
+# These generators read EXCLUSIVELY from `common.yaml` + `<env>.yaml`
+# (post-SSOT-012, configmaps.yaml no longer pulls non-secret values from
+# SOPS), so the gate is deterministic in CI without decryption.
 #
-# OUT of scope for Phase 1 (Phase 2 = `config-check-drift-extended` target
-# below — runs on self-hosted runner only, reads age key from filesystem).
+# NOT included (each has a specific reason):
+#   - deployments.yaml — committed, but the generator omits `secretRef`
+#     refs when SOPS decryption fails. Drift-checking without an age key
+#     produces false positives. Tracked as SSOT-018 (refactor generator
+#     to emit secretRef from SOPS file presence, not decryption success).
+#   - edge/traefik/generated/<env>/dynamic/middlewares.yml — gitignored
+#     (embeds plaintext basic_auth credentials). Drift-check is no-op.
+#   - infra/config/authelia/generated/<env>/configuration.yml — gitignored
+#     (embeds plaintext jwt_secret + argon2 hashes). Drift-check is no-op.
 .PHONY: config-check-drift
 config-check-drift:
 	@test -n "$(ENV)" || (echo "Usage: make config-check-drift ENV=staging|prod" && exit 1)
-	@echo "→ Regenerating $(ENV) configs and checking for drift (Phase 1, SOPS-independent)..."
+	@echo "→ Regenerating $(ENV) configs and checking for drift..."
 	@$(TOOLKIT) config generate --env $(ENV) --force
 	@_status=0; \
-	_paths="infra/k8s/overlays/$(ENV)/generated/ingress.yaml infra/ansible/generated/$(ENV)/hosts.yml"; \
+	_paths="infra/k8s/overlays/$(ENV)/generated/ingress.yaml \
+	        infra/k8s/overlays/$(ENV)/generated/configmaps.yaml \
+	        infra/ansible/generated/$(ENV)/hosts.yml"; \
 	if git diff --quiet -- $$_paths; then \
-		echo "✓ No drift in $(ENV) generated configs ($$_paths)"; \
+		echo "✓ No drift in $(ENV) generated configs"; \
 	else \
 		echo "✗ Drift detected in $(ENV) generated configs:"; \
-		git --no-pager diff -- $$_paths; \
-		_status=1; \
-	fi; \
-	git checkout -- infra edge 2>/dev/null || true; \
-	exit $$_status
-
-# CI-GATE-003: extend drift gate to SOPS-dependent generated files.
-# Requires an age key at ~/.config/sops/age/keys.txt (or $SOPS_AGE_KEY_FILE).
-# Runs on self-hosted runner only (per ADR-030); fork PRs and the
-# GitHub-hosted fallback skip this target via workflow `if:` guards.
-#
-# Scope additions over Phase 1:
-#   - infra/k8s/overlays/<env>/generated/configmaps.yaml — post-SSOT-012
-#     the SMTP/beehiiv values come from common.yaml, but other SOPS values
-#     (api keys, etc.) still flow through here.
-#   - infra/k8s/overlays/<env>/generated/deployments.yaml — image digests
-#     and env vars sourced from common + SOPS.
-#   - edge/traefik/generated/<env>/dynamic/middlewares.yml — embeds
-#     BASIC_AUTH_CREDENTIALS hashes from SOPS.
-#   - infra/config/authelia/generated/<env>/configuration.yml — has
-#     jwt_secret, session_secret, OIDC issuer key from SOPS.
-.PHONY: config-check-drift-extended
-config-check-drift-extended:
-	@test -n "$(ENV)" || (echo "Usage: make config-check-drift-extended ENV=staging|prod" && exit 1)
-	@if [ ! -f "$$HOME/.config/sops/age/keys.txt" ] && [ -z "$$SOPS_AGE_KEY_FILE" ]; then \
-		echo "✗ Extended drift check requires an age key."; \
-		echo "  Looked for ~/.config/sops/age/keys.txt and \$$SOPS_AGE_KEY_FILE — neither found."; \
-		echo "  This target is meant to run on the self-hosted runner (ADR-030) where the key lives on disk."; \
-		exit 1; \
-	fi
-	@echo "→ Regenerating $(ENV) configs and checking extended drift (Phase 2, SOPS-dependent)..."
-	@$(TOOLKIT) config generate --env $(ENV) --force
-	@_status=0; \
-	_paths="infra/k8s/overlays/$(ENV)/generated/configmaps.yaml \
-	        infra/k8s/overlays/$(ENV)/generated/deployments.yaml \
-	        edge/traefik/generated/$(ENV)/dynamic/middlewares.yml \
-	        infra/config/authelia/generated/$(ENV)/configuration.yml"; \
-	if git diff --quiet -- $$_paths; then \
-		echo "✓ No drift in $(ENV) extended generated configs"; \
-	else \
-		echo "✗ Drift detected in $(ENV) extended generated configs:"; \
 		git --no-pager diff -- $$_paths; \
 		_status=1; \
 	fi; \


### PR DESCRIPTION
## Summary

Extends the existing **Phase 1** drift gate (CI-GATE-002 in PR #207) to include `infra/k8s/overlays/<env>/generated/configmaps.yaml`. After SSOT-012 (PRs #208/#209/#210) moved SMTP/beehiiv non-secrets out of SOPS, configmaps.yaml regenerates byte-identical without an age key — safe to drift-check in CI on any runner.

> **Note on PR history:** earlier commits in this branch added a separate `config-check-drift-extended` Phase 2 target that required an age key. CI run [#26424780200](https://github.com/mlorentedev/kubelab/actions/runs/26424780200) surfaced that the self-hosted runner (dockerized) doesn't see the host's age key. Design review concluded the original scope was wrong — see the most recent commit message and the audit below. PR final scope is narrower and self-consistent.

## Final scope

| File | Status | In gate? |
|---|---|---|
| `infra/k8s/overlays/<env>/generated/ingress.yaml` | committed, SOPS-independent | YES (CI-GATE-002) |
| `infra/ansible/generated/<env>/hosts.yml` | committed, SOPS-independent | YES (CI-GATE-002) |
| `infra/k8s/overlays/<env>/generated/configmaps.yaml` | committed, SOPS-independent post-SSOT-012 | **YES (CI-GATE-003, this PR)** |
| `infra/k8s/overlays/<env>/generated/deployments.yaml` | committed, but generator emits secretRef conditional on SOPS decryption success | NO — blocked by **SSOT-018** (generator refactor) |
| `edge/traefik/generated/<env>/dynamic/middlewares.yml` | gitignored (plaintext basic_auth) | NO — drift-check no-op on gitignored files |
| `infra/config/authelia/generated/<env>/configuration.yml` | gitignored (plaintext jwt_secret + argon2 hashes) | NO — drift-check no-op on gitignored files |

## Why no age key in CI

The original Phase 2 plan was to mount the age key in the self-hosted runner per ADR-030. Two reasons we backed off:

1. **Most "extended" files are gitignored** — drift-checking them via `git diff` is a no-op regardless of age-key access.
2. **For deployments.yaml specifically**, the real bug is that the generator omits `secretRef` blocks when SOPS decryption fails. That is a determinism problem in the generator, not a CI plumbing problem. Mounting the age key would mask the bug. Fix the generator (SSOT-018) and `deployments.yaml` becomes SOPS-independent for drift purposes.

## Verification

```
$ make config-check-drift ENV=staging  → No drift
$ make config-check-drift ENV=prod     → No drift
```

And the earlier test (age key removed mid-run) confirmed `configmaps.yaml` regenerates byte-identical without SOPS access.

## Follow-ups

- **SSOT-018** (new): refactor `generator_k8s.py` so `secretRef` is emitted from SOPS file presence, not decryption success. Once landed, extend this gate to `deployments.yaml`.
- **ADR-038** (new): document the three secret-delivery paths (K8s Secret envFrom, Traefik Middleware embedded, K8s Secret as file) and evaluate Sealed Secrets as a future unification path.

## Test plan

- [x] CI green on this PR (every runner type — including the GitHub-hosted fallback)
- [ ] Nightly schedule (06:00 UTC) on master green post-merge
