### PR TITLE
docs(adr): ADR-045 mlorente.dev interactive-CV migration + WEB-010 spec

### DIFF
--- a/docs/adr/adr-045-mlorente-dev-interactive-cv.md
+++ b/docs/adr/adr-045-mlorente-dev-interactive-cv.md
@@ -1,0 +1,100 @@
+---
+id: adr-045-mlorente-dev-interactive-cv
+type: adr
+status: accepted
+created: "2026-06-14"
+owner: manu
+tags: [architecture, mlorente-dev, web, portfolio, rag, chatbot, llmops, personal-brand, astro, proof-of-work]
+depends_on: [adr-031-positioning-pivot, adr-029-intelligence-layer, adr-043-unified-knowledge-memory-plane, adr-042-reference-architecture]
+---
+
+# ADR-045: mlorente.dev → Interactive-CV (RAG chat + living-telemetry proof surfaces)
+
+> **Status:** Accepted
+> **Date:** 2026-06-14
+> **Related:** ADR-031 (positioning pivot — the "Chat with Manu" widget is a portfolio deliverable), ADR-029 (intelligence layer — `POST /v1/knowledge/chat`), ADR-043 (unified knowledge plane — vault → pgvector → `/v1/knowledge/search`), ADR-042 (reference architecture — always-on vs on-demand inference).
+> **Reference analysis:** vault `10_projects/kubelab/20-business/strategy/interactive-cv-reference-analysis-2026-06-13.md` (santifer.io + miia.dev, incl. the MIT `cv-santiago` repo) and `positioning-authority-references-2026-06-12.md` (14 reference profiles).
+> **Epic:** WEB-010.
+
+## Context
+
+`mlorente.dev` today is a static Astro portfolio (`output: 'static'`, served by nginx on prod VPS K3s behind Traefik + Let's Encrypt), with ~16 bilingual notes and a `portfolio.ts` project grid. It is mature on the build/deploy side but **passive** (no interactivity, thin conversion) and **stale on positioning** (`site.ts` still reads "Engineer from Silicon to Cloud").
+
+A reference site — [santifer.io](https://santifer.io) — crystallised a model worth adopting: **the site IS the portfolio**. It is a production AI system (a first-person RAG chatbot avatar + an LLMOps dashboard + case studies) that *demonstrates* the skills it claims rather than asserting them. Its frontend bot is open source (MIT, `github.com/santifer/cv-santiago`), making it a usable reference implementation.
+
+Critically, the backend for this is **already designed in our own roadmap**: ADR-031 makes the "Chat with Manu" widget a portfolio deliverable; ADR-029 §6 defines `POST /v1/knowledge/chat`; ADR-043 defines the knowledge plane (`vault git → chunk → embed → pgvector → POST /v1/knowledge/search`) and names a *"future public widget"* as an explicit consumer; the board already carries IDP-023 (#299) → IDP-027 (#395) → IDP-028 (#396). This ADR records the **product/site-level decision** that ties those threads together and adds two dimensions the infra ADRs do not cover: the **conversion funnel** and a **belt of "proof-surface" dashboards**.
+
+Goal refinement from the working session: the site's **#1 job is email capture** (own the audience; feed the planned YouTube channel + newsletter); **#2 is "work with me"** — a deliberately ambiguous CTA covering both employment and consulting. The bot and proof surfaces are the trust engine that feeds both.
+
+## Reference audit (Regla del 3)
+
+| Dimension | R1 · santifer.io (engine) | R2 · miia.dev (chassis) | R3 · own roadmap (ADR-029/043) |
+|---|---|---|---|
+| Model | "the system IS the portfolio" — RAG avatar + LLMOps + case studies | Consultant minimalism: quantified credibility, availability widget, no interactivity | Knowledge plane consumed by a public widget |
+| RAG backend | Supabase pgvector + BM25, Haiku rerank, OpenAI embeddings | — (no bot) | pgvector on prod K3s + `/v1/knowledge/search` (IDP-028) |
+| Inference | Claude Sonnet/Haiku + OpenAI Realtime (voice), all SaaS | — | Managed (NaN cloud); ace2/Ollama is on-demand only (ADR-042) |
+| Observability | Langfuse (SaaS) | — | Grafana + Loki + Vector already running; LLM dashboard IDP-025/026 |
+| Design | React/Vite SPA on Vercel Edge | Brutalist-minimal, numbered sections, quantified band | Astro static (SEO) — keep |
+| Conversion | "Listo para el siguiente capítulo" (hire) | "Available 2 retainer spots" (retainer) | Email capture + Beehiiv (existing Go API) |
+
+Take: **miia chassis (clean design + quantified credibility) + santi engine (RAG bot + live dashboards), on our self-hosted data plane.** Inference is the one place we diverge from "all on-prem" — see Decision §3.
+
+## Decision
+
+Migrate `mlorente.dev` from a static portfolio to an **interactive-CV / living-telemetry portfolio**. Five locked choices:
+
+1. **Frontend — evolve, do not rebuild.** Keep the existing Astro static site (preserve SEO, ~16 notes, bilingual routing, Docker→nginx→K3s pipeline) and add interactivity via **islands** (React/Solid/Preact). Server logic does NOT go in the Astro app (it is static by design); it lives in the Go API. The CV/experience timeline becomes the landing skeleton; design language moves toward miia (clean, numbered, a quantified-credibility band).
+2. **Backend — adopt the ADR-043 knowledge plane.** pgvector self-hosted on prod K3s (IDP-023) → embedding pipeline honouring the allowlist (IDP-027) → `POST /v1/knowledge/search` (IDP-028) → a new `POST /v1/knowledge/chat` (ADR-029 §6) in the Go API: system prompt in Manu's 70/30 voice tuned to sell him, tool-use RAG, SSE streaming, first-person persona, rate-limit via the existing Redis.
+3. **Inference — managed API, self-hosted data plane.** The chat LLM runs on a **managed API** (NaN cloud / Claude). The data plane (pgvector, search API, traces) stays self-hosted. This complies with ADR-042: nothing always-on may depend on the on-demand, UPS-less `ace2`/Ollama node, so Ollama is NOT in the public widget path.
+4. **Corpus — curated allowlist.** The RAG corpus is an explicit per-directory allowlist plus a `rag: public` frontmatter flag, with ADR-043's embedding exclusions (SOPS-adjacent, `80_agents/`, `status: archived`, business strategy, employment constraints). Rationale: fail-safe vs a fail-open denylist; for an employability goal, a curated *professional* corpus is higher-signal than the whole vault. The curated set doubles as the public **knowledge garden** (proof surface PS3).
+5. **Conversion — email primary, "work with me" secondary.** Omnipresent email capture is the #1 CTA (feeds YouTube + newsletter, owns the data). A single ambiguous "Work with me / Hablemos" CTA routes employment *and* consulting to one conversation. The bot may also capture email in-conversation.
+
+Plus: a **proof-surface belt** — an *extensible* catalogue (PS1–PS7+, see Implementation) of read-only dashboards each backed by a real system Manu operates. MVP is capped (anti polish-trap): the bot + one cheap surface.
+
+### Resolved design questions
+
+| Question | Decision |
+|---|---|
+| Rebuild (React SPA) vs evolve (Astro + islands) | **Evolve.** Islands capture ~90% of the WoW without discarding SEO/content or adding a SPA to maintain. |
+| Where does chat logic live | **Go API.** Astro is static by ADR; this is the correct separation, not a limitation. |
+| Inference on-prem vs managed | **Managed** (ADR-042 forbids always-on dependency on on-demand nodes). Data plane stays self-hosted. |
+| Corpus allowlist vs denylist | **Allowlist + `rag: public` flag.** Fail-safe; higher employability signal. |
+| Observability stack | **Reuse Grafana/Loki/Vector** (+ IDP-025/026), not a new SaaS (Langfuse). Demonstrates the owned stack. |
+| Proof-surface scope | **Extensible catalogue, MVP capped.** New endpoints appended to the reference doc + epic as discovered. |
+| Site objective | **Email capture primary + ambiguous hire/consult secondary.** Refines (does not contradict) ADR-006's two-layer brand. |
+
+## Options considered and rejected
+
+- **Greenfield React/Vite (clone `cv-santiago`).** Rejected: discards the Astro SEO/content investment and adds a SPA to maintain; islands reach ~90% of the value at far lower risk.
+- **Fully on-prem inference (Ollama on `ace2`).** Rejected: violates ADR-042 (on-demand, no UPS); a public widget would die when the node is off.
+- **Whole-vault RAG minus a denylist.** Rejected: fail-open leak risk for private strategy/employment constraints; dilutes the employability signal.
+- **Consulting-retainer-primary (miia model).** Rejected as the primary objective: Manu's goal is employability + audience-building; consulting stays secondary and inbound.
+
+## Consequences
+
+**Positive:** executes the existing IDP backlog rather than inventing work; the strongest possible proof-of-work (real systems shown running); owns audience data ahead of the YouTube launch; an on-brand self-hosted data plane that *is* "platform engineering for AI workloads".
+
+**Costs / risks:**
+- **IDP-023 (pgvector) is the critical-path blocker** for the bot; everything in Stream A + corpus governance + the GitHub proof surface can proceed in parallel without it.
+- Corpus curation is **ongoing manual effort** (mitigated by the `rag: public` flag + directory allowlist).
+- Managed inference carries **per-conversation cost** (mitigated by a small/large model split, top-K context caps, and Redis rate limits).
+- Public proof surfaces require an **exposure review** per surface (no secret/PII leakage; read-only; separate ingress + rate limits).
+
+**Inherited constraints:** ADR-042 (always-on tier = VPS; inference managed), ADR-043 (one index, one ranking, allowlist exclusions, freshness SLO ≤15 min), ADR-016 (mlorente.dev is public — no Authelia bypass needed; public endpoints are rate-limited).
+
+## Implementation sequencing (epic WEB-010)
+
+- **Stream A (no infra — starts immediately):** reposition `site.ts`/Hero; CV-as-landing IA + quantified band; email/funnel + ambiguous CTA; case-study template (2 from existing ADRs/lessons).
+- **Stream B (backend):** IDP-023 (pgvector) → IDP-027 (pipeline, allowlist) → IDP-028 (search) → `/v1/knowledge/chat`.
+- **Stream C (bot frontend):** chat island → wire to `/v1/knowledge/chat` (**MVP live**) → boundaries v1 (keyword + canary + refusal).
+- **Stream D (proof surfaces):** **PS2** GitHub/OSS telemetry (cheapest, MVP); **PS1** homelab `/ops` (infra exists) and **PS3** knowledge garden (renders the curated set) in Release 2.
+- **Backlog:** voice mode, evals-as-CI-gate, self-healing loop, animated architecture diagram; PS4 (DORA), PS5 (bot LLMOps), PS6 (agent activity feed), PS7+.
+
+**Critical path:** `IDP-023 → IDP-027 → IDP-028 → /v1/knowledge/chat → C2 (bot live)`.
+
+## Open questions
+
+- Final inference provider (NaN open models vs Claude) — decided when building `/v1/knowledge/chat`.
+- Chunking strategy + freshness SLO — inherit ADR-043 (≤15 min cron); tuned in IDP-027.
+- Per-surface public exposure/auth model — separate IngressRoute + rate limit + read-only; reviewed per surface.
+- The proof-surface catalogue is **explicitly open**: new interesting endpoints are appended to the reference analysis doc and the epic as they are discovered, not treated as scope creep.

--- a/specs/WEB-010-interactive-cv/proposal.md
+++ b/specs/WEB-010-interactive-cv/proposal.md
@@ -1,0 +1,53 @@
+---
+id: "WEB-010-interactive-cv"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-14"
+issue: "kubelab#611"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# WEB-010: mlorente.dev interactive-CV migration
+
+> **Naming**: `kubelab/specs/WEB-010-interactive-cv/`. Epic: kubelab#611. Anchored by ADR-045.
+> `[AGENT-DRAFT — review before archive]` — the sections below were pre-drafted from ADR-045; refine via `/spec fill` and remove this tag before archive.
+
+## Why
+
+<!-- from issue #611: WEB-010: mlorente.dev to interactive CV (RAG chat + living-telemetry proof surfaces) -->
+
+`mlorente.dev` is a static, passive portfolio with stale positioning and thin conversion. To serve employability (primary) and audience-building for the upcoming YouTube channel, the site must *demonstrate* platform/AI-engineering ability rather than assert it: an interactive CV with a RAG chatbot grounded on a curated vault corpus, plus read-only "proof-surface" dashboards backed by real systems Manu operates. This executes the already-decided roadmap (ADR-031/029/043) with santifer.io as a de-risking reference implementation. If we don't ship it, the site keeps under-converting and the proof-of-work stays invisible.
+
+## What
+
+- A public "Ask me / Pregúntame" chat island on `mlorente.dev` that answers in first person from a curated vault corpus, served by a new `POST /v1/knowledge/chat` in the Go API (agentic RAG over self-hosted pgvector, managed inference).
+- A repositioned, quantified, CV-as-landing site (clean miia-style design) with an **email-capture primary CTA** + an ambiguous **"work with me"** secondary CTA (employment or consulting).
+- At least one live **proof surface** (GitHub/OSS telemetry), with the homelab `/ops` and knowledge garden as fast-followers.
+
+## Out of scope
+
+- Voice mode, evals-as-CI-gate, and the self-healing loop (backlog; santi-parity later).
+- Proof surfaces PS4–PS6 (DORA, bot LLMOps, agent feed) — catalogued, not MVP.
+- Any domain change (`mlorente.dev` stays; a `.io` move is a separate decision under ADR-017).
+
+## Risks / open questions
+
+- **[MUST resolve before code]** IDP-023 (pgvector on prod K3s, #299) is the critical-path blocker; the bot backend cannot run without it.
+- Corpus leakage: the curated `rag: public` allowlist MUST exclude private strategy/employment material (fail-safe allowlist, never a denylist).
+- Managed-inference provider (NaN cloud vs Claude) + a per-conversation cost guard — decide at WEB-016.
+- Public proof-surface exposure review (no secret/PII leakage; read-only; rate-limited).
+
+## Acceptance criteria
+
+- [ ] `POST /v1/knowledge/chat` returns a streamed, first-person answer grounded in ≥1 retrieved curated-corpus chunk, with source attribution, behind a rate limit.
+- [ ] The "Ask me" island is live on `mlorente.dev` (bilingual) and answers a known question about Manu's experience correctly.
+- [ ] The corpus pipeline indexes ONLY `rag: public`-allowlisted docs (a private/denied doc is provably absent from retrieval).
+- [ ] `mlorente.dev` hero + landing reflect the locked positioning, with a working email-capture CTA.
+- [ ] One proof surface (GitHub/OSS telemetry) renders live on the site.
+
+## References
+
+- ADR: `kubelab/docs/adr/adr-045-mlorente-dev-interactive-cv.md` (+ ADR-031 / ADR-029 / ADR-043 / ADR-042)
+- Epic + tasks: kubelab#611 (WEB-010) → #602–#610 (WEB-011..019); IDP-023 #299 / IDP-027 #395 / IDP-028 #396
+- Vault: `10_projects/kubelab/20-business/strategy/interactive-cv-reference-analysis-2026-06-13.md`

--- a/specs/WEB-010-interactive-cv/tasks.md
+++ b/specs/WEB-010-interactive-cv/tasks.md
@@ -1,0 +1,51 @@
+---
+tags: [spec, tasks]
+created: "2026-06-14"
+---
+
+# Tasks - WEB-010-interactive-cv
+
+> One task = one focused commit/PR. Maps to epic kubelab#611 child issues. Reorder freely while spec is in `draft`.
+
+## Setup
+
+- [ ] Work in kubelab worktree (foreign-repo rule); branch `feat/mlorente-dev-interactive-cv`
+- [ ] `proposal.md` acceptance criteria reviewed (remove the `[AGENT-DRAFT]` tag)
+- [ ] Open questions resolved — esp. IDP-023 (#299) pgvector blocker
+
+## Stream A — Brand & funnel (no infra; start now)
+
+- [ ] WEB-011 (#602) Reposition `site.ts`/Hero + clean design pass
+- [ ] WEB-012 (#603) CV-as-landing: experience timeline + quantified credibility band
+- [ ] WEB-013 (#604) Email funnel (primary) + ambiguous "work with me" CTA
+- [ ] WEB-014 (#605) Case-study template + author two (hive, homelab)
+
+## Stream B — Knowledge plane (backend RAG)
+
+- [ ] IDP-023 (#299) Postgres + pgvector on prod K3s **[BLOCKER]**
+- [ ] IDP-027 (#395) embedding pipeline (honours `rag:public` allowlist)
+- [ ] IDP-028 (#396) `/v1/knowledge/search`
+- [ ] WEB-015 (#606) corpus governance (`rag:public` allowlist + exclusions)
+- [ ] WEB-016 (#607) `POST /v1/knowledge/chat` endpoint
+
+## Stream C — Chatbot frontend
+
+- [ ] WEB-017 (#608) chat island wired → **MVP bot live**
+- [ ] WEB-018 (#609) boundaries v1 (keyword + canary + refusal)
+
+## Stream D — Proof surfaces
+
+- [ ] WEB-019 (#610) PS2 GitHub/OSS telemetry (MVP)
+- [ ] PS1 homelab `/ops` (Release 2)
+- [ ] PS3 knowledge garden (Release 2; renders the curated corpus)
+
+## Closing
+
+- [ ] Every acceptance criterion covered by a test/smoke check
+- [ ] `features.json` emitted (one feature per acceptance criterion)
+- [ ] `verification.md` filled
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+Emit a sibling `features.json` (one feature per acceptance criterion: `id`, `behavior`, `verification`, `state`, `evidence`). The agent CANNOT set `state: passing` — only the harness, after running `verification` with exit 0, may.

--- a/specs/WEB-010-interactive-cv/verification.md
+++ b/specs/WEB-010-interactive-cv/verification.md
@@ -1,0 +1,40 @@
+---
+tags: [spec, verification]
+created: "2026-06-14"
+---
+
+# Verification - WEB-010-interactive-cv
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 (`/v1/knowledge/chat` grounded+streamed) -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 (island live + correct answer) -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 (allowlist-only retrieval) -> commit `<hash>` / test `<name>`
+- [ ] Criterion 4 (repositioned landing + email CTA) -> commit `<hash>` / test `<name>`
+- [ ] Criterion 5 (GitHub/OSS proof surface live) -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+-
+-
+
+## Promotion candidates
+
+- [ ] Lesson for `kubelab/docs/lessons.md`? <yes / no - one line>
+- [ ] ADR-worthy decision for `kubelab/docs/adr/`? (ADR-045 already exists) <yes / no - one line>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if it recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/WEB-010-interactive-cv/` -> `specs/archive/WEB-010-interactive-cv/`
+- [ ] Backlog entry / epic kubelab#611 ticked with PR link
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Summary

Records the decision and scaffolds the spec to migrate `mlorente.dev` from a static portfolio to an interactive-CV / living-telemetry portfolio: a RAG chatbot grounded on a curated vault corpus + read-only proof-surface dashboards, on a self-hosted data plane with managed inference.

- **ADR-045** — ties ADR-031 (positioning), ADR-029 (chat endpoint), ADR-043 (knowledge plane), ADR-042 (always-on vs on-demand). Five locked decisions: evolve Astro + interactive islands; self-hosted pgvector + managed inference (NaN/Claude); curated `rag:public` corpus; email-primary funnel + ambiguous "work with me" CTA; extensible proof-surface catalog.
- **WEB-010 spec** — proposal / tasks / verification scaffold. The proposal is pre-drafted from the ADR and tagged `[AGENT-DRAFT]` pending review.

## Tracking

- Epic: mlorentedev/web#40 (WEB-010) -> tasks mlorentedev/web#41-#610 (WEB-011..019)
- Critical path: mlorentedev/kubelab#299 (IDP-023 pgvector) -> mlorentedev/kubelab#395 -> mlorentedev/kubelab#396 -> mlorentedev/kubelab#607 -> mlorentedev/web#45

## Notes

- Docs-only PR (no code). No auto-merge — for human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural decision and implementation specifications for an interactive CV redesign, including a conversational chat interface, knowledge-based Q&A system, bilingual support, optimized email capture, proof-surface showcase areas, and comprehensive project roadmap with task tracking and verification procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->