### PR TITLE
fix(oidc): OIDC-SYNC-001b align sync --check paths with FILE_PATHS

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -7,10 +7,37 @@ from pathlib import Path
 import pytest
 from typer.testing import CliRunner
 
-from toolkit.cli.sync import _normalize_content, _restore_snapshots, _run_with_check
+from toolkit.cli.sync import (
+    _get_oidc_output_files,
+    _normalize_content,
+    _restore_snapshots,
+    _run_with_check,
+)
 from toolkit.main import app
 
 runner = CliRunner()
+
+
+class TestOidcCheckPaths:
+    """The --check snapshot set must match the files the sync actually writes.
+
+    OIDC-SYNC-001b: _get_oidc_output_files() hardcoded the old authelia.yaml /
+    patches.yaml paths while sync_oidc_hashes wrote configuration.yml, so
+    `toolkit sync oidc --check` compared/restored the wrong files — falsely
+    reporting "in sync" and leaving the real config modified on disk.
+    """
+
+    def test_check_paths_match_sync_file_paths(self) -> None:
+        from toolkit.scripts.sync_oidc_hashes import FILE_PATHS
+
+        assert set(_get_oidc_output_files()) == set(FILE_PATHS.values())
+
+    def test_check_paths_point_at_configuration_yml(self) -> None:
+        for path in _get_oidc_output_files():
+            assert path.name == "configuration.yml", (
+                f"--check snapshots {path}, not the authelia-config configuration.yml "
+                "the sync writes (OIDC-SYNC-001b path drift)."
+            )
 
 
 class TestSyncCLI:

--- a/toolkit/cli/sync.py
+++ b/toolkit/cli/sync.py
@@ -167,11 +167,17 @@ def _get_homepage_output_files() -> list[Path]:
 
 
 def _get_oidc_output_files() -> list[Path]:
-    """Target files for OIDC hash sync."""
-    return [
-        settings.project_root / "infra/k8s/base/services/authelia.yaml",
-        settings.project_root / "infra/k8s/overlays/prod/patches.yaml",
-    ]
+    """Target files for OIDC hash sync.
+
+    Reuses sync_oidc_hashes.FILE_PATHS as the single source of truth so the
+    --check snapshot/compare/restore set can never drift from the files the sync
+    actually writes. Hardcoding them separately is what broke OIDC-SYNC-001
+    (--check compared/restored the old files while the sync wrote the new ones,
+    falsely reporting "in sync" and leaving the real config modified).
+    """
+    from toolkit.scripts.sync_oidc_hashes import FILE_PATHS
+
+    return list(FILE_PATHS.values())
 
 
 def _run_oidc_sync(env: str) -> int:


### PR DESCRIPTION
## OIDC-SYNC-001b — follow-up to #229 (Codex P2)

[Codex flagged](https://github.com/mlorentedev/kubelab/pull/229) that #229 fixed the
path drift in only one of two places.

### Problem
#229 repointed `sync_oidc_hashes.FILE_PATHS` to `authelia-config/configuration.yml`,
but `cli/sync.py:_get_oidc_output_files()` still hardcoded the old
`infra/k8s/base/services/authelia.yaml` and `infra/k8s/overlays/prod/patches.yaml`.

In `toolkit sync oidc --check` / `toolkit sync all --check`, `_run_with_check`
snapshots → runs sync → compares → restores **the list it is given**. Since that
list was the stale one, the check:
- ran the (now-correct) sync against `configuration.yml`,
- compared/restored only the old files,

so OIDC hash drift in `configuration.yml` could be reported as "in sync" **and the
check could leave the real config file modified on disk**. This silently defeated
the fail-loud guarantee #229 was meant to add.

### Fix
- `_get_oidc_output_files()` now derives its list from `sync_oidc_hashes.FILE_PATHS`
  — single source of truth, so the check set can never drift from what the sync
  writes again. Removes the duplicated constant that caused the bug.
- `tests/test_sync.py`: new `TestOidcCheckPaths` asserts the `--check` paths equal
  `FILE_PATHS` and resolve to `configuration.yml`.

### Verification
- `make test` → 135 passed, 108 deselected (133 + 2 new).
- `ruff check` / `ruff format --check` / `mypy` clean.

Root cause class: a constant duplicated across the writer and the checker. Fixing
one copy gave false closure; the durable fix is to dedupe to one source.
