### PR TITLE
feat(ci): SHA tags + staging continuous-delivery (ADR-046 PR-C)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -83,37 +83,19 @@ jobs:
         if: steps.changes.outputs.should_build == 'true'
         env:
           BRANCH: ${{ github.ref_name }}
-          RUN_NUMBER: ${{ github.run_number }}
         run: |
-          SOURCE_DIR="${{ steps.changes.outputs.source_dir }}"
-          VERSION_FILE="${SOURCE_DIR}/version.txt"
-
-          # Read current version from version.txt (managed by release-please)
-          if [ -f "$VERSION_FILE" ]; then
-            BASE_VERSION=$(cat "$VERSION_FILE" | tr -d '[:space:]')
-          else
-            BASE_VERSION="0.0.0"
-          fi
-
           if [[ "$BRANCH" == "main" || "$BRANCH" == "master" || "$BRANCH" == release-please--* ]]; then
-            # Master + release-please branches: skip Docker (release.yml handles stable builds)
+            # Master + release-please: skip here. staging-deploy.yml builds the SHA
+            # tag on push to master; release.yml builds the stable semver on release
+            # (ADR-046 — no version prediction in this workflow).
             echo "version=skip" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping Docker build (release-please handles stable releases)"
+            echo "::notice::Skipping Docker build on master (staging-deploy.yml / release.yml handle it)"
           else
-            # Feature branches: predict next version from conventional commits
-            # Matches release-please behavior: feat→minor, fix→patch, breaking(!)→major
-            IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
-            COMMITS="$(git log origin/master..HEAD --oneline 2>/dev/null || echo '')"
-            if echo "$COMMITS" | grep -qE '^[a-f0-9]+ [a-z]+(\(.*\))?!:'; then
-              RC_BASE="$((MAJOR + 1)).0.0"
-            elif echo "$COMMITS" | grep -qE '^[a-f0-9]+ feat(\(.*\))?:'; then
-              RC_BASE="${MAJOR}.$((MINOR + 1)).0"
-            else
-              RC_BASE="${MAJOR}.${MINOR}.$((PATCH + 1))"
-            fi
-            FINAL_VERSION="${RC_BASE}-rc.${RUN_NUMBER}"
+            # Feature branches: immutable per-commit tag for pre-merge preview.
+            # release-please stays the sole authority for semver releases (ADR-046).
+            FINAL_VERSION="sha-${GITHUB_SHA::7}"
             echo "version=$FINAL_VERSION" >> "$GITHUB_OUTPUT"
-            echo "::notice::[DEV] Feature build: $FINAL_VERSION (next release after $BASE_VERSION)"
+            echo "::notice::[DEV] Feature build: $FINAL_VERSION"
           fi
 
       # API

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -74,12 +74,15 @@ jobs:
           echo "Branch: $BRANCH_NAME"
 
           case "$DOCKER_VERSION" in
-            *-rc.*)
+            sha-*)
+              # ADR-046: immutable per-commit build tag for staging. No mutable
+              # alias (no :dev, no :latest) — staging tracks this exact tag.
               FINAL_TAG="$DOCKER_VERSION"
-              DOCKER_TAGS="${REGISTRY}:${FINAL_TAG},${REGISTRY}:dev"
-              TAG_TYPE="rc"
+              DOCKER_TAGS="${REGISTRY}:${FINAL_TAG}"
+              TAG_TYPE="sha"
               ;;
             *)
