### PR TITLE
feat(oidc): OIDC-DRIFT-001 token round-trip verification in configure-oidc

### DIFF
--- a/tests/test_configure_oidc.py
+++ b/tests/test_configure_oidc.py
@@ -1,0 +1,77 @@
+"""Tests for configure_oidc token-endpoint drift verification (OIDC-DRIFT-001).
+
+The incident: `make configure-oidc ENV=prod` reported success (exit 0) while the
+Gitea OIDC flow was actually broken — the SOPS plaintext no longer matched the
+argon2 hash Authelia stored. configure_oidc now does a post-update token round-trip
+and classifies the response: invalid_client => the secret<->hash drift is real.
+
+classify_token_response is a pure function (no I/O), so the PASS/FAIL discrimination
+is pinned here deterministically; the HTTP call is mocked in the integration tests.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from toolkit.scripts import configure_oidc
+from toolkit.scripts.configure_oidc import (
+    VERIFY_FAIL,
+    VERIFY_INCONCLUSIVE,
+    VERIFY_PASS,
+    classify_token_response,
+    verify_token_endpoint,
+)
+
+_CFG = {"authelia_url": "https://auth.staging.kubelab.live", "oidc_client_secret": "s3cr3t"}
+
+
+class TestClassifyTokenResponse:
+    """invalid_client => FAIL (the drift); any other outcome => PASS."""
+
+    def test_invalid_client_is_fail(self) -> None:
+        assert classify_token_response(401, {"error": "invalid_client"}) == VERIFY_FAIL
+
+    def test_access_token_is_pass(self) -> None:
+        assert classify_token_response(200, {"access_token": "abc", "token_type": "bearer"}) == VERIFY_PASS
+
+    def test_other_oauth_error_is_pass(self) -> None:
+        # client auth already succeeded; we tripped on the (disabled) grant instead
+        assert classify_token_response(400, {"error": "unauthorized_client"}) == VERIFY_PASS
+        assert classify_token_response(400, {"error": "unsupported_grant_type"}) == VERIFY_PASS
+
+    def test_invalid_client_wins_even_on_non_401_status(self) -> None:
+        # the machine-readable error field is authoritative, not the HTTP status
+        assert classify_token_response(400, {"error": "invalid_client"}) == VERIFY_FAIL
+
+
+class TestVerifyTokenEndpoint:
+    """Network/parse failures must be inconclusive, never a false drift."""
+
+    def test_unreachable_endpoint_is_inconclusive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(*_a: object, **_k: object) -> object:
+            raise httpx.ConnectError("refused")
+
+        monkeypatch.setattr(configure_oidc.httpx, "post", boom)
+        assert verify_token_endpoint(_CFG, "staging") == VERIFY_INCONCLUSIVE
+
+    def test_invalid_client_maps_to_fail(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_post(*_a: object, **_k: object) -> httpx.Response:
+            return httpx.Response(401, json={"error": "invalid_client"})
+
+        monkeypatch.setattr(configure_oidc.httpx, "post", fake_post)
+        assert verify_token_endpoint(_CFG, "staging") == VERIFY_FAIL
+
+    def test_client_auth_ok_maps_to_pass(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_post(*_a: object, **_k: object) -> httpx.Response:
+            return httpx.Response(400, json={"error": "unsupported_grant_type"})
+
+        monkeypatch.setattr(configure_oidc.httpx, "post", fake_post)
+        assert verify_token_endpoint(_CFG, "staging") == VERIFY_PASS
+
+    def test_non_json_body_is_inconclusive(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def fake_post(*_a: object, **_k: object) -> httpx.Response:
+            return httpx.Response(502, text="<html>bad gateway</html>")
+
+        monkeypatch.setattr(configure_oidc.httpx, "post", fake_post)
+        assert verify_token_endpoint(_CFG, "staging") == VERIFY_INCONCLUSIVE

--- a/toolkit/scripts/configure_oidc.py
+++ b/toolkit/scripts/configure_oidc.py
@@ -13,6 +13,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import httpx
+
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(PROJECT_ROOT))
 
@@ -128,18 +130,103 @@ def configure_gitea_oidc(config: dict[str, str], env: str) -> None:
         print(f"WARNING: Gitea restart failed: {restart_result.stderr}")
 
 
-def main() -> None:
+# Verdicts returned by classify_token_response (OIDC-DRIFT-001).
+VERIFY_PASS = "pass"  # client authentication succeeded (secret matches the hash)
+VERIFY_FAIL = "fail"  # invalid_client — secret<->hash drift or stale Gitea OAuth source
+VERIFY_INCONCLUSIVE = "inconclusive"  # could not reach/parse the endpoint — do not gate on this
+
+
+def classify_token_response(status_code: int, body: dict[str, object]) -> str:
+    """Classify an OAuth2 token-endpoint response into a drift verdict.
+
+    OIDC-DRIFT-001: the only thing we can assert without enabling a grant is whether
+    the *client authenticated* — i.e. whether the plaintext secret we hold matches the
+    argon2 hash Authelia stores. The token endpoint authenticates the client BEFORE it
+    evaluates the grant, so:
+
+      - `invalid_client` (RFC 6749 §5.2, usually HTTP 401) means the secret did NOT
+        match -> this is exactly the secret<->hash drift / stale Gitea source the
+        incident was about -> FAIL.
+      - ANY other OAuth2 error (`unauthorized_client`, `invalid_grant`,
+        `unsupported_grant_type`, ...) means client auth already PASSED and we tripped
+        on the grant instead -> PASS (drift is not present).
+      - HTTP 200 with an access_token -> PASS.
+
+    Per RFC 6749 §5.2, `invalid_client` is the ONLY error code that denotes failed
+    client authentication; every other code (`invalid_request`, `invalid_grant`,
+    `unauthorized_client`, `unsupported_grant_type`, `invalid_scope`) is raised only
+    after the client has been authenticated. So the machine-readable `error` field is
+    authoritative — the HTTP status (400 vs 401 for invalid_client) varies across
+    implementations and is not relied upon here.
+    """
+    error = str(body.get("error", "")).strip().lower()
+    return VERIFY_FAIL if error == "invalid_client" else VERIFY_PASS
+
+
+def verify_token_endpoint(config: dict[str, str], env: str) -> str:
+    """Probe Authelia's token endpoint with the Gitea client credentials.
+
+    Returns a VERIFY_* verdict. Network/parse failures map to VERIFY_INCONCLUSIVE so a
+    transient outage never reports a false drift. Hits the EXTERNAL issuer URL because
+    Authelia's OIDC issuer is request-dependent (CLAUDE.md gotcha), and posts the
+    secret in the body to match Gitea's `client_secret_post` auth method.
+    """
+    token_url = f"{config['authelia_url']}/api/oidc/token"
+    try:
+        resp = httpx.post(
+            token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": "gitea",
+                "client_secret": config["oidc_client_secret"],
+            },
+            headers={"Accept": "application/json"},
+            timeout=10.0,
+        )
+    except httpx.HTTPError as exc:
+        print(f"WARNING: token endpoint unreachable ({exc}) — skipping drift verification")
+        return VERIFY_INCONCLUSIVE
+
+    try:
+        body = resp.json()
+    except ValueError:
+        print(f"WARNING: token endpoint returned non-JSON (HTTP {resp.status_code}) — skipping verification")
+        return VERIFY_INCONCLUSIVE
+
+    verdict = classify_token_response(resp.status_code, body)
+    if verdict == VERIFY_FAIL:
+        err = body.get("error_description") or body.get("error") or "client authentication failed"
+        print(f"FAIL: OIDC token round-trip rejected the Gitea client secret: {err}")
+    else:
+        print("✓ Token endpoint round-trip succeeded (Gitea client secret matches Authelia)")
+    return verdict
+
+
+def main() -> int:
     parser = argparse.ArgumentParser(description="Configure OIDC providers")
     parser.add_argument("--env", "-e", required=True, help="Target environment")
+    parser.add_argument(
+        "--skip-verify",
+        action="store_true",
+        help="Skip the post-update token round-trip verification (OIDC-DRIFT-001)",
+    )
     args = parser.parse_args()
 
     config = get_config(args.env)
     if not config["oidc_client_secret"]:
         print("ERROR: Gitea oidc_client_secret not found in SOPS")
-        sys.exit(1)
+        return 1
 
     configure_gitea_oidc(config, args.env)
 
+    if args.skip_verify:
+        return 0
+
+    verdict = verify_token_endpoint(config, args.env)
+    if verdict == VERIFY_FAIL:
+        return 2  # drift confirmed: secret<->hash mismatch or stale Gitea source
+    return 0
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/toolkit/scripts/configure_oidc.py
+++ b/toolkit/scripts/configure_oidc.py
@@ -136,31 +136,50 @@ VERIFY_FAIL = "fail"  # invalid_client — secret<->hash drift or stale Gitea OA
 VERIFY_INCONCLUSIVE = "inconclusive"  # could not reach/parse the endpoint — do not gate on this
 
 
+# RFC 6749 §5.2 token-endpoint error codes. `invalid_client` denotes failed CLIENT
+# authentication; the rest are raised only AFTER the client has authenticated.
+_OAUTH2_TOKEN_ERRORS = frozenset(
+    {
+        "invalid_request",
+        "invalid_client",
+        "invalid_grant",
+        "unauthorized_client",
+        "unsupported_grant_type",
+        "invalid_scope",
+    }
+)
+
+
 def classify_token_response(status_code: int, body: dict[str, object]) -> str:
     """Classify an OAuth2 token-endpoint response into a drift verdict.
 
     OIDC-DRIFT-001: the only thing we can assert without enabling a grant is whether
     the *client authenticated* — i.e. whether the plaintext secret we hold matches the
