### PR TITLE
chore(ci): scope Dependabot version updates to durable L0 ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,73 +1,24 @@
 ---
 # Dependabot governance for the KubeLab monorepo.
 #
-# Declares every dependency ecosystem present in the repo so updates arrive
-# managed (scheduled, grouped, labelled) instead of as default ungoverned
-# grouped security PRs. Security updates are delivered regardless of this file;
-# the blocks below additionally enable scheduled VERSION updates.
+# Policy (see docs/runbooks/dependency-updates.md):
+#   - Security updates flow for EVERY ecosystem automatically, regardless of this file.
+#   - Scheduled VERSION updates are enabled only for code that stays in L0.
+#   - Apps departing to their own repos (web, api) are security-only here:
+#     open-pull-requests-limit: 0 disables version PRs while keeping security
+#     updates and ignore rules active. Their new repos carry their own config.
 #
-# Conventions:
-#   - Weekly (Monday) to batch review and limit churn on the single self-hosted
-#     runner.
-#   - commit prefix "fix" for runtime deps so release-please cuts a patch and
-#     rebuilds the image (per CLAUDE.md); "chore" for dev deps (no release).
-#   - minor+patch grouped per ecosystem to cut PR count; majors stay individual
-#     for explicit review.
-#   - Astro majors are pinned on the web apps until @astrojs/mdx supports
-#     Astro 6 (tracked separately). Remove the ignore block at migration time.
+# Conventions for the version-update ecosystems:
+#   - Weekly (Monday) to batch review and limit churn on the single self-hosted runner.
+#   - commit prefix "fix" for runtime deps (release-please rebuilds the image),
+#     "chore" for dev deps, "ci" for actions.
+#   - minor+patch grouped; majors stay individual for explicit review.
 version: 2
 
 updates:
-  # ---- JavaScript / Astro web apps ----
-  - package-ecosystem: "npm"
-    directories:
-      - "/apps/web/site"
-      - "/apps/web/astro-site"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "web"
-    commit-message:
-      prefix: "fix"
-      prefix-development: "chore"
-      include: "scope"
-    groups:
-      web-minor-patch:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      # Blocked: @astrojs/mdx@4 needs astro@^5. Lift with the Astro 6 migration.
-      - dependency-name: "astro"
-        update-types:
-          - "version-update:semver-major"
-      - dependency-name: "@astrojs/*"
-        update-types:
-          - "version-update:semver-major"
-
-  # ---- Go API ----
-  - package-ecosystem: "gomod"
-    directory: "/apps/api/src"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "api"
-    commit-message:
-      prefix: "fix"
-      include: "scope"
-    groups:
-      go-minor-patch:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
+  # ============================================================
+  # Version updates ON -- durable L0 (stays in this repo)
+  # ============================================================
 
   # ---- Python toolkit (Poetry) ----
   - package-ecosystem: "pip"
@@ -90,12 +41,9 @@ updates:
           - "minor"
           - "patch"
 
-  # ---- Container images ----
+  # ---- Container image: edge/errors (edge service, not an app) ----
   - package-ecosystem: "docker"
-    directories:
-      - "/apps/web"
-      - "/apps/api"
-      - "/edge/errors"
+    directory: "/edge/errors"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -107,7 +55,7 @@ updates:
       prefix: "fix"
       include: "scope"
     groups:
-      docker-minor-patch:
+      edge-docker-minor-patch:
         applies-to: version-updates
         update-types:
           - "minor"
@@ -133,3 +81,53 @@ updates:
           - "minor"
           - "patch"
           - "major"
+
+  # ============================================================
+  # Security-only -- apps departing to their own repos
+  # (open-pull-requests-limit: 0 -> no version PRs; security still flows)
+  # ============================================================
+
+  # ---- npm / Astro web apps (-> kubelab.live / mlorente.dev) ----
+  - package-ecosystem: "npm"
+    directories:
+      - "/apps/web/site"
+      - "/apps/web/astro-site"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "web"
+    ignore:
+      # Blocked: @astrojs/mdx@4 needs astro@^5. Lift with the Astro 6 migration.
+      - dependency-name: "astro"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "@astrojs/*"
+        update-types:
+          - "version-update:semver-major"
+
+  # ---- Go API (-> own repo) ----
+  - package-ecosystem: "gomod"
+    directory: "/apps/api/src"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "api"
+
+  # ---- App container images (-> own repos) ----
+  - package-ecosystem: "docker"
+    directories:
+      - "/apps/web"
+      - "/apps/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
## What

Calibrates `.github/dependabot.yml` so scheduled **version updates** run only for code that stays in L0; apps departing to their own repos are **security-only**.

| Ecosystem | Directory | Mode |
|---|---|---|
| pip (toolkit) | `/` | version updates |
| docker | `edge/errors` | version updates |
| github-actions | `/` | version updates |
| npm | `apps/web/*` | security-only (`limit: 0`) |
| gomod | `apps/api/src` | security-only (`limit: 0`) |
| docker | `apps/web`, `apps/api` | security-only (`limit: 0`) |

## Why

The initial full-coverage config (#618) opened a 14-PR burst on merge, much of it on apps slated to graduate to their own repos (WEB-002b kubelab.live, PUB-001 kubelab-cli, mlorente.dev). Managing versions on departing code is churn on the single self-hosted runner for little value.

`open-pull-requests-limit: 0` disables version-update PRs while **security updates keep flowing** and the **Astro-major ignore stays active**. The docker block is split so `edge/errors` (a durable edge service) keeps version updates while app images do not.

Aligns the live config with `docs/runbooks/dependency-updates.md` (#633).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized dependency update configuration for Docker ecosystems with dedicated grouping for edge services. Implemented security-only mode for npm packages, Go modules, and container images, restricting routine version updates while preserving critical security patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->