### PR TITLE
fix(secrets): SECRET_CATALOG admin hash key follows operator rename (Codex P1 catch on #221)

### DIFF
--- a/toolkit/features/secrets_manager.py
+++ b/toolkit/features/secrets_manager.py
@@ -117,9 +117,15 @@ SECRET_CATALOG: list[SecretSpec] = [
     # =========================================================================
     # Authelia — User Password Hashes
     # =========================================================================
+    # Tracks `apps.auth.admin_username` SSOT (SSOT-014b). Static key here —
+    # when admin_username is renamed (e.g. Phase B "manu" → "operator" on
+    # 2026-05-25), this catalog entry MUST be updated in lockstep with the
+    # SOPS key rename, or audit/init/rotation workflows will silently target
+    # the wrong path. Future refactor: derive this `key_path` dynamically
+    # from the SSOT at catalog-build time so the manual lockstep is removed.
     SecretSpec(
-        key_path=f"{_AUTH}.users_manu_password_hash",
-        description="Argon2 hash of admin user password (username from apps.auth.admin_username)",
+        key_path=f"{_AUTH}.users_operator_password_hash",
+        description="Argon2 hash of admin user password (username from apps.auth.admin_username SSOT)",
         kind=SecretKind.ARGON2_HASH,
         services=("authelia",),
         derived_from="(interactive password prompt)",


### PR DESCRIPTION
## Summary

Hotfix for **Codex P1 review** on merged PR #221.

**Bug:** the SOPS hash key was renamed `users_manu_password_hash` → `users_operator_password_hash` in Phase B (PR #221), but `SECRET_CATALOG` in `toolkit/features/secrets_manager.py:121` still pointed at the old path.

**Consequence:** `secrets_manager` workflows (`audit`, `init`, rotation flows) would silently:
- Report admin hash as **MISSING** (lookup of dead key)
- Write updates to the **unused** `users_manu_password_hash` path

Meanwhile `k8s_secrets._build_users_database` resolves the correct `users_operator_password_hash` at runtime (per SSOT-014b `is_admin` flow). Net result: admin password rotation/maintenance would be **silently ineffective**.

## Fix

Update `SECRET_CATALOG` `key_path` to match current SOPS state. Add inline comment noting the catalog entry must track `apps.auth.admin_username` SSOT in lockstep on every rename — flagged for future refactor.

```diff
+    # Tracks `apps.auth.admin_username` SSOT (SSOT-014b). Static key here —
+    # when admin_username is renamed (e.g. Phase B "manu" → "operator" on
+    # 2026-05-25), this catalog entry MUST be updated in lockstep with the
+    # SOPS key rename, or audit/init/rotation workflows will silently target
+    # the wrong path. Future refactor: derive this `key_path` dynamically
+    # from the SSOT at catalog-build time so the manual lockstep is removed.
     SecretSpec(
-        key_path=f"{_AUTH}.users_manu_password_hash",
+        key_path=f"{_AUTH}.users_operator_password_hash",
```

## Verification

- `make test` → 110 passed (no regressions)
- Pattern matches actual SOPS state in `infra/config/secrets/{staging,prod}.enc.yaml`
- `toolkit secrets audit` would now correctly find the hash (verified mentally — manual run requires SOPS access on runner)

## Follow-up

Future improvement: derive this `key_path` dynamically from the SSOT at catalog-build time so the manual lockstep is removed. Out of scope for this hotfix — that is a small refactor that should land as its own ticket (e.g., a new `SSOT-019` "make SECRET_CATALOG keys SSOT-derived where applicable").