### PR TITLE
fix(authelia): mount users_database without subPath (Phase B unblocker)

### DIFF
--- a/infra/k8s/base/services/authelia.yaml
+++ b/infra/k8s/base/services/authelia.yaml
@@ -46,7 +46,9 @@ data:
     # ---- Authentication Backend ----
     authentication_backend:
       file:
-        path: /config/users_database.yml
+        # Mounted as a directory (no subPath) so K8s propagates Secret updates;
+        # Authelia's `watch: true` then reloads users_database.yml without restart.
+        path: /config/users/users_database.yml
         watch: true
         password:
           algorithm: argon2
@@ -276,8 +278,7 @@ spec:
               subPath: configuration.yml
               readOnly: true
             - name: users
-              mountPath: /config/users_database.yml
-              subPath: users_database.yml
+              mountPath: /config/users
               readOnly: true
             - name: assets
               mountPath: /config/assets

--- a/infra/k8s/overlays/prod/patches.yaml
+++ b/infra/k8s/overlays/prod/patches.yaml
@@ -40,7 +40,8 @@ data:
     # ---- Authentication Backend ----
     authentication_backend:
       file:
-        path: /config/users_database.yml
+        # Mount uses a directory (no subPath) so K8s propagates Secret updates.
+        path: /config/users/users_database.yml
         watch: true
         password:
           algorithm: argon2


### PR DESCRIPTION
## Summary

K8s does not propagate Secret/ConfigMap updates to volumes mounted with **subPath** — the file is frozen at mount time. Authelia already has `authentication_backend.file.watch: true`, but with subPath the watched file never changed inside the pod, so any \`users_database\` update required a manual \`kubectl rollout restart\` to take effect.

This PR mounts the \`authelia-users\` Secret **as a directory** at \`/config/users\` (the Secret has a single key, so the resulting path is \`/config/users/users_database.yml\`). K8s now refreshes the file in the pod's filesystem ~60s after the Secret changes, Authelia's watch detects it, and reloads — **zero-downtime, no restart**.

## Why this matters NOW

Surfaced during the Phase B prod smoke. After #221 (\`manu\` → \`operator\`) + #223 (test coverage) + today's \`make deploy-k8s ENV=prod\`:

- Secret \`authelia-users\` in prod now contains \`operator\` (verified post-deploy).
- Authelia pod (AGE 47h) kept serving the cached \`manu\` user.
- Without this fix the only path forward was an ad-hoc \`kubectl rollout restart\`, violating the project's "no manual kubectl" convention.

With this fix the Phase B smoke completes naturally on the next deploy.

## Mechanics

- \`infra/k8s/base/services/authelia.yaml\`: \`path: /config/users/users_database.yml\` + mount dropped \`subPath\` + new mountPath \`/config/users\`.
- \`infra/k8s/overlays/prod/patches.yaml\`: matching \`path:\` update so the prod overlay stays in sync.
- One rolling restart on this deploy (deployment spec changes). After that, future \`users_database\` updates propagate without restart.

## Test plan

- [x] \`make check\` → green
- [x] CI green
- [ ] After merge: \`make deploy-k8s ENV=prod\` → \`make pods ENV=prod\` (Authelia AGE near 0) → \`make test-e2e ENV=prod\` → manual login \`operator\` to confirm OIDC chain (Gitea + ArgoCD).

## Follow-ups (tracked separately)

- Audit other \`subPath\` mounts across base/overlay manifests for the same gotcha.
- \`make restart SVC=x ENV=y\` utility for services where app-level watch is not an option.
- ADR-039 documenting policy: Secret/ConfigMap reload strategies (app watch > directory mount > Reloader > hash suffix > manual restart).