### PR TITLE
fix(oidc): OIDC-SYNC-001 sync_oidc_hashes path drift + fail-loud

### DIFF
--- a/tests/test_sync_oidc_hashes.py
+++ b/tests/test_sync_oidc_hashes.py
@@ -1,0 +1,80 @@
+"""Regression tests for sync_oidc_hashes — guards path drift + silent no-op.
+
+OIDC-SYNC-001: PR #225 moved the OIDC clients out of authelia.yaml / patches.yaml
+into authelia-config/configuration.yml, but FILE_PATHS still pointed at the old
+files. The script then reported ``OK: ... already current`` while doing nothing, so
+prod Gitea OIDC drifted undetected until a manual smoke caught ``invalid_client``.
+
+These tests fail loudly if either regression returns:
+  1. FILE_PATHS points at a file that has no ``client_secret:`` line (path drift).
+  2. ``update_client_secret`` silently returns unchanged content on a regex miss.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from toolkit.scripts.sync_oidc_hashes import (
+    FILE_PATHS,
+    OIDC_CLIENTS,
+    update_client_secret,
+)
+
+# Structurally valid argon2id shape, not a real secret — only used in-memory.
+_SAMPLE_HASH = "$argon2id$v=19$m=65536,t=3,p=4$TESTSALT$TESTHASHTESTHASHTESTHASHTESTHASH00"
+
+
+class TestFilePaths:
+    """Every FILE_PATHS target must actually contain OIDC client secrets."""
+
+    @pytest.mark.parametrize("key", sorted(FILE_PATHS))
+    def test_target_exists_and_has_client_secret(self, key: str) -> None:
+        path = FILE_PATHS[key]
+        assert path.exists(), f"FILE_PATHS['{key}'] does not exist: {path}"
+        assert "client_secret:" in path.read_text(), (
+            f"FILE_PATHS['{key}'] ({path}) has no 'client_secret:' line — path drift "
+            "would make sync_oidc_hashes a silent no-op (OIDC-SYNC-001)."
+        )
+
+
+class TestUpdateClientSecret:
+    """Replace on match; raise (never silently no-op) on miss."""
+
+    def test_replaces_existing_secret(self) -> None:
+        content = (
+            "clients:\n"
+            "  - client_id: gitea\n"
+            "    client_name: Gitea\n"
+            "    client_secret: 'OLDHASH'\n"
+            "    public: false\n"
+        )
+        result = update_client_secret(content, "gitea", _SAMPLE_HASH)
+        assert _SAMPLE_HASH in result
+        assert "OLDHASH" not in result
+
+    def test_raises_when_client_missing(self) -> None:
+        content = "clients:\n  - client_id: minio\n    client_secret: 'X'\n"
+        with pytest.raises(RuntimeError, match="not found"):
+            update_client_secret(content, "gitea", _SAMPLE_HASH)
+
+
+def test_managed_clients_resolve_in_repo_configs() -> None:
+    """The direct OIDC-SYNC-001 guard: run the real regex against the real files.
+
+    For every managed client, in every file it claims to live in, the secret must be
+    found and replaced. This is exactly the check that the broken FILE_PATHS bypassed.
+    """
+    for sops_path, info in OIDC_CLIENTS.items():
+        client_id = str(info["client_id"])
+        files = info["files"]
+        assert isinstance(files, list)
+        for file_key in files:
+            key = str(file_key)
+            content = FILE_PATHS[key].read_text()
+            updated = update_client_secret(content, client_id, _SAMPLE_HASH)
+            assert updated != content, (
+                f"client '{client_id}' ({sops_path}) not updated in "
+                f"FILE_PATHS['{key}'] ({FILE_PATHS[key]}) — regex/path drift "
+                "(OIDC-SYNC-001)."
+            )
+            assert _SAMPLE_HASH in updated

--- a/toolkit/scripts/sync_oidc_hashes.py
+++ b/toolkit/scripts/sync_oidc_hashes.py
@@ -1,8 +1,8 @@
 """Sync OIDC client_secret hashes from SOPS into Authelia K8s ConfigMap YAMLs.
 
 Reads argon2 hashes from SOPS and replaces placeholder/stale values in:
-  - infra/k8s/base/services/authelia.yaml (staging)
-  - infra/k8s/overlays/prod/patches.yaml (prod)
+  - infra/k8s/base/services/authelia-config/configuration.yml (staging)
+  - infra/k8s/overlays/prod/authelia-config/configuration.yml (prod)
 
 This eliminates the manual step of copy-pasting hashes after `toolkit secrets hash`.
 
