### PR TITLE
feat(ssot): SSOT-014a — consolidate ssh_user as networking.ssh_users.{homelab,cloud}

### DIFF
--- a/infra/ansible/playbooks/_includes/check-vps-reachable.yml
+++ b/infra/ansible/playbooks/_includes/check-vps-reachable.yml
@@ -15,7 +15,7 @@
 - name: "Pre-flight: verify VPS reachable (needed for Headscale pre-auth key)"
   ansible.builtin.command: >-
     ssh -o ConnectTimeout=5 -o BatchMode=yes
-    {{ _ssot_common.networking.vps.ssh_user }}@{{ _ssot_common.networking.vps.tailscale_ip }}
+    {{ _ssot_common.networking.vps.ssh_user | default(_ssot_common.networking.ssh_users.cloud) }}@{{ _ssot_common.networking.vps.tailscale_ip }}
     echo ok
   delegate_to: localhost
   changed_when: false

--- a/infra/ansible/playbooks/_includes/check-vps-reachable.yml
+++ b/infra/ansible/playbooks/_includes/check-vps-reachable.yml
@@ -15,7 +15,7 @@
 - name: "Pre-flight: verify VPS reachable (needed for Headscale pre-auth key)"
   ansible.builtin.command: >-
     ssh -o ConnectTimeout=5 -o BatchMode=yes
-    {{ _ssot_common.networking.vps.ssh_user | default(_ssot_common.networking.ssh_users.cloud) }}@{{ _ssot_common.networking.vps.tailscale_ip }}
+    {{ _ssot_common.networking.vps.ssh_user | default(_ssot_common.networking.ssh_users.cloud, true) }}@{{ _ssot_common.networking.vps.tailscale_ip }}
     echo ok
   delegate_to: localhost
   changed_when: false

--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -39,11 +39,19 @@ networking:
       node: jetson         # resolves to networking.nodes.jetson.tailscale_ip
   ipv6_prefix: "fd7a:115c:a1e0::/48"
   ssh_key: "~/.ssh/id_ed25519"
+
+  # SSOT-014a: SSH user per node category. Consumers infer category by YAML
+  # position (vps + aws → cloud; nodes.* → homelab). Per-node `ssh_user` field
+  # remains supported as an override (currently unused — no node deviates from
+  # its category default). See specs/SSOT-014-ssh-user/proposal.md.
+  ssh_users:
+    homelab: "manu"
+    cloud: "deployer"
+
   vps:
     hostname: "kubelab-vps"
     public_ip: "162.55.57.175"
     tailscale_ip: "100.64.0.2"
-    ssh_user: "deployer"
     ansible_groups: ["vps", "docker_hosts"]  # prod.yaml adds k3s_servers
     docker_network: "kubelab"  # Migrated from "proxy" by traefik_vps role (ADR-020 Phase 2b)
     # Homepage cockpit tile (SSOT-005). Consumed by sync_homepage_config.build_node_list.
@@ -78,7 +86,6 @@ networking:
     # stable identity — prefer tailscale_dns over tailscale_ip in IaC.
     tailscale_ip: "100.64.0.7"
     tailscale_dns: "aws1.kubelab.internal"
-    ssh_user: "deployer"
     k3s_version: "v1.34.4+k3s1"  # Match spoke versions
     # Homepage cockpit tile (SSOT-005). Decision documented in ADR-033:
     # widget=ping (not glances) until RELIAB-009 brings hub day-2 Ansible.
@@ -97,7 +104,6 @@ networking:
       tailscale_ip: "100.64.0.11"
       lan_ip: "172.16.1.2"
       lan_interface: "enp1s0"
-      ssh_user: "manu"
       ansible_groups: ["k3s_servers", "docker_hosts", "minipc"]
       dashboard:
         order: 1
@@ -109,7 +115,6 @@ networking:
       tailscale_ip: "100.64.0.5"
       lan_ip: "172.16.1.5"
       lan_interface: "enp1s0"