-    argon2 hash Authelia stores. The token endpoint authenticates the client BEFORE it
-    evaluates the grant, so:
+    argon2 hash Authelia stores. Three outcomes, because a JSON body is not proof that
+    we even reached the token endpoint (an ingress/proxy/Authelia 404/403/502 can be
+    JSON too):
 
-      - `invalid_client` (RFC 6749 §5.2, usually HTTP 401) means the secret did NOT
-        match -> this is exactly the secret<->hash drift / stale Gitea source the
-        incident was about -> FAIL.
-      - ANY other OAuth2 error (`unauthorized_client`, `invalid_grant`,
-        `unsupported_grant_type`, ...) means client auth already PASSED and we tripped
-        on the grant instead -> PASS (drift is not present).
-      - HTTP 200 with an access_token -> PASS.
+      - `access_token` present -> the client authenticated AND the grant ran -> PASS.
+      - an OAuth2 error code present (RFC 6749 §5.2):
+          * `invalid_client` -> the secret did NOT match -> FAIL (the drift / stale
+            Gitea source the incident was about).
+          * any other §5.2 code -> client auth already PASSED, we tripped on the grant
+            -> PASS (drift not present).
+      - anything else (no access_token, no recognized OAuth2 error) -> we did not get a
+        real token-endpoint response -> INCONCLUSIVE. Never report PASS for a body we
+        cannot interpret — that would be the same silent-success this check exists to kill.
 
