### PR TITLE
fix(ssot): SSOT-019 extend contact.email loader injection to gitea.admin_email

### DIFF
--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -377,6 +377,7 @@ apps:
   # the following downstream fields if they are empty/absent:
   #   - edge.traefik.acme_email                                   (Let's Encrypt account)
   #   - apps.services.observability.uptime_kuma.admin_email       (incident alerts)
+  #   - apps.services.core.gitea.admin_email                      (Gitea admin user)
   #   - apps.services.security.authelia.users[is_admin=true].email (admin user identity)
   # NOT auto-filled (semantic distinction): infra.smtp.user — that is the SMTP
   # relay account, which may legitimately differ (e.g. noreply@) in the future.

--- a/tests/test_credentials_reconcile.py
+++ b/tests/test_credentials_reconcile.py
@@ -248,6 +248,24 @@ class TestSSOTContactEmail:
             f"apps.contact.email ({contact!r}) via loader injection (SSOT-014c)"
         )
 
+    def test_loader_injects_gitea_admin_email_from_contact(self, env: str) -> None:
+        """SSOT-019: apps.services.core.gitea.admin_email derives from apps.contact.email.
+
+        Surfaced 2026-05-26 during Phase B prod smoke (apply-secrets warning) and confirmed
+        2026-05-26 in staging (gitea pod CreateContainerConfigError — missing ADMIN_EMAIL key
+        in gitea-secrets Secret).
+        """
+        from toolkit.features.configuration import ConfigurationManager
+
+        cm = ConfigurationManager(env)
+        config = cm.get_merged_config()
+        contact = config["apps"]["contact"]["email"]
+        admin_email = config["apps"]["services"]["core"]["gitea"]["admin_email"]
+        assert admin_email == contact, (
+            f"gitea.admin_email ({admin_email!r}) must derive from "
+            f"apps.contact.email ({contact!r}) via loader injection (SSOT-019)"
+        )
+
     def test_loader_injects_authelia_admin_email_from_contact(self, env: str) -> None:
         from toolkit.features.configuration import ConfigurationManager
 

--- a/toolkit/features/configuration.py
+++ b/toolkit/features/configuration.py
@@ -131,6 +131,7 @@ class ConfigurationManager:
         Reads `apps.contact.email` and uses it as the default for:
           - edge.traefik.acme_email
           - apps.services.observability.uptime_kuma.admin_email
+          - apps.services.core.gitea.admin_email
           - any Authelia user with `is_admin: true` and no explicit `email`
 
         Per ADR-036 / SSOT-014 master plan: single declaration, multiple
@@ -156,6 +157,11 @@ class ConfigurationManager:
         )
         if not uptime_kuma.get("admin_email"):
             uptime_kuma["admin_email"] = contact_email
+
+        # apps.services.core.gitea.admin_email (SSOT-019 follow-up to 014c)
+        gitea = config.setdefault("apps", {}).setdefault("services", {}).setdefault("core", {}).setdefault("gitea", {})
+        if not gitea.get("admin_email"):
+            gitea["admin_email"] = contact_email
 
         # Authelia admin users (is_admin: true) with no explicit email
         authelia_users = (


### PR DESCRIPTION
## Summary

Closes **SSOT-019**. Extends `_inject_contact_email_derivations` to cover `apps.services.core.gitea.admin_email`, closing the comment-vs-implementation drift discovered during Phase B prod smoke (2026-05-26).

## Why now

- **Prod evidence:** `make apply-secrets ENV=prod` warned `Missing values: ADMIN_EMAIL (from APPS_SERVICES_CORE_GITEA_ADMIN_EMAIL)` (captured in SSOT-019 ticket this morning).
- **Staging evidence (NEW, found during PR #225 smoke):** Gitea pod `gitea-78ffd6b556-7ph5d` in `CreateContainerConfigError` for ~76 min with `Error: couldn't find key ADMIN_EMAIL in Secret kubelab/gitea-secrets`. e2e `test_health[gitea]` returning 503.
- Blocks staging e2e from going 100% green (and prod e2e once we ship).

## Mechanical change

4-line mirror of the existing `uptime_kuma` block in `_inject_contact_email_derivations`:

```python
gitea = (
    config.setdefault("apps", {})
    .setdefault("services", {})
    .setdefault("core", {})
    .setdefault("gitea", {})
)
if not gitea.get("admin_email"):
    gitea["admin_email"] = contact_email
```

Same shape as the other 3 derivations. Single SSOT preserved (`apps.contact.email`).

## Tests

- 2 new parametrized cases (`staging`, `prod`) under `TestSSOTContactEmail.test_loader_injects_gitea_admin_email_from_contact`
- `TestSSOTContactEmail` total: 10 (was 8)
- Full suite: `pytest` 128/128 ✓ | `make lint` ✓ | `make validate` ✓

## Doc updates

- Docstring of `_inject_contact_email_derivations` adds gitea to the list of consumers.
- `common.yaml` SSOT comment block (lines 375-384) adds gitea to the documented derivations.

## Test plan

- [x] CI green (drift gate, tests, lint)
- [ ] Deploy staging: `make apply-secrets ENV=staging` → re-create `gitea-secrets` with `ADMIN_EMAIL` key → Gitea pod recovers from `CreateContainerConfigError` → e2e Gitea tests pass
- [ ] Deploy prod: `make apply-secrets ENV=prod` → no more `Missing values: ADMIN_EMAIL` warning → prod e2e Gitea tests pass

## Related

- SSOT-014c (PR #220) — the master pattern this extends
- ADR-036 — `infra.<service>.*` shared namespace pattern
- PR #225 (Authelia subPath refactor) — surfaced this gap during staging smoke