### PR TITLE
feat(web): reposition mlorente.dev hero to "Platform engineering for AI workloads"

### DIFF
--- a/apps/web/site/src/components/Hero.astro
+++ b/apps/web/site/src/components/Hero.astro
@@ -13,4 +13,10 @@ const ctaHref = isEs ? '#newsletter-home' : translatePath('/notes');
   <h1 class="text-6xl font-extrabold">{t('hero.title')}</h1>
   <hr class="my-2 border-gray-300" />
   <p class="text-lg text-gray-500 mt-2">{t('hero.subtitle')}</p>
+  <p class="mt-4">
+    <span class="inline-flex items-center gap-2 rounded-full border border-gray-300 px-3 py-1 text-sm text-gray-500">
+      <span class="inline-block h-2 w-2 rounded-full bg-emerald-500"></span>
+      {t('hero.status')}
+    </span>
+  </p>
 </div>

--- a/apps/web/site/src/data/site.ts
+++ b/apps/web/site/src/data/site.ts
@@ -1,6 +1,6 @@
 export const site = {
-  title: 'Manu Lorente — Engineer from Silicon to Cloud',
-  description: 'Engineer. I build infrastructure and products — from hardware to Kubernetes.',
+  title: 'Manu Lorente — Platform engineering for AI workloads',
+  description: 'I build, automate, and operate the infrastructure AI agents run on — Kubernetes, on-prem, reproducible. I run a 40-service homelab and document what breaks.',
   author: 'Manu Lorente',
   domain: 'mlorente.dev',
   url: 'https://mlorente.dev',

--- a/apps/web/site/src/i18n/ui.ts
+++ b/apps/web/site/src/i18n/ui.ts
@@ -15,8 +15,9 @@ export const ui = {
     'nav.toggle': 'Toggle menu',
 
     // Hero
-    'hero.title': 'Engineer from silicon to cloud',
-    'hero.subtitle': 'My personal site about side hustles, notes, and products built across three continents. This boosts my productivity and pays the (some) bills.',
+    'hero.title': 'Platform engineering for AI workloads',
+    'hero.subtitle': 'I build, automate, and operate the infrastructure AI agents run on — Kubernetes, on-prem, reproducible. I run a 40-service homelab and document what breaks.',
+    'hero.status': 'Open to opportunities',
     'hero.cta': 'Read my notes',
 
     // Home sections
@@ -76,7 +77,7 @@ export const ui = {
     '404.cta': 'Go home',
 
     // Meta
-    'meta.description': 'Engineer from silicon to cloud. Infrastructure, Kubernetes, and what breaks in production.',
+    'meta.description': 'Platform engineering for AI workloads. I build and operate agent infrastructure on Kubernetes — on-prem, reproducible.',
     'meta.ghchart.alt': "Manu's GitHub contribution chart",
   },
   es: {
@@ -86,8 +87,9 @@ export const ui = {
     'nav.toggle': 'Abrir menú',
 
     // Hero
-    'hero.title': 'Hazlo tú',
-    'hero.subtitle': 'A mí también me creaba ansiedad poder producir cosas que no era ni capaz de imaginar hace 5 años. De hecho me aterraba. Ahora abrazo el cambio',
+    'hero.title': 'Infraestructura para agentes de IA, en producción',
+    'hero.subtitle': 'Construyo, automatizo y opero la infraestructura sobre la que corren los agentes de IA — Kubernetes, on-prem, reproducible. Tengo un homelab de 40 servicios y documento lo que se rompe.',
+    'hero.status': 'Abierto a oportunidades',
     'hero.cta': 'Empieza ahora',
 
     // Home sections
@@ -147,7 +149,7 @@ export const ui = {
     '404.cta': 'Ir al inicio',
 
     // Meta
-    'meta.description': 'Ingeniero. Del silicio a Kubernetes. Infraestructura real, decisiones reales, documentado mientras construyo.',
+    'meta.description': 'Infraestructura para agentes de IA, en producción. Construyo, automatizo y opero plataformas en Kubernetes — on-prem y reproducible.',
     'meta.ghchart.alt': 'Contribuciones de Manu en GitHub',
   },
 } as const;


### PR DESCRIPTION
## Summary
Repositions the mlorente.dev hero from the stale "Engineer from Silicon to Cloud" to the locked positioning **"Platform engineering for AI workloads"** (ADR-031 / ADR-045), in EN + ES, plus site.ts title/description and meta descriptions. Adds a discreet "Open to opportunities" availability badge (employability objective).

Copy-only; the silicon-to-cloud / from-the-metal-up narrative is retained as supporting color in the notes intro. Visual redesign is deferred to WEB-012.

## Tracking
- WEB-011 (#602) - part of epic mlorentedev/web#40 (WEB-010)

## Notes
- No auto-merge - for human review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added status indicator pill to the hero section with visual badge

* **Content & Localization**
  * Updated website title and description
  * Refreshed hero section messaging in English and Spanish
  * Updated meta descriptions for both languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->