-    Per RFC 6749 §5.2, `invalid_client` is the ONLY error code that denotes failed
-    client authentication; every other code (`invalid_request`, `invalid_grant`,
-    `unauthorized_client`, `unsupported_grant_type`, `invalid_scope`) is raised only
-    after the client has been authenticated. So the machine-readable `error` field is
-    authoritative — the HTTP status (400 vs 401 for invalid_client) varies across
-    implementations and is not relied upon here.
+    The machine-readable `error` field is authoritative; the HTTP status (400 vs 401 for
+    invalid_client) varies across implementations and is not relied upon here.
     """
+    if body.get("access_token"):
+        return VERIFY_PASS
+
     error = str(body.get("error", "")).strip().lower()
-    return VERIFY_FAIL if error == "invalid_client" else VERIFY_PASS
+    if error in _OAUTH2_TOKEN_ERRORS:
+        return VERIFY_FAIL if error == "invalid_client" else VERIFY_PASS
+
+    return VERIFY_INCONCLUSIVE
 
 
 def verify_token_endpoint(config: dict[str, str], env: str) -> str:
@@ -197,6 +216,11 @@ def verify_token_endpoint(config: dict[str, str], env: str) -> str:
     if verdict == VERIFY_FAIL:
         err = body.get("error_description") or body.get("error") or "client authentication failed"
         print(f"FAIL: OIDC token round-trip rejected the Gitea client secret: {err}")
+    elif verdict == VERIFY_INCONCLUSIVE:
+        print(
+            f"WARNING: token endpoint returned an unrecognized JSON response (HTTP {resp.status_code}) "
+            "— not a token-endpoint round-trip; skipping verification"
+        )
     else:
         print("✓ Token endpoint round-trip succeeded (Gitea client secret matches Authelia)")
     return verdict


### PR DESCRIPTION
## OIDC-DRIFT-001 (LOW)

`make configure-oidc ENV=prod` exited 0 ("Gitea restarted successfully ... OIDC
providers configured") even when the OIDC flow was actually broken — the SOPS
plaintext no longer matched the argon2 hash in Authelia's `configuration.yml`. The
breakage was only visible when a human tried an interactive login (`invalid_client`).

### Fix
Add a post-update token round-trip to `configure_oidc.py`:

- **`verify_token_endpoint()`** — POSTs to the **external** Authelia
  `/api/oidc/token` with the Gitea client credentials. External URL because the
  Authelia OIDC issuer is request-dependent (CLAUDE.md gotcha); `client_secret_post`
  body because that is Gitea's `token_endpoint_auth_method`.
- **`classify_token_response()`** — pure function, RFC 6749 §5.2: `invalid_client`
  is the only error code denoting failed *client* authentication; every other code
  is raised only after the client authenticated. So the machine-readable `error`
  field is authoritative (the HTTP status for `invalid_client` varies 400/401 across
  implementations). `invalid_client` → FAIL; client-auth-passed → PASS. This works
  without enabling the `client_credentials` grant — the endpoint authenticates the
  client before it evaluates the grant.
- Network/parse failures → **INCONCLUSIVE** (a transient outage never reports a
  false drift).
- `main()` returns exit code **2** on confirmed drift; `--skip-verify` opts out.

### Verification
- `make test` → 141 passed, 108 deselected (133 + 8 new).
- `ruff check` / `ruff format --check` / `mypy` clean.

This is the verification step that OIDC-SYNC-002 (atomic rotation) will reuse.