-      ssh_user: "manu"
       ansible_groups: ["compute_nodes", "docker_hosts", "minipc"]  # ADR-028: Ollama only
       dashboard:
         order: 5
@@ -127,7 +132,6 @@ networking:
       # down. Both DHCP-reserved on the home router.
       lan_ip: "172.16.1.1"
       wifi_lan_ip: "10.0.0.131"
-      ssh_user: "manu"
       ansible_groups: ["gateway", "dns_hosts", "docker_hosts"]
       dashboard:
         display_name: "RPi4"
@@ -144,7 +148,6 @@ networking:
       # reservation on home router for MAC b8:27:eb:3d:8e:54 (SSOT-003).
       lan_ip: "10.0.0.157"
       lan_interface: "wlan0"
-      ssh_user: "manu"
       ansible_groups: ["monitoring", "docker_hosts"]
       dashboard:
         display_name: "RPi3"
@@ -157,7 +160,6 @@ networking:
       tailscale_ip: "100.64.0.3"
       lan_ip: "172.16.1.3"
       lan_interface: "enp1s0"
-      ssh_user: "manu"
       ansible_groups: ["platform_nodes", "docker_hosts"]  # ADR-028: MinIO + GH Runner + Glances
       dashboard:
         display_name: "Beelink"
@@ -169,7 +171,6 @@ networking:
       hostname: "jetson"
       tailscale_ip: "100.64.0.8"
       lan_ip: "172.16.1.4"
-      ssh_user: "manu"
       ansible_groups: ["compute"]
       legacy_python: true
       dashboard:

--- a/specs/SSOT-014-ssh-user/proposal.md
+++ b/specs/SSOT-014-ssh-user/proposal.md
@@ -1,0 +1,52 @@
+---
+id: "SSOT-014-ssh-user"
+type: spec
+status: draft
+created: "2026-05-25"
+tags: [spec, proposal, ssot, ansible, networking]
+template_version: "1.0"
+---
+
+# SSOT-014a: Consolidate `ssh_user` as a single source of truth
+
+<!-- from 10_projects/kubelab/11-tasks.md SSOT-014a: "Consolidate ssh_user — new SSOT networking.ssh_users.{homelab,cloud} in common.yaml. Generator (generator_ansible.py) infers category by YAML position (vps + aws → cloud; nodes.* → homelab). Per-node override stays optional." -->
+
+## Why
+
+`infra/config/values/common.yaml` currently repeats `ssh_user: "manu"` 6 times (once per homelab node: ace1, ace2, beelink, rpi3, rpi4, jetson) and `ssh_user: "deployer"` 2 times (vps, aws1). Changing any of these — for a rename, a new operator user, or a fork — means touching 8 lines that must stay in lockstep. The duplication is friction: every rename becomes an audit instead of a one-line change.
+
+This is master plan SSOT-014's first sub-task (a/b/c). It does NOT change the value `"manu"` (that is the trivial SEC-PRIVACY-001 follow-up after the SSOT exists). It establishes the structure that makes the value change a one-liner.
+
+## What
+
+A new SSOT `networking.ssh_users.{homelab,cloud}` is the single declaration site for the SSH user per node category. The Ansible inventory generator (`toolkit/features/generator_ansible.py`) resolves each node's `ansible_user` as: per-node `ssh_user` override if present, else `networking.ssh_users.cloud` (for nodes under `networking.vps` or `networking.aws`), else `networking.ssh_users.homelab` (for nodes under `networking.nodes.*`).
+
+Concrete output: regenerated `infra/ansible/generated/{staging,prod,hub}/hosts.yml` is byte-identical to the current committed versions (no semantic change — only the SSOT layer changes).
+
+## Out of scope
+
+- Renaming the value `"manu"` to anything else. That is SEC-PRIVACY-001 (Phase B in the master plan), done as a 1-line follow-up after SSOT-014a/b/c land.
+- Consolidating `admin_username` (SSOT-014b) and `apps.contact.email` (SSOT-014c). Each is a separate spec/PR.
+- Refactoring node category to an explicit `category:` field. The current spec uses YAML-position inference (vps/aws → cloud, nodes.* → homelab) per the design decision.
+
+## Risks / open questions
+
+- **Schema migration safety:** the 6 homelab `ssh_user: "manu"` lines are removed in this PR. If any consumer (other than the Ansible inventory generator) reads `networking.nodes.<x>.ssh_user` directly, it will see `None`. Mitigation: audit consumers before the PR via `git grep "ssh_user" toolkit/ tests/`. **Status:** to be verified during implementation; no blocker expected since the only known consumer is `generator_ansible.py`.
+- **CI-GATE-003 drift gate:** the regenerated `hosts.yml` must be byte-identical to the committed version. If it isn't, the gate will fail and surface real semantic drift. Acts as a safety net, not a risk.
+
+## Acceptance criteria
+
+- [ ] AC1: `infra/config/values/common.yaml` declares `networking.ssh_users.homelab` and `networking.ssh_users.cloud`; the 6 per-node `ssh_user` lines under `networking.nodes.*` (homelab) and the 2 lines under `networking.vps` / `networking.aws` (cloud) are removed.
+- [ ] AC2: `git grep '"manu"' infra/config/values/common.yaml` returns exactly **one** match (the new SSOT line) — down from 7.
+- [ ] AC3: `make config-generate ENV=staging` regenerates `infra/ansible/generated/staging/hosts.yml` byte-identical to the committed version (verified via `git diff --quiet`).
+- [ ] AC4: same as AC3 for `ENV=prod` and `ENV=hub`.
+- [ ] AC5: `make config-check-drift ENV=staging` and `ENV=prod` both pass (CI-GATE-002/003 gate green).
+- [ ] AC6: existing tests pass (`make test`).
+
+## References
+
+- Vault backlog: `10_projects/kubelab/11-tasks.md` SSOT-014 master + SSOT-014a sub-task
+- Related ADR: ADR-036 (shared infra namespace pattern — same SSOT discipline applied here)
+- Related patterns: `00_meta/patterns/pattern-spec-driven-development.md`
+- Master plan context: session memory `MEMORY.md` Session Handoff 2026-05-25
+- Sibling specs (future): SSOT-014b (admin_username), SSOT-014c (contact email)