@@ -52,9 +52,13 @@ OIDC_CLIENTS = {
     },
 }
 
+# OIDC clients live in the Authelia configuration.yml ConfigMap (configMapGenerator).
+# PR #225 (authelia-config refactor) moved them out of authelia.yaml / patches.yaml.
+# These paths MUST track that file or the sync becomes a silent no-op (OIDC-SYNC-001);
+# tests/test_sync_oidc_hashes.py guards against drift.
 FILE_PATHS = {
-    "base": PROJECT_ROOT / "infra/k8s/base/services/authelia.yaml",
-    "prod": PROJECT_ROOT / "infra/k8s/overlays/prod/patches.yaml",
+    "base": PROJECT_ROOT / "infra/k8s/base/services/authelia-config/configuration.yml",
+    "prod": PROJECT_ROOT / "infra/k8s/overlays/prod/authelia-config/configuration.yml",
 }
 
 
@@ -84,9 +88,13 @@ def update_client_secret(content: str, client_id: str, new_hash: str) -> str:
         re.MULTILINE,
     )
     match = pattern.search(content)
-    if match:
-        return content[: match.start()] + match.group(1) + new_hash + match.group(2) + content[match.end() :]
-    return content
+    if not match:
+        raise RuntimeError(
+            f"OIDC client '{client_id}' not found: no 'client_id: {client_id}' + "
+            "'client_secret' block in the target config. FILE_PATHS is stale or the "
+            "client was removed/renamed. Refusing to report success (OIDC-SYNC-001)."
+        )
+    return content[: match.start()] + match.group(1) + new_hash + match.group(2) + content[match.end() :]
 
 
 def main() -> int:
@@ -134,7 +142,11 @@ def main() -> int:
         file_path = FILE_PATHS[target_key]
         content = file_path.read_text()
         client_id = str(client_info["client_id"])
-        new_content = update_client_secret(content, client_id, hash_value)
+        try:
+            new_content = update_client_secret(content, client_id, hash_value)
+        except RuntimeError as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 1
 
         if new_content != content:
             file_path.write_text(new_content)


### PR DESCRIPTION
## OIDC-SYNC-001 (HIGH)

`make sync-oidc-hashes` (`toolkit sync oidc`) was silently broken after PR #225.

### Problem
PR #225 (authelia-config refactor) moved the OIDC clients out of
`infra/k8s/base/services/authelia.yaml` and `infra/k8s/overlays/prod/patches.yaml`
into `authelia-config/configuration.yml`. Two defects combined:

1. **Path drift** — `FILE_PATHS` still pointed at the old files, which no longer
   contain any `client_secret:` block.
2. **Silent-success anti-pattern** — `update_client_secret()` returned the content
   unchanged when its regex did not match, so `main()` printed
   `OK: ... already current` exactly like a real no-op. No error path existed for
   "target block not found".

**Impact:** the argon2 hash in Authelia prod drifted from the SOPS plaintext and
it was invisible until a manual smoke caught `invalid_client` on Gitea login. The
tool whose job is to prevent this drift was failing in silence.

### Fix
- `FILE_PATHS` -> `base/services/authelia-config/configuration.yml` and
  `overlays/prod/authelia-config/configuration.yml`.
- `update_client_secret()` raises `RuntimeError` on a regex miss; `main()` turns
  that into a non-zero exit instead of a misleading success.
- Module docstring re-pointed at the real files.
- New `tests/test_sync_oidc_hashes.py`: (1) every `FILE_PATHS` target exists and
  has a `client_secret:` line; (2) `update_client_secret` raises on a missing
  client; (3) the real regex resolves every managed client against the actual
  repo configs (the check the broken paths bypassed).

### Verification
- `make test` -> 133 passed, 108 deselected (e2e/infra need a live cluster).
  The 16 `test_sync.py` drift-check tests (ADR-027) still pass -> the new `raise`
  does not break that path.
- `ruff check` / `ruff format --check` / `mypy` clean.

### Scope / follow-ups (not in this PR)
This hardens a regex-on-YAML mechanism (makes it fail loud); it does not replace
it. The scalable end-state is tracked separately: OIDC-SYNC-002 (atomic
`make rotate-oidc-secret`), OIDC-E2E-001 (programmatic OIDC flow tests in CI),
OIDC-DRIFT-001 (post-update token round-trip verification).
