### PR TITLE
chore(ci): add Dependabot governance config for all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,135 @@
+---
+# Dependabot governance for the KubeLab monorepo.
+#
+# Declares every dependency ecosystem present in the repo so updates arrive
+# managed (scheduled, grouped, labelled) instead of as default ungoverned
+# grouped security PRs. Security updates are delivered regardless of this file;
+# the blocks below additionally enable scheduled VERSION updates.
+#
+# Conventions:
+#   - Weekly (Monday) to batch review and limit churn on the single self-hosted
+#     runner.
+#   - commit prefix "fix" for runtime deps so release-please cuts a patch and
+#     rebuilds the image (per CLAUDE.md); "chore" for dev deps (no release).
+#   - minor+patch grouped per ecosystem to cut PR count; majors stay individual
+#     for explicit review.
+#   - Astro majors are pinned on the web apps until @astrojs/mdx supports
+#     Astro 6 (tracked separately). Remove the ignore block at migration time.
+version: 2
+
+updates:
+  # ---- JavaScript / Astro web apps ----
+  - package-ecosystem: "npm"
+    directories:
+      - "/apps/web/site"
+      - "/apps/web/astro-site"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "web"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      web-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      # Blocked: @astrojs/mdx@4 needs astro@^5. Lift with the Astro 6 migration.
+      - dependency-name: "astro"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@astrojs/*"
+        update-types:
+          - "version-update:semver-major"
+
+  # ---- Go API ----
+  - package-ecosystem: "gomod"
+    directory: "/apps/api/src"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "api"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    groups:
+      go-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- Python toolkit (Poetry) ----
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "toolkit"
+    commit-message:
+      prefix: "fix"
+      prefix-development: "chore"
+      include: "scope"
+    groups:
+      toolkit-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- Container images ----
+  - package-ecosystem: "docker"
+    directories:
+      - "/apps/web"
+      - "/apps/api"
+      - "/edge/errors"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    groups:
+      docker-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ---- GitHub Actions ----
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions-all:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+          - "major"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` declaring every dependency ecosystem in the monorepo:

| Ecosystem | Directory(ies) |
|---|---|
| npm | `apps/web/site`, `apps/web/astro-site` |
| gomod | `apps/api/src` |
| pip (Poetry) | `/` (toolkit) |
| docker | `apps/web`, `apps/api`, `edge/errors` |
| github-actions | `/` |

## Why

The repo had **no** `dependabot.yml`, so updates arrived as ungoverned default grouped *security* PRs (the `npm_and_yarn` group). That grouped bump pulled in an Astro 5 to 6 major that breaks `@astrojs/mdx@4` (peer `astro@^5`), failing CI repeatedly.

This config makes updates managed:

- **Weekly** schedule (Monday) to batch review and limit churn on the single self-hosted runner.
- **Grouped** minor+patch per ecosystem to cut PR count; majors stay individual for review.
- Commit prefix **`fix`** for runtime deps (release-please cuts a patch and rebuilds the image, per CLAUDE.md) and **`chore`** for dev deps.
- **Astro majors pinned** on the web apps until `@astrojs/mdx` supports Astro 6.

## Notes

- App/toolkit blocks are **interim**: they migrate to their own repos when WEB-002b (kubelab.live), BLOG-001 (cubernautas-blog) and PUB-001 (kubelab-cli) graduate. Durable-in-L0 ecosystems are github-actions and docker/edge-errors.
- Enables scheduled version updates in addition to security updates (deliberate, managed posture).
- Validated locally: `pre-commit` (yamllint, check-yaml) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates for npm, Go, Python, Docker, and GitHub Actions using Dependabot. Updates are scheduled weekly with minor and patch versions grouped together for efficient management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->