### PR TITLE
chore(homepage): correct ollama node drift (Beelink -> ace2)

### DIFF
--- a/infra/k8s/base/services/homepage-config/custom.js
+++ b/infra/k8s/base/services/homepage-config/custom.js
@@ -32,7 +32,7 @@ STAGING (VPN-only via split DNS)
 
 VPN-ONLY (Headscale extra_records)
   pihole.kubelab.live                RPi4 (172.16.1.1)
-  ollama.kubelab.live                ace2 (100.64.0.5)`,
+  ollama.kubelab.live                ace2 (172.16.1.5)`,
   tech_stack: `TECHNOLOGY           PURPOSE                      WHERE                    MANAGED BY
 ──────────────────── ──────────────────────────── ──────────────────────── ────────────────────
 
@@ -379,7 +379,7 @@ var KUBELAB_SERVICES_SHARED = [
     "health": "http://ollama.kubelab.live/api/tags",
     "auth": "Public",
     "category": "AI",
-    "node": "Beelink",
+    "node": "ace2",
     "version": "",
     "notes": "LLM inference"
   },

--- a/infra/k8s/base/services/homepage-config/custom.js
+++ b/infra/k8s/base/services/homepage-config/custom.js
@@ -32,7 +32,7 @@ STAGING (VPN-only via split DNS)
 
 VPN-ONLY (Headscale extra_records)
   pihole.kubelab.live                RPi4 (172.16.1.1)
-  ollama.kubelab.live                Beelink (172.16.1.3)`,
+  ollama.kubelab.live                ace2 (100.64.0.5)`,
   tech_stack: `TECHNOLOGY           PURPOSE                      WHERE                    MANAGED BY
 ──────────────────── ──────────────────────────── ──────────────────────── ────────────────────
 

--- a/toolkit/scripts/sync_homepage_config.py
+++ b/toolkit/scripts/sync_homepage_config.py
@@ -385,7 +385,7 @@ def build_service_tables(
             f"http://ollama.{base}/api/tags",
             "Public",
             "AI",
-            "Beelink",
+            "ace2",
             "LLM inference",
         ),
         _svc("Pollex", f"http://pollex.{base}", f"http://pollex.{base}", "Public", "AI", "Jetson", "Edge AI"),
@@ -609,7 +609,7 @@ def build_dns_map(config: dict[str, Any]) -> str:
         "",
         "VPN-ONLY (Headscale extra_records)",
         f"  {'pihole.kubelab.live':<34} RPi4 ({rpi4_lan})",
-        f"  {'ollama.kubelab.live':<34} Beelink ({n.get('beelink', {}).get('lan_ip', '?')})",
+        f"  {'ollama.kubelab.live':<34} ace2 ({n.get('ace2', {}).get('lan_ip', '?')})",
     ]
     return "\n".join(rows)
 


### PR DESCRIPTION
Homepage topology display listed Ollama on Beelink (172.16.1.3); it moved to ace2 (100.64.0.5) per ADR-029. One-line display fix. Public-exposure cleanup (removing `ollama.kubelab.live`) is intentionally NOT here — it reverses AI-001 across deployed config + SSOTs + tests and is folded into AI-003 per ADR-042.