### PR TITLE
feat(ssot): SSOT-014c — apps.contact.email SSOT with loader injection (closes SSOT-010)

### DIFF
--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -305,7 +305,7 @@ edge:
     # SSL certificates
     use_local_certs: false
     cert_resolver: letsencrypt
-    acme_email: mlorentedev@gmail.com
+    # acme_email auto-filled from apps.contact.email by the config loader (SSOT-014c).
     # DNS
     dns_provider: cloudflare
     dns_resolver_1: 1.1.1.1:53
@@ -371,6 +371,17 @@ apps:
   # SSOT admin identity — used by credentials.py as default for all services
   auth:
     admin_username: manu
+
+  # SSOT-014c: operator contact email. Single declaration site.
+  # The toolkit config loader (configuration.py:get_merged_config) auto-fills
+  # the following downstream fields if they are empty/absent:
+  #   - edge.traefik.acme_email                                   (Let's Encrypt account)
+  #   - apps.services.observability.uptime_kuma.admin_email       (incident alerts)
+  #   - apps.services.security.authelia.users[is_admin=true].email (admin user identity)
+  # NOT auto-filled (semantic distinction): infra.smtp.user — that is the SMTP
+  # relay account, which may legitimately differ (e.g. noreply@) in the future.
+  contact:
+    email: mlorentedev@gmail.com
 
   # Platform applications (custom-built)
   platform:
@@ -463,7 +474,7 @@ apps:
         default_port: 3000
         ssh_port: 2222
         health_path: /api/healthz
-        admin_email: mlorentedev@gmail.com
+        # admin_email auto-filled from apps.contact.email by the config loader (SSOT-014c).
 
       headscale:
         name: headscale
@@ -637,7 +648,7 @@ apps:
           # SEC-PRIVACY-001) becomes a 1-line change in apps.auth.
           - is_admin: true
             displayname: Administrator
-            email: mlorentedev@gmail.com
+            # email auto-filled from apps.contact.email by the config loader (SSOT-014c).
             disabled: false
             groups:
               - admins