--- a/specs/SSOT-014-ssh-user/tasks.md
+++ b/specs/SSOT-014-ssh-user/tasks.md
@@ -1,0 +1,44 @@
+---
+tags: [spec, tasks, ssot, ansible]
+created: "2026-05-25"
+---
+
+# Tasks — SSOT-014-ssh-user
+
+> TDD order. One task = one focused commit (or staged within one commit if mechanically tied). Tick as you go.
+
+## Setup
+
+- [ ] Branch created from master: `feat/ssot-014a-ssh-user-ssot`
+- [ ] `proposal.md` complete; AC are testable
+- [ ] No open questions blocking implementation
+
+## Audit (verification before changes)
+
+- [ ] `git grep -n "ssh_user" toolkit/ tests/ infra/` — list every consumer of `ssh_user`
+- [ ] Confirm the only programmatic consumer is `generator_ansible.py` (other reads would need migration)
+
+## Implementation
+
+- [ ] Add `networking.ssh_users.{homelab,cloud}` block to `infra/config/values/common.yaml` (keep per-node lines intact for now — additive change)
+- [ ] Update `toolkit/features/generator_ansible.py` resolution: `ansible_user = node.get("ssh_user") or networking.ssh_users.cloud` (for vps/aws) or `networking.ssh_users.homelab` (for nodes.*)
+- [ ] Regenerate inventory locally: `make config-generate ENV=staging`, `ENV=prod`, `ENV=hub`
+- [ ] Verify `git diff infra/ansible/generated/` is empty (byte-identical output)
+- [ ] Remove per-node `ssh_user: "manu"` lines from `networking.nodes.*` (6 lines)
+- [ ] Remove `ssh_user: "deployer"` lines from `networking.vps` and `networking.aws` (2 lines)
+- [ ] Regenerate inventory again — still byte-identical
+- [ ] If any test references `networking.nodes.<x>.ssh_user` directly (e.g. `tests/infra/`), update to read from the new SSOT path
+
+## Closing
+
+- [ ] All 6 AC from `proposal.md` verified
+- [ ] `make test` green
+- [ ] `make config-check-drift ENV=staging` green
+- [ ] `make config-check-drift ENV=prod` green
+- [ ] `verification.md` filled with evidence
+- [ ] PR opened referencing `specs/SSOT-014-ssh-user/`
+- [ ] Vault `11-tasks.md` SSOT-014a ticked with PR link on merge
+
+## Machine-readable features
+
+Deferred for SSOT-014 series. The acceptance criteria are mechanical (grep + diff + drift gate) and verified by the existing CI-GATE-002/003 workflow. A `features.json` would duplicate that. If a future spec in the series needs harness-tracked verification, re-introduce here.

