### PR TITLE
fix(authelia): declare explicit token_endpoint_auth_method on all OIDC clients

### DIFF
--- a/infra/k8s/base/services/authelia-config/configuration.yml
+++ b/infra/k8s/base/services/authelia-config/configuration.yml
@@ -149,6 +149,7 @@ identity_providers:
         client_secret: '$argon2id$v=19$m=65536,t=3,p=4$wj5wl7QJ0kBjfoU14xHzsg$+zHidCseBsuXzhFQikc2YQCuCwccULc04PEvB/N+15I'
         public: false
         authorization_policy: one_factor
+        token_endpoint_auth_method: 'client_secret_basic'
         redirect_uris:
           - https://console.minio.staging.kubelab.live/oauth_callback
         scopes:
@@ -162,6 +163,7 @@ identity_providers:
         client_secret: '$argon2id$v=19$m=65536,t=3,p=4$hwMft6DGS9q0FeRZ1LEqHQ$Q3B4hHugcx3NJetiiarH0pmHBZgdE+/LgqtX/6JRXkk'
         public: false
         authorization_policy: one_factor
+        token_endpoint_auth_method: 'client_secret_basic'
         redirect_uris:
           - https://grafana.staging.kubelab.live/login/generic_oauth
         scopes:
@@ -176,6 +178,9 @@ identity_providers:
         client_secret: '$argon2id$v=19$m=65536,t=3,p=4$b8EeluewDlRZUEkKSvh4nA$Uq8EryLj+omkz5Q7SwpVHIOKVSICBt2J+2U5Qgs9Z44'
         public: false
         authorization_policy: one_factor
+        # Gitea sends client credentials in POST body. Authelia 4.39.x defaults to
+        # client_secret_basic, so this MUST be set explicitly (else: invalid_client).
+        token_endpoint_auth_method: 'client_secret_post'
         redirect_uris:
           - https://gitea.staging.kubelab.live/user/oauth2/authelia/callback
         scopes:
@@ -190,6 +195,7 @@ identity_providers:
         client_secret: '$argon2id$v=19$m=65536,t=3,p=4$ITrEVRiT5s0czAnRKOPviA$00Z6kT5lnb+mbWluVLWZyd5tn7jtDOwJu0qbMhldTA8'
         public: false
         authorization_policy: one_factor
+        token_endpoint_auth_method: 'client_secret_basic'
         redirect_uris:
           - https://argo.kubelab.live/auth/callback
         scopes:

--- a/infra/k8s/overlays/prod/authelia-config/configuration.yml
+++ b/infra/k8s/overlays/prod/authelia-config/configuration.yml
@@ -158,6 +158,7 @@ identity_providers:
         client_secret: '$argon2id$v=19$m=65536,t=3,p=4$ZENMbw+Oru2372cUdxItFA$2cSPmiwXPbTp+m+/cytz9V6J/ppsnVKXW9Izlaq653o'
         public: false
         authorization_policy: one_factor
+        token_endpoint_auth_method: 'client_secret_basic'
         redirect_uris:
           - https://console.minio.kubelab.live/oauth_callback
         scopes:
@@ -171,6 +172,7 @@ identity_providers:
         client_secret: '$argon2id$v=19$m=65536,t=3,p=4$YFjurhJUZsZA7nET/rOWtQ$kCyKlh6EPH3FX5tO7Z15IOXBnOdqxp5EU05/aGMKe3M'
         public: false
         authorization_policy: one_factor
+        token_endpoint_auth_method: 'client_secret_basic'
         redirect_uris:
           - https://grafana.kubelab.live/login/generic_oauth
         scopes:
@@ -185,6 +187,9 @@ identity_providers:
         client_secret: '$argon2id$v=19$m=65536,t=3,p=4$dZFZpAXgnOINpkcZriaNBA$fTErQSrR/HFPha6he0Vvs/ibiBDKtNtCqVXZ99KMG5k'
         public: false
         authorization_policy: one_factor
+        # Gitea sends client credentials in POST body. Authelia 4.39.x defaults to
+        # client_secret_basic, so this MUST be set explicitly (else: invalid_client).
+        token_endpoint_auth_method: 'client_secret_post'
         redirect_uris:
           - https://gitea.kubelab.live/user/oauth2/authelia/callback
         scopes:
@@ -199,6 +204,7 @@ identity_providers:
         client_secret: '$argon2id$v=19$m=65536,t=3,p=4$ITrEVRiT5s0czAnRKOPviA$00Z6kT5lnb+mbWluVLWZyd5tn7jtDOwJu0qbMhldTA8'
         public: false
         authorization_policy: one_factor
+        token_endpoint_auth_method: 'client_secret_basic'
         redirect_uris:
           - https://argo.kubelab.live/auth/callback
         scopes:


### PR DESCRIPTION
## Summary

Fixes an OIDC `invalid_client` failure when logging into Gitea via Authelia, discovered during manual smoke after #225/#226. **Pre-existing bug**, unrelated to PR #225 — the configuration.yml content was byte-identical across that refactor, but no automated test exercises the interactive OIDC flow so this remained latent.

## Bug

Browser flow `gitea.kubelab.live → Sign in via Authelia` returns:

> `invalid_client` — Client authentication failed (e.g., unknown client, no client authentication included, or unsupported authentication method). The request was determined to be using `token_endpoint_auth_method` method `client_secret_post`, however the OAuth 2.0 client registration does not allow this method.

## Root cause

- Authelia 4.39.x defaults the per-client `token_endpoint_auth_method` to `client_secret_basic` when the field is absent.
- Gitea 1.25.x sends credentials in the **POST body** (`client_secret_post`).
- Mismatch → token endpoint rejects with `invalid_client`.

## Fix

Declare `token_endpoint_auth_method` explicitly on every OIDC client in both staging and prod `configuration.yml`:

| Client | Method | Rationale |
|---|---|---|
| `gitea` | `client_secret_post` | **the fix** — matches what Gitea sends |
| `minio` | `client_secret_basic` | current implicit default; declared explicitly so future Authelia bumps that change the default cannot silently break MinIO too |
| `grafana` | `client_secret_basic` | same |
| `argocd` | `client_secret_basic` | same |

Inline comment on the `gitea` client documents why it differs (so the next reader does not delete the line thinking it's redundant).

## Why declare it on the others too (scope C)

User asked for the robust fix instead of "just gitea". The marginal cost is 3 lines per env and a future Authelia version that changes the default cannot break us without an explicit schema rejection. Documents the de-facto behavior.

## Verification

- `kubectl kustomize` produces new hash suffixes (content changed): `authelia-config-9gcffdbm7h` (staging), `authelia-config-k9fhf6gtf9` (prod) — PR #225 auto-restarts Authelia on deploy.
- `pytest`: 128/128 ✓
- `make lint` ✓
- `make validate` ✓ — **Authelia schema-validates the config**, so the new field is accepted on 4.39.x.

## Test plan

- [x] CI green
- [x] Deploy staging — Authelia pod auto-restarts (new hashed CM)
- [ ] Manual: incognito → `gitea.staging.kubelab.live` → Sign in via Authelia → confirm login flow completes
- [ ] Deploy prod (Argo CD auto-sync) — Authelia pod auto-restarts
- [ ] Manual: incognito → `gitea.kubelab.live` → Sign in via Authelia → confirm login flow completes
- [ ] Sanity: re-test Grafana / MinIO / ArgoCD OIDC still work (no regression from declaring `client_secret_basic` explicitly)

## Related

- PR #225 (hash-suffix refactor) — what makes this fix cheap (auto-restart on deploy)
- Discovered during manual smoke validation step of post-#225/#226 session