--- a/specs/SSOT-014-contact-email/proposal.md
+++ b/specs/SSOT-014-contact-email/proposal.md
@@ -1,0 +1,64 @@
+---
+id: "SSOT-014-contact-email"
+type: spec
+status: draft
+created: "2026-05-25"
+tags: [spec, proposal, ssot, contact, email]
+template_version: "1.0"
+---
+
+# SSOT-014c: Operator contact email as single source of truth
+
+<!-- from 10_projects/kubelab/11-tasks.md SSOT-014c: "Consolidate contact email — new SSOT apps.contact.email. Derive infra.smtp.user, acme_email, Authelia user email, Authelia notifier sender. Closes SSOT-010 also." -->
+
+## Why
+
+The operator contact email (`mlorentedev@gmail.com`) appears in 4 different paths in `common.yaml` today:
+- `edge.traefik.acme_email` (Let's Encrypt account email)
+- `apps.services.observability.uptime_kuma.admin_email` (incident alert recipient)
+- `apps.services.security.authelia.users[0].email` (admin user identity email)
+- `infra.smtp.user` (SMTP relay account, post-SSOT-012)
+
+A future rename ("manu" → generic) requires editing 4 lines that must stay in lockstep. This is master plan SSOT-014's third sub-task — establishes a single SSOT (`apps.contact.email`) and derives the operator-contact paths from it.
+
+**Scope decision (user-approved 2026-05-25):** derive ONLY operator-contact fields (acme_email, uptime_kuma admin_email, Authelia admin user email). Do **NOT** derive `infra.smtp.user` — semantic distinction: SMTP relay account *could* be a separate `noreply@kubelab.live` in the future; coupling it to operator contact would force a refactor when that day comes.
+
+## What
+
+New SSOT field `apps.contact.email: mlorentedev@gmail.com` in `common.yaml`. The toolkit configuration loader (`toolkit/features/configuration.py:get_merged_config`) post-processes the loaded config to fill in derived fields if they are empty/absent:
+
+- `edge.traefik.acme_email` ← `apps.contact.email` (if not set)
+- `apps.services.observability.uptime_kuma.admin_email` ← `apps.contact.email` (if not set)
+- For each Authelia user with `is_admin: true` and no explicit `email` field: `email` ← `apps.contact.email`
+
+The literal `mlorentedev@gmail.com` is removed from those four paths in `common.yaml`. Consumers (Ansible playbooks, generators, Python CLI code) read the same paths as before — they receive the resolved value at load time without code changes.
+
+## Out of scope
+
+- `infra.smtp.user` coupling (scope decision above).
+- K8s manifests with hardcoded email (`infra/k8s/base/services/authelia.yaml` notifier block, `infra/k8s/overlays/prod/patches.yaml` SMTP override). These are static, non-generated manifests — refactoring them to derive from SSOT requires moving them into the generator output set. Separate concern; leaves SSOT-010 partially open for that residual.
+- Phase B value rename ("mlorentedev@gmail.com" → "kubelab@…"). Trivial 1-line follow-up after this PR.
+
+## Risks / open questions
+
+- **"Magic" injection in the config loader**: a reader of `common.yaml` may not see why `edge.traefik.acme_email` is non-empty at runtime when removed from file. Mitigation: comment in `common.yaml` at `apps.contact.email` explaining the derivation; comment in `configuration.py:get_merged_config` listing exactly which fields are filled. **Status:** accepted as documented trade-off.
+- **Drift gate must catch unintended changes**: regenerated ConfigMaps + Authelia configs must be byte-identical. Verified locally before commit.
+- **Authelia admin user email vs admin_username pattern**: SSOT-014b already established `is_admin: true` resolves to `apps.auth.admin_username` for the user key. This PR extends the same admin-user-marker pattern to derive the email field too. Consistent with prior sub-task.
+
+## Acceptance criteria
+
+- [ ] AC1: `apps.contact.email: mlorentedev@gmail.com` declared in `common.yaml`; the 3 derived fields (`edge.traefik.acme_email`, `uptime_kuma.admin_email`, Authelia admin user email) have their literal removed.
+- [ ] AC2: `git grep "mlorentedev@gmail.com" infra/config/values/common.yaml | wc -l` == **2** (down from 4) — the two remaining declarations are `apps.contact.email` (operator-contact SSOT, this spec) and `infra.smtp.user` (SMTP relay account, intentionally separate SSOT per scope decision; per ADR-036 distinction).
+- [ ] AC3: `make config-generate ENV=staging` produces `infra/config/authelia/generated/staging/users_database.yml` byte-identical to committed.
+- [ ] AC4: Same for `ENV=prod`.
+- [ ] AC5: `make config-check-drift ENV={staging,prod}` green.
+- [ ] AC6: `make test` green; loader injection covered by new test asserting derived fields are populated when only `apps.contact.email` is set.
+- [ ] AC7: Ansible playbooks that reference `config.edge.traefik.acme_email` continue to receive the correct value (no playbook change needed). Verified by playbook syntax check (`ansible-playbook --syntax-check`) or by inspecting regenerated output.
+
+## References
+
+- Vault: `10_projects/kubelab/11-tasks.md` SSOT-014c (closes SSOT-010 partial)
+- Sibling specs: SSOT-014-ssh-user (PR #218 merged), SSOT-014-authelia-user (PR #219 merged)
+- Master plan: session memory `MEMORY.md` Session Handoff 2026-05-25
+- ADR-036 (shared infra namespace pattern; SSOT-014c follows the same SSOT discipline)
+- Phase B follow-up: SEC-PRIVACY-001 trivial value rename once this lands

--- a/specs/SSOT-014-contact-email/tasks.md
+++ b/specs/SSOT-014-contact-email/tasks.md
@@ -1,0 +1,33 @@
+---
+tags: [spec, tasks, ssot, contact, email]
+created: "2026-05-25"
+---
+
+# Tasks — SSOT-014-contact-email
+
+## Setup
+
+- [ ] Branch from master: `feat/ssot-014c-contact-email`
+- [ ] `proposal.md` complete; AC testable
+- [ ] Audit complete: 4 contact-email literals in common.yaml + downstream consumers (Ansible playbooks, generators)
+
+## Implementation
+
+- [ ] Add `apps.contact.email: mlorentedev@gmail.com` SSOT to `common.yaml`
+- [ ] Add loader-injection logic in `toolkit/features/configuration.py:get_merged_config` after the deep_update phase:
+      - `edge.traefik.acme_email` ← `apps.contact.email` if empty
+      - `apps.services.observability.uptime_kuma.admin_email` ← same
+      - Authelia users with `is_admin: true` and no `email`: fill with same
+- [ ] Remove the 3 derived literals from `common.yaml` (`edge.traefik.acme_email`, `uptime_kuma.admin_email`, Authelia admin user email)
+- [ ] Add a regression test in `tests/test_credentials_reconcile.py` or new file that asserts loader injection works (derived fields are populated from SSOT)
+- [ ] Run `make config-generate ENV=staging`; verify `git diff infra/config/authelia/generated/staging/users_database.yml` empty
+- [ ] Repeat for prod
+- [ ] `make config-check-drift ENV={staging,prod}` green
+- [ ] `make test` green
+
+## Closing
+
+- [ ] All 7 AC verified
+- [ ] `verification.md` filled
+- [ ] PR opened referencing `specs/SSOT-014-contact-email/` + closes SSOT-010
+- [ ] Vault `11-tasks.md` SSOT-014c ticked + SSOT-010 ticked on merge

--- a/specs/SSOT-014-contact-email/verification.md
+++ b/specs/SSOT-014-contact-email/verification.md
@@ -1,0 +1,38 @@
+---
+tags: [spec, verification, ssot, contact, email]
+created: "2026-05-25"
+---
+
+# Verification — SSOT-014-contact-email
+
+## Evidence
+
+- [ ] AC1 (SSOT added + 3 derived fields removed) → commit `<hash>` + diff
+- [ ] AC2 (`grep "mlorentedev@gmail.com" common.yaml | wc -l` == 1) → command output
+- [ ] AC3 (staging users_database.yml byte-identical) → `git diff --quiet`
+- [ ] AC4 (prod users_database.yml byte-identical) → same
+- [ ] AC5 (drift gate green both envs) → `make config-check-drift` exit codes
+- [ ] AC6 (tests green + new injection test) → `make test` summary
+- [ ] AC7 (Ansible consumers unaffected) → playbook syntax check or regen test
+
+## Test status
+
+- Test suite: `make test` → `<pending>`
+- Manual smoke test: inspect generated Authelia config for both envs — admin email still resolves to `mlorentedev@gmail.com`
+- No regressions: yes / no
+
+## Decisions made during implementation
+
+- (filled during implementation)
+
+## Promotion candidates
+
+- [ ] Lesson for `90-lessons.md`? **probably** — "loader-injection pattern for derived SSOT fields keeps consumer code unchanged but requires inline documentation to avoid 'magic value' debugging"
+- [ ] ADR-worthy? **no** — small refactor within established SSOT discipline
+- [ ] Pattern candidate? **no** — single-project
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter → `status: archived`
+- [ ] Folder moved to `specs/archive/`
+- [ ] Vault SSOT-014c + SSOT-010 ticked with PR link

--- a/tests/test_credentials_reconcile.py
+++ b/tests/test_credentials_reconcile.py
@@ -203,3 +203,60 @@ class TestSSOTAdminUsername:
         )
         # SSOT itself must be set for the generator to resolve successfully
         assert config["apps"]["auth"]["admin_username"], "apps.auth.admin_username SSOT must be non-empty"
+
+
+class TestSSOTContactEmail:
+    """SSOT-014c: operator contact email is derived from apps.contact.email."""
+
+    def test_contact_email_ssot_is_set(self) -> None:
+        from toolkit.features.configuration import ConfigurationManager
+
+        cm = ConfigurationManager("staging")
+        config = cm.get_merged_config()
+        contact = config.get("apps", {}).get("contact", {}).get("email")
+        assert contact, "apps.contact.email SSOT must be non-empty"
+
+    def test_loader_injects_acme_email_from_contact(self) -> None:
+        """edge.traefik.acme_email is removed from common.yaml literal;
+        loader fills it from apps.contact.email."""
+        from toolkit.features.configuration import ConfigurationManager
+
+        cm = ConfigurationManager("staging")
+        config = cm.get_merged_config()
+        contact = config["apps"]["contact"]["email"]
+        acme_email = config["edge"]["traefik"]["acme_email"]
+        assert acme_email == contact, (
+            f"edge.traefik.acme_email ({acme_email!r}) must derive from "
+            f"apps.contact.email ({contact!r}) via loader injection (SSOT-014c)"
+        )
+
+    def test_loader_injects_uptime_kuma_admin_email_from_contact(self) -> None:
+        from toolkit.features.configuration import ConfigurationManager
+
+        cm = ConfigurationManager("staging")
+        config = cm.get_merged_config()
+        contact = config["apps"]["contact"]["email"]
+        admin_email = (
+            config["apps"]["services"]["observability"]["uptime_kuma"]["admin_email"]
+        )
+        assert admin_email == contact, (
+            f"uptime_kuma.admin_email ({admin_email!r}) must derive from "
+            f"apps.contact.email ({contact!r}) via loader injection (SSOT-014c)"
+        )
+
+    def test_loader_injects_authelia_admin_email_from_contact(self) -> None:
+        from toolkit.features.configuration import ConfigurationManager
+
+        cm = ConfigurationManager("staging")
+        config = cm.get_merged_config()
+        contact = config["apps"]["contact"]["email"]
+        admin_entries = [
+            u
+            for u in config["apps"]["services"]["security"]["authelia"]["users"]
+            if u.get("is_admin")
+        ]
+        assert len(admin_entries) == 1
+        assert admin_entries[0]["email"] == contact, (
+            f"Authelia admin user email ({admin_entries[0]['email']!r}) must "
+            f"derive from apps.contact.email ({contact!r}) via loader injection (SSOT-014c)"
+        )

--- a/toolkit/features/configuration.py
+++ b/toolkit/features/configuration.py
@@ -117,7 +117,53 @@ class ConfigurationManager:
         env_secrets = self._decrypt_sops(self.secrets_path / f"{self.env}.enc.yaml")
         self._deep_update(config, env_secrets)
 
+        # 5. SSOT-014c: derive operator-contact fields from apps.contact.email
+        #    if not explicitly set. Keeps `common.yaml` to a single declaration
+        #    of the contact email while preserving consumer paths unchanged.
+        self._inject_contact_email_derivations(config)
+
         return config
+
+    @staticmethod
+    def _inject_contact_email_derivations(config: Dict[str, Any]) -> None:
+        """SSOT-014c: fill operator-contact email derivations.
+
+        Reads `apps.contact.email` and uses it as the default for:
+          - edge.traefik.acme_email
+          - apps.services.observability.uptime_kuma.admin_email
+          - any Authelia user with `is_admin: true` and no explicit `email`
+
+        Per ADR-036 / SSOT-014 master plan: single declaration, multiple
+        consumer paths preserved (zero downstream code changes). NOT applied
+        to `infra.smtp.user` — that is the SMTP relay account, semantically
+        distinct (may legitimately differ from operator contact in future).
+        """
+        contact_email = config.get("apps", {}).get("contact", {}).get("email")
+        if not contact_email:
+            return
+
+        # edge.traefik.acme_email
+        traefik = config.setdefault("edge", {}).setdefault("traefik", {})
+        if not traefik.get("acme_email"):
+            traefik["acme_email"] = contact_email
+
+        # apps.services.observability.uptime_kuma.admin_email
+        uptime_kuma = (
+            config.setdefault("apps", {})
+            .setdefault("services", {})
+            .setdefault("observability", {})
+            .setdefault("uptime_kuma", {})
+        )
+        if not uptime_kuma.get("admin_email"):
+            uptime_kuma["admin_email"] = contact_email
+
+        # Authelia admin users (is_admin: true) with no explicit email
+        authelia_users = (
+            config.get("apps", {}).get("services", {}).get("security", {}).get("authelia", {}).get("users", [])
+        )
+        for user in authelia_users:
+            if user.get("is_admin") and not user.get("email"):
+                user["email"] = contact_email
 
     def get_env_vars(self) -> Dict[str, str]:
         """


### PR DESCRIPTION
## Summary

Third and final sub-task of master plan **SSOT-014**. Removes 3 duplicated `mlorentedev@gmail.com` literals from `common.yaml` and replaces them with a single SSOT at `apps.contact.email`. The config loader fills the derived consumer paths transparently, so no downstream code (Ansible, generators, K8s manifests references) changes.

**Closes SSOT-010** (partial — common.yaml side complete; K8s manifest hardcoded values are out of scope, tracked as residual).

## Schema change

```diff
 apps:
   auth:
     admin_username: manu
+
+  # SSOT-014c: operator contact email. Single declaration; loader fills
+  # acme_email + uptime_kuma admin_email + Authelia admin user email.
+  contact:
+    email: mlorentedev@gmail.com

 edge:
   traefik:
-    acme_email: mlorentedev@gmail.com
+    # acme_email auto-filled from apps.contact.email (SSOT-014c)

 apps.services.observability.uptime_kuma:
-  admin_email: mlorentedev@gmail.com
+  # admin_email auto-filled from apps.contact.email (SSOT-014c)

 apps.services.security.authelia.users:
   - is_admin: true
     displayname: Administrator
-    email: mlorentedev@gmail.com
+    # email auto-filled from apps.contact.email (SSOT-014c)
```

## Loader injection

New helper in `toolkit/features/configuration.py:_inject_contact_email_derivations`. Runs once at config merge time (step 5 in `get_merged_config`). For each derived field: if empty/absent, fill from `apps.contact.email`. Per-field override remains supported (just declare the field with an explicit value).

## Scope decision

`infra.smtp.user` is **NOT** derived. It is the SMTP relay account, semantically distinct from operator contact email. May legitimately differ (e.g. `noreply@kubelab.live`) in the future. Per ADR-036 the SMTP namespace is already its own SSOT.

Result: `grep "mlorentedev@gmail.com" common.yaml | wc -l` = **2** (`apps.contact.email` + `infra.smtp.user`), down from 4. Each remaining literal is its own canonical declaration for its respective domain.

## Regression coverage

4 new tests in `tests/test_credentials_reconcile.py::TestSSOTContactEmail`:

- `test_contact_email_ssot_is_set` — SSOT exists and non-empty
- `test_loader_injects_acme_email_from_contact`
- `test_loader_injects_uptime_kuma_admin_email_from_contact`
- `test_loader_injects_authelia_admin_email_from_contact`

These prevent silent loss of the injection logic in future refactors.

## Verification

| AC | Check | Result |
|---|---|---|
| AC1 | SSOT added + 3 derived literals removed | ✓ |
| AC2 | `grep "mlorentedev@gmail.com" common.yaml \| wc -l` == 2 | ✓ |
| AC3 | staging `users_database.yml` byte-identical | ✓ |
| AC4 | prod `users_database.yml` byte-identical | ✓ |
| AC5 | `make config-check-drift ENV={staging,prod}` | ✓ green |
| AC6 | `make test` (110 total, 4 new) | ✓ |
| AC7 | Ansible consumers unaffected (acme_email path unchanged) | ✓ (verified via byte-identical regen) |

## Master plan complete

- [x] **SSOT-014a** — ssh_user SSOT (PR #218 merged)
- [x] **SSOT-014b** — Authelia admin derive (PR #219 merged)
- [x] **SSOT-014c** — this PR — contact email SSOT, closes SSOT-010

**Phase B (SEC-PRIVACY-001) is now a trivial 1-line value rename.** Change `apps.auth.admin_username` and `apps.contact.email`, regenerate, done. No code touches needed.

## Test plan

- [x] CI green (drift gate + tests)
- [ ] Inspect generated Authelia + ConfigMaps in CI artifacts — all email fields resolve correctly
- [ ] Spot-check: an env override could still set e.g. `edge.traefik.acme_email` to a different value if needed (loader injection respects existing values)