--- a/specs/SSOT-014-ssh-user/verification.md
+++ b/specs/SSOT-014-ssh-user/verification.md
@@ -1,0 +1,40 @@
+---
+tags: [spec, verification, ssot, ansible]
+created: "2026-05-25"
+---
+
+# Verification — SSOT-014-ssh-user
+
+> Filled DURING implementation. Evidence below maps each AC to a concrete proof (commit hash, command output, test name).
+
+## Evidence
+
+- [ ] AC1 (new SSOT block + per-node lines removed) → commit `<hash>` + `git diff` summary
+- [ ] AC2 (single `"manu"` match in common.yaml) → `git grep -c '"manu"' infra/config/values/common.yaml` output
+- [ ] AC3 (staging hosts.yml byte-identical) → `git diff --quiet infra/ansible/generated/staging/hosts.yml; echo $?` → 0
+- [ ] AC4 (prod + hub hosts.yml byte-identical) → same command for each env
+- [ ] AC5 (drift gate green both envs) → `make config-check-drift ENV={staging,prod}` exit codes
+- [ ] AC6 (existing tests pass) → `make test` summary
+
+## Test status
+
+- Test suite: `make test` → `<pending — fill on completion>`
+- Manual smoke test: regenerate inventories, run `ansible -i infra/ansible/generated/staging/hosts.yml all -m ping` if possible (validates `ansible_user` field is still correct end-to-end)
+- No regressions: yes / no (pending)
+
+## Decisions made during implementation
+
+- (filled during implementation)
+
+## Promotion candidates
+
+- [ ] Lesson for `10_projects/kubelab/90-lessons.md`? **probably yes** — short lesson on "consolidating duplicated SSOT values via category-inference is cheaper than per-entity overrides; YAML position can be a category signal without needing a `category:` field"
+- [ ] ADR-worthy decision for `10_projects/kubelab/30-architecture/`? **no** — small refactor, no architectural shift; reuses ADR-036 (shared infra namespace) pattern
+- [ ] New pattern candidate for `00_meta/patterns/`? **no** — single-project SSOT consolidation
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter → `status: archived`
+- [ ] Folder moved: `specs/SSOT-014-ssh-user/` → `specs/archive/SSOT-014-ssh-user/`
+- [ ] Vault backlog SSOT-014a ticked with PR link
+- [ ] Lesson promoted (if approved)

--- a/tests/infra/fixtures.py
+++ b/tests/infra/fixtures.py
@@ -35,7 +35,8 @@ VPS_NODE = NodeInfo(
     name="vps",
     host=_COMMON["networking"]["vps"]["tailscale_ip"],
     group="vps",
-    vars={"ansible_user": _COMMON["networking"]["vps"].get("ssh_user", "deployer")},
+    # SSOT-014a: per-node override wins, else category SSOT (cloud for VPS).
+    vars={"ansible_user": _COMMON["networking"]["vps"].get("ssh_user") or _COMMON["networking"]["ssh_users"]["cloud"]},
 )
 
 # Default SSH user from Ansible inventory global vars (SSOT)

