### PR TITLE
test(ssot): extend SSOT-014 admin identity coverage to prod + generator output

### DIFF
--- a/tests/test_credentials_reconcile.py
+++ b/tests/test_credentials_reconcile.py
@@ -1,5 +1,7 @@
 """Tests for credential-to-service mapping and reconciliation."""
 
+import pytest
+
 from toolkit.features.credentials import (
     CREDENTIAL_SERVICE_MAP,
     IMMUTABLE_SECRETS,
@@ -175,25 +177,26 @@ class TestFlattenDict:
         assert result["apps.services.security.authelia.session_secret"] == "abc"
 
 
+@pytest.mark.parametrize("env", ["staging", "prod"])
 class TestSSOTAdminUsername:
-    """Verify admin username is read from common.yaml SSOT."""
+    """Verify admin username is read from common.yaml SSOT (both envs)."""
 
-    def test_common_yaml_has_admin_username(self) -> None:
+    def test_common_yaml_has_admin_username(self, env: str) -> None:
         from toolkit.features.configuration import ConfigurationManager
 
-        cm = ConfigurationManager("staging")
+        cm = ConfigurationManager(env)
         config = cm.get_merged_config()
         username = config.get("apps", {}).get("auth", {}).get("admin_username")
         assert username == "operator"
 
-    def test_authelia_admin_user_derives_from_ssot(self) -> None:
+    def test_authelia_admin_user_derives_from_ssot(self, env: str) -> None:
         """SSOT-014b: admin entry is flagged with `is_admin: true` and has no
         duplicated `username` field. Generators resolve username from
         `apps.auth.admin_username` at generation time, so the admin identity
         lives in exactly one place."""
         from toolkit.features.configuration import ConfigurationManager
 
-        cm = ConfigurationManager("staging")
+        cm = ConfigurationManager(env)
         config = cm.get_merged_config()
         users = config["apps"]["services"]["security"]["authelia"]["users"]
         admin_entries = [u for u in users if u.get("is_admin")]
@@ -205,23 +208,24 @@ class TestSSOTAdminUsername:
         assert config["apps"]["auth"]["admin_username"], "apps.auth.admin_username SSOT must be non-empty"
 
 
+@pytest.mark.parametrize("env", ["staging", "prod"])
 class TestSSOTContactEmail:
-    """SSOT-014c: operator contact email is derived from apps.contact.email."""
+    """SSOT-014c: operator contact email is derived from apps.contact.email (both envs)."""
 
-    def test_contact_email_ssot_is_set(self) -> None:
+    def test_contact_email_ssot_is_set(self, env: str) -> None:
         from toolkit.features.configuration import ConfigurationManager
 
-        cm = ConfigurationManager("staging")
+        cm = ConfigurationManager(env)
         config = cm.get_merged_config()
         contact = config.get("apps", {}).get("contact", {}).get("email")
         assert contact, "apps.contact.email SSOT must be non-empty"
 
-    def test_loader_injects_acme_email_from_contact(self) -> None:
+    def test_loader_injects_acme_email_from_contact(self, env: str) -> None:
         """edge.traefik.acme_email is removed from common.yaml literal;
         loader fills it from apps.contact.email."""
         from toolkit.features.configuration import ConfigurationManager
 
-        cm = ConfigurationManager("staging")
+        cm = ConfigurationManager(env)
         config = cm.get_merged_config()
         contact = config["apps"]["contact"]["email"]
         acme_email = config["edge"]["traefik"]["acme_email"]
@@ -230,10 +234,10 @@ class TestSSOTContactEmail:
             f"apps.contact.email ({contact!r}) via loader injection (SSOT-014c)"
         )
 
-    def test_loader_injects_uptime_kuma_admin_email_from_contact(self) -> None:
+    def test_loader_injects_uptime_kuma_admin_email_from_contact(self, env: str) -> None:
         from toolkit.features.configuration import ConfigurationManager
 
-        cm = ConfigurationManager("staging")
+        cm = ConfigurationManager(env)
         config = cm.get_merged_config()
         contact = config["apps"]["contact"]["email"]
         admin_email = (
@@ -244,10 +248,10 @@ class TestSSOTContactEmail:
             f"apps.contact.email ({contact!r}) via loader injection (SSOT-014c)"
         )
 
-    def test_loader_injects_authelia_admin_email_from_contact(self) -> None:
+    def test_loader_injects_authelia_admin_email_from_contact(self, env: str) -> None:
         from toolkit.features.configuration import ConfigurationManager
 
