### PR TITLE
ci: deploy bitácora workflows (OPS-002)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -12,6 +12,10 @@ on:
 
 jobs:
   add-to-project:
+    # Fork PRs run without repository secrets — BITACORA_PAT would be empty and the
+    # job would fail (Codex review on kubelab#237). Skip them; fork PRs reach the
+    # board via the rollout backfill or a manual item-add.
+    if: github.event_name == 'issues' || github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     steps:
       # Pin a real release: actions/add-to-project@v1 does NOT resolve (no floating v1 tag).


### PR DESCRIPTION
Canonical `add-to-project.yml` + `bitacora-status.yml` from `mlorentedev/dotfiles` (runbook §7). Deployed via `scripts/bitacora-rollout.sh` — this repo's default branch is protected, so the rollout lands through a PR.