--- a/toolkit/cli/infra.py
+++ b/toolkit/cli/infra.py
@@ -123,11 +123,13 @@ def _get_vps_config() -> _VpsBackupConfig:
     common_path = settings.project_root / "infra" / "config" / "values" / "common.yaml"
     with open(common_path) as f:
         config = yaml.safe_load(f)
-    vps = config["networking"]["vps"]
+    networking = config["networking"]
+    vps = networking["vps"]
     backup = vps.get("backup", {})
     return _VpsBackupConfig(
         ip=vps["tailscale_ip"],
-        user=vps.get("ssh_user", "deployer"),
+        # SSOT-014a: read from networking.ssh_users.cloud, fall back to per-node override.
+        user=vps.get("ssh_user") or networking["ssh_users"]["cloud"],
         backup_root=backup.get("root", "/opt/backups"),
         retention=backup.get("retention", 3),
         filesystem_paths=tuple(backup.get("filesystem_paths", [])),

--- a/toolkit/cli/monitoring.py
+++ b/toolkit/cli/monitoring.py
@@ -38,7 +38,8 @@ def _get_kuma_config() -> dict[str, str]:
     config_manager = ConfigurationManager("staging", settings.project_root)
     merged = config_manager.get_merged_config()
 
-    node = merged.get("networking", {}).get("nodes", {}).get("rpi3", {})
+    networking = merged.get("networking", {})
+    node = networking.get("nodes", {}).get("rpi3", {})
     svc = merged.get("apps", {}).get("services", {}).get("observability", {}).get("uptime_kuma", {})
 
     host = node.get("tailscale_ip", "")
@@ -50,7 +51,8 @@ def _get_kuma_config() -> dict[str, str]:
 
     _kuma_config = {
         "host": host,
-        "ssh_user": node.get("ssh_user", "manu"),
+        # SSOT-014a: read from networking.ssh_users.homelab, fall back to per-node override.
+        "ssh_user": node.get("ssh_user") or networking["ssh_users"]["homelab"],
         "container": svc.get("name", "uptime-kuma"),
         "url": f"http://{host}:{port}",
     }

--- a/toolkit/features/generator_ansible.py
+++ b/toolkit/features/generator_ansible.py
@@ -61,6 +61,11 @@ class AnsibleGenerator(BaseGenerator):
             logger.error(f"Failed to generate Ansible config: {e}")
             return {"success": False, "error": str(e)}
 
+    @staticmethod
+    def _resolve_ssh_user(node: dict[str, Any], networking: dict[str, Any], category: str) -> str:
+        """SSOT-014a: per-node `ssh_user` wins as override, else category default."""
+        return node.get("ssh_user") or networking["ssh_users"][category]
+
     def _generate_inventory(self, networking: dict[str, Any], output_path: Path, bootstrap: bool = False) -> None:
         """Generate Ansible inventory YAML from networking config.
 
@@ -83,7 +88,7 @@ class AnsibleGenerator(BaseGenerator):
                 {
                     "hostname": vps.get("hostname", "kubelab-vps"),
                     "ansible_host": vps.get("public_ip") or vps.get("tailscale_ip"),
-                    "ansible_user": vps.get("ssh_user", "deployer"),
+                    "ansible_user": self._resolve_ssh_user(vps, networking, "cloud"),
                     "public_ip": vps.get("public_ip"),
                     "groups": vps.get("ansible_groups", []),
                 }
@@ -98,7 +103,7 @@ class AnsibleGenerator(BaseGenerator):
                 {
                     "hostname": aws.get("hostname", "aws1"),
                     "ansible_host": aws.get("tailscale_dns") or aws["tailscale_ip"],
-                    "ansible_user": aws.get("ssh_user", "deployer"),
+                    "ansible_user": self._resolve_ssh_user(aws, networking, "cloud"),
                     "groups": ["hub"],
                 }
             )
@@ -112,7 +117,7 @@ class AnsibleGenerator(BaseGenerator):
             entry: dict[str, Any] = {
                 "hostname": node.get("hostname", _node_key),
                 "ansible_host": host_ip,
-                "ansible_user": node.get("ssh_user", "manu"),
+                "ansible_user": self._resolve_ssh_user(node, networking, "homelab"),
                 "groups": node.get("ansible_groups", []),
             }
             if node.get("lan_ip"):


### PR DESCRIPTION
## Summary

First sub-task of master plan **SSOT-014**. Consolidates 8 duplicated `ssh_user` lines in `common.yaml` into a single SSOT block, removing future-rename friction. The value `"manu"` itself is unchanged — Phase B (SEC-PRIVACY-001) will be a trivial 1-line follow-up once SSOT-014a/b/c are all merged.

## Changes

**SSOT** (`infra/config/values/common.yaml`):
```yaml
networking:
  ssh_users:
    homelab: "manu"
    cloud: "deployer"
```

- 6× `ssh_user: "manu"` removed from `networking.nodes.{ace1,ace2,beelink,rpi3,rpi4,jetson}`
- 2× `ssh_user: "deployer"` removed from `networking.vps` and `networking.aws`
- Per-node `ssh_user` field remains supported as an override (currently unused)

**Consumers updated** (5 files):
| File | Change |
|---|---|
| `toolkit/features/generator_ansible.py` | New `_resolve_ssh_user(node, networking, category)` helper; used in vps/aws/nodes loops |
| `toolkit/cli/infra.py` | VPS backup SSH reads `networking.ssh_users.cloud` |
| `toolkit/cli/monitoring.py` | RPi3 SSH reads `networking.ssh_users.homelab` |
| `infra/ansible/playbooks/_includes/check-vps-reachable.yml` | Jinja `\| default(_ssot_common.networking.ssh_users.cloud)` |
| `tests/infra/fixtures.py` | `VPS_NODE.ansible_user` reads SSOT |

## Spec

`specs/SSOT-014-ssh-user/{proposal,tasks,verification}.md` scaffolded per SDD pattern, includes the 6 ACs verified below.

## Verification (per spec ACs)

| AC | Check | Result |
|---|---|---|
| AC1 | New SSOT block present + per-node lines removed | ✓ |
| AC2 | `git grep '"manu"' common.yaml \| wc -l` == 1 | ✓ (down from 7) |
| AC3 | `git diff infra/ansible/generated/staging/hosts.yml` after regen | ✓ empty |
| AC4 | Same for prod | ✓ empty |
| AC5 | `make config-check-drift ENV={staging,prod}` | ✓ green both |
| AC6 | `make test` | ✓ 106 passed, 0 failed |

## Master plan position

This is **PR 1 of 3** in the SSOT-014 series:

- [x] **SSOT-014a** — this PR — ssh_user
- [ ] **SSOT-014b** — Authelia user key auto-derive from `apps.auth.admin_username`
- [ ] **SSOT-014c** — `apps.contact.email` SSOT (also closes SSOT-010)

After all three: SEC-PRIVACY-001 becomes a 1-line value rename (Phase B, optional).

## Follow-ups surfaced during implementation

- **Makefile tech debt:** `make config-check-drift` ends with `git checkout -- infra edge` to clean regenerated files, but this also reverts ANY uncommitted edits inside those paths. Workaround applied here: stage before running. Worth tracking as a small ticket if it bites again.
- **Hub env not supported by `config-check-drift`:** the target only accepts `staging|prod`. Hub inventory exists and was previously regenerated via `toolkit infra ansible generate --env hub` but isn't in the drift gate. Out of scope for this PR; could be added if hub starts drifting.

## Test plan

- [ ] CI green on this PR (drift gate + tests)
- [ ] Spot-check the regenerated inventories in CI artifacts (should be byte-identical to committed)
- [ ] No regression in `make test` suite