-        cm = ConfigurationManager("staging")
+        cm = ConfigurationManager(env)
         config = cm.get_merged_config()
         contact = config["apps"]["contact"]["email"]
         admin_entries = [

--- a/tests/test_k8s_secrets_users_db.py
+++ b/tests/test_k8s_secrets_users_db.py
@@ -1,0 +1,71 @@
+"""Tests for k8s_secrets._build_users_database — Authelia users_database YAML generator.
+
+Verifies the OUTPUT of the generator is coherent with SSOT inputs:
+  - SSOT-014b: admin username derives from apps.auth.admin_username
+  - SSOT-014c: admin email derives from apps.contact.email (loader-injected)
+
+Companion to `test_credentials_reconcile.py::TestSSOTAdminUsername` /
+`TestSSOTContactEmail`, which cover the INPUT side (config has the SSOT).
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from toolkit.features.configuration import ConfigurationManager
+from toolkit.features.k8s_secrets import _build_users_database
+
+
+@pytest.mark.parametrize("env", ["staging", "prod"])
+class TestUsersDatabaseGenerator:
+    """Generated Authelia users_database.yml must be coherent with SSOT (both envs)."""
+
+    @staticmethod
+    def _build(env: str) -> tuple[dict, dict]:
+        cm = ConfigurationManager(env)
+        users_db_yaml = _build_users_database(cm)
+        assert users_db_yaml, f"_build_users_database returned empty for {env}"
+        return yaml.safe_load(users_db_yaml), cm.get_merged_config()
+
+    def test_output_is_valid_yaml_with_users_root(self, env: str) -> None:
+        parsed, _ = self._build(env)
+        assert isinstance(parsed, dict) and "users" in parsed, (
+            f"users_database for {env} must be a YAML mapping with 'users' root key"
+        )
+
+    def test_admin_username_from_ssot_is_present(self, env: str) -> None:
+        parsed, merged = self._build(env)
+        admin_username = merged["apps"]["auth"]["admin_username"]
+        assert admin_username in parsed["users"], (
+            f"users_database for {env} must contain admin user '{admin_username}' "
+            f"(derived from apps.auth.admin_username SSOT)"
+        )
+
+    def test_admin_email_matches_contact_ssot(self, env: str) -> None:
+        parsed, merged = self._build(env)
+        admin_username = merged["apps"]["auth"]["admin_username"]
+        contact_email = merged["apps"]["contact"]["email"]
+        admin_entry = parsed["users"][admin_username]
+        assert admin_entry["email"] == contact_email, (
+            f"Admin '{admin_username}' email ({admin_entry['email']!r}) in {env} "
+            f"must match apps.contact.email SSOT ({contact_email!r}) via loader injection (SSOT-014c)"
+        )
+
+    def test_admin_has_admins_group(self, env: str) -> None:
+        parsed, merged = self._build(env)
+        admin_username = merged["apps"]["auth"]["admin_username"]
+        admin_entry = parsed["users"][admin_username]
+        assert "admins" in admin_entry.get("groups", []), (
+            f"Admin '{admin_username}' in {env} must have 'admins' group"
+        )
+
+    def test_admin_has_password_hash(self, env: str) -> None:
+        parsed, merged = self._build(env)
+        admin_username = merged["apps"]["auth"]["admin_username"]
+        admin_entry = parsed["users"][admin_username]
+        password = admin_entry.get("password", "")
+        assert password.startswith("$argon2"), (
+            f"Admin '{admin_username}' password in {env} must be an argon2 hash "
+            f"(got prefix: {password[:20]!r}) — check users_<{admin_username}>_password_hash in SOPS"
+        )


### PR DESCRIPTION
## Summary

Two complementary test additions to harden SSOT-014 (admin identity) coverage **before** deploying Phase B to prod:

- **Parametrize existing input-side tests** (`tests/test_credentials_reconcile.py::TestSSOTAdminUsername` / `TestSSOTContactEmail`) over `[staging, prod]`. Previously hardcoded to `staging` — any per-env override that breaks `apps.auth.admin_username` or `apps.contact.email` resolution in `prod.yaml` would slip through CI.
- **New `tests/test_k8s_secrets_users_db.py`** with `TestUsersDatabaseGenerator` (parametrized over both envs). Verifies the **OUTPUT** of `_build_users_database()`: admin key matches SSOT, email matches `apps.contact.email` (loader injection, SSOT-014c), `admins` group present, valid argon2 password hash. Catches generator-side bugs that pass input-side tests but corrupt runtime output.

Coverage matrix is now: **input × output × {staging, prod} = full SSOT coherence guard**.

## Motivation

Prerequisite for the Phase B prod smoke. PR #221 merged Phase B (`manu` → `operator`, `mlorentedev@gmail.com` → `info@kubelab.live`) and was validated end-to-end in staging, but prod still runs the pre-Phase-B `users_database` (verified via `kubectl get secret -n kubelab authelia-users`: contains `manu` with old email). The next `make deploy-k8s ENV=prod` will materialize the rename in prod. Adding these tests now means the deploy is backed by automated coherence assertions, not just a one-off smoke.

## Test plan

- [x] `make test` → 126 passed
- [x] `make check` → lint + type + test + validate-sync green
- [x] Explicit run of new/parametrized tests → 22/22 passed (10 new + 12 parametrized)
- [x] CI green
- [ ] After merge: `make deploy-k8s ENV=prod` → `make pods ENV=prod` healthy → `make test-e2e ENV=prod` green → manual login with `operator` to confirm OIDC chain (Gitea + ArgoCD)