+              # Stable semver release (release-please): immutable tag + :latest alias.
               FINAL_TAG="$DOCKER_VERSION"
               DOCKER_TAGS="${REGISTRY}:${FINAL_TAG},${REGISTRY}:latest"
               TAG_TYPE="stable"

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,124 @@
+---
+name: Deploy Staging
+# Continuous delivery to staging (ADR-046 D3 — PR-per-update). On each push to
+# master that changes app code, build an immutable `sha-<short>` image per
+# changed app, run `toolkit deployment promote --env staging`, and open a PR with
+# the regenerated overlay. Merging it (human + required checks) lets Argo CD sync
+# staging to master HEAD. Same mechanism as prod promotion; staging differs only
+# in that the PR is opened automatically here.
+#
+# The PR is opened with RELEASE_PLEASE_TOKEN (a PAT), NOT the default
+# GITHUB_TOKEN: a PR opened by GITHUB_TOKEN does not trigger `on: pull_request`
+# workflows, so its required checks would never run and it could never be merged.
+#
+# `paths: apps/**` means the promotion PR (which touches only infra/) does not
+# re-trigger this workflow — no loop.
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'apps/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      web: ${{ steps.filter.outputs.web }}
+      sha: ${{ steps.sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - 'apps/api/**'
+            web:
+              - 'apps/web/**'
+      - id: sha
+        run: echo "sha=sha-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+  build-web:
+    name: Build Web
+    needs: detect-changes
+    if: needs.detect-changes.outputs.web == 'true'
+    uses: ./.github/workflows/ci-publish.yml
+    with:
+      app: web
+      tag: ${{ needs.detect-changes.outputs.sha }}
+      sha: ${{ github.sha }}
+      context: ./apps/web
+      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
+    secrets: inherit
+
+  build-api:
+    name: Build API
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true'
+    uses: ./.github/workflows/ci-publish.yml
+    with:
+      app: api
+      tag: ${{ needs.detect-changes.outputs.sha }}
+      sha: ${{ github.sha }}
+      context: ./apps/api
+      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
+    secrets: inherit
+
+  open-pr:
+    name: Open Staging Deploy PR
+    needs: [detect-changes, build-web, build-api]
+    # Run if at least one app built successfully (skipped builds are not failures).
+    if: >-
+      always() &&
+      needs.detect-changes.result == 'success' &&
+      (needs.build-web.result == 'success' || needs.build-api.result == 'success')
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install toolkit
+        run: |
+          python -m pip install "poetry>=1.8,<2.0"
+          poetry install --only main
+      - name: Promote built apps to staging
+        env:
+          SHA: ${{ needs.detect-changes.outputs.sha }}
+          WEB_BUILT: ${{ needs.build-web.result }}
+          API_BUILT: ${{ needs.build-api.result }}
+        run: |
+          if [ "$WEB_BUILT" = "success" ]; then
+            poetry run toolkit deployment promote --env staging --app web --version "$SHA"
+          fi
+          if [ "$API_BUILT" = "success" ]; then
+            poetry run toolkit deployment promote --env staging --app api --version "$SHA"
+          fi
+      - name: Open staging deploy PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          SHA: ${{ needs.detect-changes.outputs.sha }}
+        run: |
+          git config user.name "kubelab-bot"
+          git config user.email "bot@kubelab.live"
+          git add infra/config/values/staging.yaml infra/k8s/overlays/staging/
+          if git diff --staged --quiet; then
+            echo "No staging overlay changes to promote"; exit 0
+          fi
+          BRANCH="deploy/staging-${SHA}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore(staging): deploy ${SHA}"
+          git push -u origin "$BRANCH" --force-with-lease
+          gh pr create --base master --head "$BRANCH" \
+            --title "chore(staging): deploy ${SHA}" \
+            --body "Automated staging promotion to \`${SHA}\` (ADR-046)."

--- a/docs/adr/adr-046-gitops-delivery-promotion-strategy.md
+++ b/docs/adr/adr-046-gitops-delivery-promotion-strategy.md
@@ -20,6 +20,17 @@ Accepted — 2026-06-14
 
 Extends and **supersedes the mechanism** of [ADR-037](adr-037-environment-promotion-strategy.md) "Pattern D — Image Tag Promotion". ADR-037's *goal* (staging auto-tracks, prod promoted by explicit PR) stands; its *assumed mechanism* (`argocd-image-updater`, tracked as the never-filed ARGO-014) is replaced by a CI-driven, controller-free design. ADR-037's reaffirmed decisions (trunk-based / Pattern A rejection; conditional selfHeal) are unchanged.
 
+## Amendment — 2026-06-15 (PR-per-update mechanism)
+
+Implementing D3/D4 surfaced a hard constraint: **`master` is fully protected** (`required_pull_request_reviews`, `enforce_admins: true`, required status checks) — nothing, not even an admin or CI, can push to it directly. The original D3 mechanism ("build on merge → commit the staging overlay bump to master") is therefore impossible.
+
+Resolution — **both lanes use one mechanism: promote-then-PR** (the industry "PR-per-update" pattern; keeps the protected single source of truth and runs required checks on every deploy):
+
+- **staging** — `staging-deploy.yml` (`on: push: master`, `paths: apps/**`) builds `sha-<short>` for each changed app, runs `toolkit deployment promote --env staging`, and **opens a PR** with the regenerated overlay. The human rubber-stamps it; Argo CD then syncs staging. The PR is opened with a PAT (`RELEASE_PLEASE_TOKEN`) so required checks fire (a `GITHUB_TOKEN`-opened PR would not trigger them). `paths: apps/**` stops the infra-only promotion PR from re-triggering the workflow.
+- **prod** — `promote-prod.yml` (`workflow_dispatch`) runs `toolkit deployment promote --env prod` and opens the PR on demand. The human reviews and merges.
+
+Both Argo Applications keep watching `master` — no rendered/deploy branch, no `targetRevision` change, no force-push to a protected branch. Rejected alternatives (rendered-manifests branch; `argocd-image-updater` `argocd` write-back) were viable but added a machine branch or in-cluster runtime; for a solo operator the per-deploy PR (self-reviewed for staging) is simpler and more auditable. The staging lane trades zero-touch continuity for one extra merge — accepted. Operational steps: `docs/runbooks/gitops-delivery-promotion.md`.
+
 ## Context
 
 ADR-037 (2026-05-23) decided the *what* of environment promotion but deferred the image-promotion *how* to "Pattern D", blocked on `argocd-image-updater` (ARGO-014). Pattern D never landed. A 2026-06-14 investigation found the interim state had drifted into a set of coupled defects:

--- a/docs/runbooks/gitops-delivery-promotion.md
+++ b/docs/runbooks/gitops-delivery-promotion.md
@@ -1,0 +1,50 @@
+# Runbook: GitOps Delivery & Promotion
+
+How code reaches staging and prod. Implements [ADR-046](../adr/adr-046-gitops-delivery-promotion-strategy.md). Both environments are Argo CD Applications watching `master`; nothing is pushed to `master` directly (it is protected) — every deploy is a reviewed PR.
+
+## Model at a glance
+
+| | staging | prod |
+|---|---|---|
+| Image tag | `sha-<short>` (immutable, per commit) | `X.Y.Z` (immutable semver, release-please) |
+| Trigger | auto on every `master` push touching `apps/**` | manual (`promote-prod.yml` workflow_dispatch) |
+| Gate | PR auto-opened, you rubber-stamp | PR opened on demand, you review |
+| `imagePullPolicy` | `Always` only for mutable tags; `sha-*`/semver → `IfNotPresent` (generator, tag-aware) | `IfNotPresent` |
+| selfHeal | false (mutable test bed) | true (system of record) |
+
+Image tags are **never reused as desired state**: a tag change is always a real git diff Argo reconciles. release-please is the sole authority for semver.
+
+## Deploy to staging (normal dev loop)
+
+1. Open a feature PR, get it green, merge to `master`.
+2. `staging-deploy.yml` fires automatically: builds `kubelab-<app>:sha-<short>` for each changed app, runs `toolkit deployment promote --env staging --app <app> --version sha-<short>`, regenerates the overlay, and opens a PR titled `chore(staging): deploy sha-<short>`.
+3. Review (a glance — the diff is the image tag) and **merge** it. Argo CD (staging) syncs and rolls the pods.
+4. Verify: `curl -sSI https://staging.mlorente.dev/` → 200, and spot-check the change.
+
+Pre-merge preview (optional): a feature-branch CI build also produces `sha-<pr-short>`; deploy it to staging out-of-band with `make deploy-k8s ENV=staging` (selfHeal:false tolerates it until the next sync).
+
+## Promote to prod (deliberate)
+
+1. Pick the stable version to ship (must already exist as a release tag — check `apps/<app>/version.txt` / the registry).
+2. Run the **Promote Prod** workflow (`promote-prod.yml`) via *Actions → Run workflow*, input `version` (and app). It runs `toolkit deployment promote --env prod --app <app> --version <X.Y.Z>` and opens a PR `promote: prod to <X.Y.Z>`.
+   - Or do it locally: `toolkit deployment promote --env prod --app web --version 1.2.0`, commit the regenerated overlay, open the PR.
+3. Review the PR (image diff + any config), ensure staging has validated equivalent code, **merge**. Argo CD (prod, selfHeal:true) deploys and then defends that version.
+
+## Rollback
+
+- **Either env:** `git revert` the deploy/promotion PR merge commit on `master` → Argo reconciles back to the previous tag. Prod self-heals to it immediately.
+- Immutable tags mean the previous image still exists; rollback is deterministic.
+
+## Troubleshooting
+
+- **Staging PR checks never run / stuck pending** → the PR must be opened by `RELEASE_PLEASE_TOKEN` (a PAT), not `GITHUB_TOKEN`; a GITHUB_TOKEN-opened PR does not trigger `on: pull_request` checks. Verify the token in `staging-deploy.yml`.
+- **`toolkit deployment promote` fails "tag not found"** → the image was not built/pushed yet (registry check is intentional — it refuses to promote a non-existent tag). Re-check the build job.
+- **Config-drift gate fails on the deploy PR** → the overlay was hand-edited instead of regenerated. Never edit `infra/k8s/overlays/<env>/generated/` by hand; always go through `toolkit deployment promote` (it regenerates atomically).
+- **Pod not picking up a new mutable tag** → only relevant for legacy mutable tags; `sha-*`/semver are immutable so a tag change always forces a pull. The generator sets `imagePullPolicy: Always` only for `dev`/`latest`/`*-rc.*`.
+- **Staging drifted from `master`** → expected within ≤1 sync cycle for out-of-band `make deploy-k8s` applies (selfHeal:false). The next `staging-deploy.yml` PR merge re-aligns it.
+
+## References
+
+- [ADR-046](../adr/adr-046-gitops-delivery-promotion-strategy.md) — the decision + the PR-per-update amendment.
+- [ADR-037](../adr/adr-037-environment-promotion-strategy.md) — conditional selfHeal; staging as mutable test bed.
+- Epic: `mlorentedev/knowledge#94`.


### PR DESCRIPTION
## What

Staging continuous-delivery lane + immutable SHA tag scheme — **ADR-046 PR-C** (epic mlorentedev/knowledge#94). Builds on the `deployment promote` command from #659.

- **`ci-publish.yml`** — `sha-*` → push only `:sha-xxx` (no `:dev`/`:latest`); stable semver → `:X.Y.Z` + `:latest`. Drops the `*-rc.*` → `:dev` case.
- **`ci-pipeline.yml`** — feature-branch version is now `sha-<short>` (immutable, per-commit). Removes the broken RC version predictor; release-please stays the sole semver authority.
- **`staging-deploy.yml`** (new) — `on: push: master` (`paths: apps/**`): build `sha-<short>` per changed app → `toolkit deployment promote --env staging` → **open a PR** with the regenerated overlay. Merging it lets Argo CD sync staging.
- **ADR-046 amendment** + **runbook** (`docs/runbooks/gitops-delivery-promotion.md`).

## Why PR-per-update (amendment)

`master` is fully protected (`enforce_admins: true`, required PR + checks) → CI **cannot** push the overlay bump directly. So both lanes use one mechanism: *promote → open PR → human merges*. Staging's PR is auto-opened; prod's is on-demand (`promote-prod.yml`, PR-D). Both Argo apps keep watching `master` — no rendered branch, no `targetRevision` change.

Key detail: the PR is opened with `RELEASE_PLEASE_TOKEN` (a PAT), **not** `GITHUB_TOKEN` — a GITHUB_TOKEN-opened PR doesn't trigger `on: pull_request` checks, so it could never be merged. `paths: apps/**` keeps the infra-only promotion PR from re-triggering this workflow (no loop).

## Validation

- ✅ yamllint (CI config) + markdownlint + gitleaks green.
- ⚠️ The `on: push: master` behavior (build → promote → open PR) can only be exercised **after merge** (first app change post-merge). Inherent to a push-triggered workflow; rollback is `git revert`. Injection-safe: only `GITHUB_SHA`/computed tag via `env:`, no untrusted event data in `run:`.

Next: **PR-D** — `promote-prod.yml` (same mechanism, `workflow_dispatch`) + first gated prod promotion off `:dev` → `:1.1.1`/`:1.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tagging strategy to use immutable per-commit identifiers instead of predictive version numbering.
  * Automated staging deployment workflow for code changes in the applications directory.

* **Documentation**
  * Added deployment promotion runbook documenting the staging and production promotion processes.
  * Updated architecture decision record with new promotion strategy details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->