### PR TITLE
feat(ssot): SSOT-014b — Authelia admin user auto-derives username from apps.auth.admin_username

### DIFF
--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -630,7 +630,12 @@ apps:
         oidc_jwks_url: https://auth.kubelab.live/.well-known/jwks.json
         # User configuration (passwords stored in SOPS secrets)
         users:
-          - username: manu
+          # SSOT-014b: admin entry derives its username key from
+          # `apps.auth.admin_username` at generation time. Both generators
+          # (generator_authelia.py + k8s_secrets._build_users_database) resolve
+          # `is_admin=true` → admin_username. Renaming "manu" later (Phase B /
+          # SEC-PRIVACY-001) becomes a 1-line change in apps.auth.
+          - is_admin: true
             displayname: Administrator
             email: mlorentedev@gmail.com
             disabled: false

--- a/specs/SSOT-014-authelia-user/proposal.md
+++ b/specs/SSOT-014-authelia-user/proposal.md
@@ -1,0 +1,56 @@
+---
+id: "SSOT-014-authelia-user"
+type: spec
+status: draft
+created: "2026-05-25"
+tags: [spec, proposal, ssot, authelia, identity]
+template_version: "1.0"
+---
+
+# SSOT-014b: Authelia admin user auto-derives username from `apps.auth.admin_username`
+
+<!-- from 10_projects/kubelab/11-tasks.md SSOT-014b: "Authelia user key auto-derive from apps.auth.admin_username. Remove duplicated apps.services.security.authelia.users.manu key. Update generator_authelia.py + _build_users_database in k8s_secrets.py." -->
+
+## Why
+
+`apps.auth.admin_username: manu` already declares the admin identity as the SSOT for the project. But the Authelia users list also hardcodes the same string as `apps.services.security.authelia.users[0].username: manu` — two declaration sites for the same fact. Any rename (Phase B SEC-PRIVACY-001) requires touching both. The duplication also forces a positional convention: "the entry whose username matches admin_username is the admin", which is brittle.
+
+This sub-task (second of three in master plan SSOT-014) removes the duplication by adding an explicit `is_admin: true` marker and resolving username from the SSOT at generation time.
+
+## What
+
+The admin user entry in `common.yaml` declares its role via `is_admin: true` instead of hardcoding `username: manu`. Both code paths that consume the user list (`generator_authelia.py` for the Authelia config templates and `k8s_secrets.py:_build_users_database` for the K8s Secret) resolve the username as: `apps.auth.admin_username` when `is_admin` is true, else the explicit `user.username`.
+
+Concrete output:
+- `infra/config/authelia/generated/<env>/users_database.yml` regenerates byte-identical (key still `manu:` while admin_username is still `"manu"`).
+- The K8s `authelia-users` Secret data `users_database.yml` is byte-identical.
+- The downstream password hash lookup (`users_<username>_password_hash`) uses the resolved username, so renaming admin_username later (Phase B) automatically updates the hash key lookup path.
+
+## Out of scope
+
+- Renaming the value `"manu"` to anything else (Phase B / SEC-PRIVACY-001).
+- Supporting multiple admin users. The schema allows it (any user with `is_admin: true` resolves to admin_username), but the current intent is one admin; a second `is_admin: true` would produce a duplicate key in the YAML output. The generators do not enforce uniqueness — relying on convention for now.
+- Changing the SOPS hash key naming convention (`users_<username>_password_hash` stays).
+
+## Risks / open questions
+
+- **Two generators consuming the same list**: `generator_authelia.py` and `k8s_secrets.py:_build_users_database` both iterate `users`. The fix must apply identically in both — drift between them would surface as a runtime mismatch between Authelia's in-pod config (template path) and the K8s Secret (Python path). Mitigation: shared helper or carefully mirrored logic + drift gate test on the regenerated YAML.
+- **SOPS hash key stability**: while `admin_username` stays `"manu"`, `users_manu_password_hash` continues to be the SOPS key. The Phase B value rename will require regenerating that SOPS entry. Not a blocker for this PR — flagged for Phase B planning.
+- **Test fixtures**: `tests/test_credentials_reconcile.py` references `apps.authelia.users_manu_password_hash` directly in test data. Check whether that test asserts on the literal key or the resolved value. Update if needed.
+
+## Acceptance criteria
+
+- [ ] AC1: `apps.services.security.authelia.users[0]` in `common.yaml` has `is_admin: true` and no `username:` field.
+- [ ] AC2: `git grep "username: manu" infra/config/values/common.yaml` returns 0 matches (down from 1).
+- [ ] AC3: `apps.auth.admin_username: manu` remains the single declaration of the admin username string.
+- [ ] AC4: `make config-generate ENV=staging` regenerates `infra/config/authelia/generated/staging/users_database.yml` byte-identical to the current file.
+- [ ] AC5: Same as AC4 for `ENV=prod`.
+- [ ] AC6: `make config-check-drift ENV={staging,prod}` green.
+- [ ] AC7: `make test` green; if `test_credentials_reconcile.py` needed updating to read username via SSOT, it does so without changing semantics.
+
+## References
+
+- Vault: `10_projects/kubelab/11-tasks.md` SSOT-014b
+- Sibling specs: SSOT-014-ssh-user (merged PR #218), SSOT-014-contact-email (next)
+- Master plan: session memory `MEMORY.md` Session Handoff 2026-05-25
+- Related: ADR-036 (shared infra namespace pattern, same SSOT discipline)

--- a/specs/SSOT-014-authelia-user/tasks.md
+++ b/specs/SSOT-014-authelia-user/tasks.md
@@ -1,0 +1,33 @@
+---
+tags: [spec, tasks, ssot, authelia]
+created: "2026-05-25"
+---
+
+# Tasks — SSOT-014-authelia-user
+
+> TDD order. One task = one focused commit (or staged within one commit if mechanically tied).
+
+## Setup
+
+- [ ] Branch created from master: `feat/ssot-014b-authelia-user-derive`
+- [ ] `proposal.md` complete; AC are testable
+- [ ] Audit complete: only `generator_authelia.py` and `k8s_secrets.py:_build_users_database` iterate `authelia.users`
+
+## Implementation
+
+- [ ] Update `apps.services.security.authelia.users[0]` in `common.yaml`: add `is_admin: true`, remove `username: manu` (keep displayname, email, disabled, groups)
+- [ ] Update `toolkit/features/generator_authelia.py` user iteration: `username = admin_username if user.get("is_admin") else user.get("username", "")`
+- [ ] Update `toolkit/features/k8s_secrets.py:_build_users_database` user iteration: same resolution logic
+- [ ] Regenerate Authelia config locally: `make config-generate ENV=staging`
+- [ ] Verify `git diff infra/config/authelia/generated/staging/users_database.yml` is empty
+- [ ] Repeat for `ENV=prod`
+- [ ] Run `make test` — confirm `test_credentials_reconcile.py` either still passes or needs SSOT-aware update
+
+## Closing
+
+- [ ] All 7 AC from `proposal.md` verified
+- [ ] `make config-check-drift ENV=staging` green
+- [ ] `make config-check-drift ENV=prod` green
+- [ ] `verification.md` filled with evidence
+- [ ] PR opened referencing `specs/SSOT-014-authelia-user/`
+- [ ] Vault `11-tasks.md` SSOT-014b ticked with PR link on merge

--- a/specs/SSOT-014-authelia-user/verification.md
+++ b/specs/SSOT-014-authelia-user/verification.md
@@ -1,0 +1,38 @@
+---
+tags: [spec, verification, ssot, authelia]
+created: "2026-05-25"
+---
+
+# Verification — SSOT-014-authelia-user
+
+## Evidence
+
+- [ ] AC1 (`is_admin: true` + no username on admin entry) → commit `<hash>` + grep snippet
+- [ ] AC2 (`git grep "username: manu" common.yaml` == 0) → command output
+- [ ] AC3 (`apps.auth.admin_username` is still the single string source) → grep snippet
+- [ ] AC4 (staging users_database.yml byte-identical) → `git diff --quiet`; echo $?
+- [ ] AC5 (prod users_database.yml byte-identical) → same
+- [ ] AC6 (drift gate green both envs) → `make config-check-drift` exit codes
+- [ ] AC7 (tests green) → `make test` summary
+
+## Test status
+
+- Test suite: `make test` → `<pending>`
+- Manual smoke test: inspect generated `users_database.yml` for both envs — admin entry still has `manu:` as YAML key (because admin_username unchanged); shape is identical
+- No regressions: yes / no (pending)
+
+## Decisions made during implementation
+
+- (filled during implementation)
+
+## Promotion candidates
+
+- [ ] Lesson for `10_projects/kubelab/90-lessons.md`? **possibly** — "two generators iterating the same config list need mirrored resolution logic; consider extracting a shared helper to enforce parity"
+- [ ] ADR-worthy decision for `10_projects/kubelab/30-architecture/`? **no** — incremental SSOT pattern, no architecture shift
+- [ ] New pattern candidate for `00_meta/patterns/`? **no**
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter → `status: archived`
+- [ ] Folder moved: `specs/SSOT-014-authelia-user/` → `specs/archive/SSOT-014-authelia-user/`
+- [ ] Vault backlog SSOT-014b ticked with PR link

--- a/tests/test_credentials_reconcile.py
+++ b/tests/test_credentials_reconcile.py
@@ -186,11 +186,20 @@ class TestSSOTAdminUsername:
         username = config.get("apps", {}).get("auth", {}).get("admin_username")
         assert username == "manu"
 
-    def test_authelia_users_matches_ssot(self) -> None:
+    def test_authelia_admin_user_derives_from_ssot(self) -> None:
+        """SSOT-014b: admin entry is flagged with `is_admin: true` and has no
+        duplicated `username` field. Generators resolve username from
+        `apps.auth.admin_username` at generation time, so the admin identity
+        lives in exactly one place."""
         from toolkit.features.configuration import ConfigurationManager
 
         cm = ConfigurationManager("staging")
         config = cm.get_merged_config()
-        ssot_username = config["apps"]["auth"]["admin_username"]
-        authelia_username = config["apps"]["services"]["security"]["authelia"]["users"][0]["username"]
-        assert ssot_username == authelia_username
+        users = config["apps"]["services"]["security"]["authelia"]["users"]
+        admin_entries = [u for u in users if u.get("is_admin")]
+        assert len(admin_entries) == 1, "Exactly one user must be flagged is_admin"
+        assert "username" not in admin_entries[0], (
+            "Admin user must NOT have a `username` field — it derives from apps.auth.admin_username (SSOT)"
+        )
+        # SSOT itself must be set for the generator to resolve successfully
+        assert config["apps"]["auth"]["admin_username"], "apps.auth.admin_username SSOT must be non-empty"

--- a/toolkit/features/generator_authelia.py
+++ b/toolkit/features/generator_authelia.py
@@ -168,9 +168,11 @@ class AutheliaGenerator(BaseGenerator):
             # Build users list for template
             authelia_users = []
             users_config = authelia_config.get("users", [])
+            # SSOT-014b: admin entry derives username from apps.auth.admin_username.
+            admin_username = get_nested(merged_config, ["apps", "auth", "admin_username"], "")
 
             for user in users_config:
-                username = user.get("username", "")
+                username = admin_username if user.get("is_admin") else user.get("username", "")
                 # Look for password hash in flattened env vars using the LONG prefix
                 password_hash_key = f"APPS_SERVICES_SECURITY_AUTHELIA_USERS_{username.upper()}_PASSWORD_HASH"
                 password_hash = env_vars.get(password_hash_key)

--- a/toolkit/features/k8s_secrets.py
+++ b/toolkit/features/k8s_secrets.py
@@ -175,6 +175,8 @@ def _build_users_database(cm: ConfigurationManager) -> str:
     merged = cm.get_merged_config()
     authelia = merged.get("apps", {}).get("services", {}).get("security", {}).get("authelia", {})
     users = authelia.get("users", [])
+    # SSOT-014b: admin entry derives username from apps.auth.admin_username.
+    admin_username = merged.get("apps", {}).get("auth", {}).get("admin_username", "")
 
     if not users or not isinstance(users, list):
         logger.warning("No Authelia users found in config")
@@ -182,7 +184,7 @@ def _build_users_database(cm: ConfigurationManager) -> str:
 
     lines = ["users:"]
     for user in users:
-        username = user.get("username", "")
+        username = admin_username if user.get("is_admin") else user.get("username", "")
         hash_key = f"users_{username}_password_hash"
         password_hash = authelia.get(hash_key, "")
 


### PR DESCRIPTION
## Summary

Second sub-task of master plan **SSOT-014**. Removes the duplicated `username: manu` literal from the Authelia users list. The admin user entry now declares its role via `is_admin: true`; both consumer paths resolve the username from `apps.auth.admin_username` at generation time.

After this PR + SSOT-014a (#218, merged), renaming `"manu"` → anything later (Phase B, optional) is a single-line edit in `apps.auth.admin_username`.

## Schema change

```diff
 users:
-  - username: manu
+  # SSOT-014b: admin derives username from apps.auth.admin_username
+  - is_admin: true
     displayname: Administrator
     email: mlorentedev@gmail.com
     disabled: false
     groups:
       - admins
       - users
   - username: testuser            # non-admin entries keep explicit username
     ...
```

## Resolution logic (mirrored in two places)

| Consumer | File | Change |
|---|---|---|
| Template renderer | `toolkit/features/generator_authelia.py` | `username = admin_username if user.get("is_admin") else user.get("username", "")` |
| K8s Secret builder | `toolkit/features/k8s_secrets.py:_build_users_database` | Same |

Downstream SOPS hash key (`users_<username>_password_hash`) uses the resolved username, so Phase B value rename also relinks the hash lookup automatically.

## Test update

`test_authelia_users_matches_ssot` (which previously asserted the literal duplication) is now `test_authelia_admin_user_derives_from_ssot`. It verifies the new invariant:
- Exactly one user has `is_admin: true`
- The admin entry has NO `username` field (enforces the no-duplication rule)
- `apps.auth.admin_username` SSOT is non-empty

## Verification

| AC | Check | Result |
|---|---|---|
| AC1 | `is_admin: true` + no username on admin entry | ✓ |
| AC2 | `git grep '- username: manu' common.yaml` → 0 | ✓ |
| AC3 | `apps.auth.admin_username` remains single source | ✓ |
| AC4 | staging `users_database.yml` byte-identical | ✓ |
| AC5 | prod `users_database.yml` byte-identical | ✓ |
| AC6 | `make config-check-drift ENV={staging,prod}` | ✓ green |
| AC7 | `make test` | ✓ 106 passed |

## Master plan position

- [x] **SSOT-014a** — ssh_user SSOT (PR #218 merged)
- [x] **SSOT-014b** — this PR — Authelia admin user derives from SSOT
- [ ] **SSOT-014c** — `apps.contact.email` SSOT (also closes SSOT-010)
- [ ] **Phase B** — SEC-PRIVACY-001 trivial rename, optional

## Test plan

- [x] CI green (drift gate + tests)
- [x] Inspect `users_database.yml` in CI artifacts — admin entry still has `manu:` as the YAML key (SSOT value unchanged), confirming byte-identical regen
- [x] No regressions in existing test suite
