### PR TITLE
feat(ci): prod promotion workflow (ADR-046 PR-D)

### DIFF
--- a/.github/workflows/promote-prod.yml
+++ b/.github/workflows/promote-prod.yml
@@ -1,0 +1,81 @@
+---
+name: Promote Prod
+# Continuous delivery to prod (ADR-046 — gated promotion). Manually dispatched:
+# pick a platform app and an existing immutable semver tag, run
+# `toolkit deployment promote --env prod`, and open a PR with the regenerated
+# overlay. Merging it (human review + required checks) lets Argo CD (prod,
+# selfHeal:true) sync and deploy that version, then defend it.
+#
+# Mirror of staging-deploy.yml, minus the build step: prod only ships tags that
+# already exist (built + released for staging). The promote command refuses a
+# non-existent registry tag, so a typo fails fast instead of ImagePullBackOff.
+#
+# Same PAT rationale as staging: the PR is opened with RELEASE_PLEASE_TOKEN, not
+# the default GITHUB_TOKEN. A GITHUB_TOKEN-opened PR does not trigger
+# `on: pull_request` workflows, so its required checks would never run and it
+# could never be merged.
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: Platform app to promote
+        type: choice
+        options:
+          - web
+          - api
+        required: true
+      version:
+        description: 'Immutable semver image tag (e.g. 1.1.1) — must already exist in the registry'
+        type: string
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# Serialize promotions of the same app; never cancel an in-flight one (it may be
+# mid-push). Different apps can promote concurrently.
+concurrency:
+  group: promote-prod-${{ inputs.app }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Promote Prod
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install toolkit
+        run: |
+          python -m pip install "poetry>=1.8,<2.0"
+          poetry install --only main
+      - name: Promote app to prod
+        env:
+          APP: ${{ inputs.app }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          poetry run toolkit deployment promote --env prod --app "$APP" --version "$VERSION"
+      - name: Open prod promotion PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          APP: ${{ inputs.app }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "kubelab-bot"
+          git config user.email "bot@kubelab.live"
+          git add infra/config/values/prod.yaml infra/k8s/overlays/prod/
+          if git diff --staged --quiet; then
+            echo "No prod overlay changes — ${APP} already at ${VERSION}"; exit 0
+          fi
+          BRANCH="promote/prod-${APP}-${VERSION}"
+          git checkout -b "$BRANCH"
+          git commit -m "promote: prod ${APP} to ${VERSION}"
+          git push -u origin "$BRANCH" --force-with-lease
+          gh pr create --base master --head "$BRANCH" \
+            --title "promote: prod ${APP} to ${VERSION}" \
+            --body "Gated prod promotion of \`${APP}\` to \`${VERSION}\` (ADR-046). Argo CD (prod) deploys on merge."

--- a/docs/runbooks/gitops-delivery-promotion.md
+++ b/docs/runbooks/gitops-delivery-promotion.md
@@ -26,7 +26,7 @@ Pre-merge preview (optional): a feature-branch CI build also produces `sha-<pr-s
 ## Promote to prod (deliberate)
 
 1. Pick the stable version to ship (must already exist as a release tag — check `apps/<app>/version.txt` / the registry).
-2. Run the **Promote Prod** workflow (`promote-prod.yml`) via *Actions → Run workflow*, input `version` (and app). It runs `toolkit deployment promote --env prod --app <app> --version <X.Y.Z>` and opens a PR `promote: prod to <X.Y.Z>`.
+2. Run the **Promote Prod** workflow (`promote-prod.yml`) via *Actions → Run workflow*, select the `app` and input the `version` (one app per run — web and api carry independent semvers). It runs `toolkit deployment promote --env prod --app <app> --version <X.Y.Z>` and opens a PR `promote: prod <app> to <X.Y.Z>`.
    - Or do it locally: `toolkit deployment promote --env prod --app web --version 1.2.0`, commit the regenerated overlay, open the PR.
 3. Review the PR (image diff + any config), ensure staging has validated equivalent code, **merge**. Argo CD (prod, selfHeal:true) deploys and then defends that version.
 


### PR DESCRIPTION
## What

Adds `promote-prod.yml` — a `workflow_dispatch`-driven, gated continuous-delivery path to prod. Completes the ADR-046 promotion model: staging is auto (PR-C), prod is deliberate.

Pick a platform app (`web`|`api`) and an existing immutable **semver** tag; the workflow runs `toolkit deployment promote --env prod`, regenerates the prod overlay, and opens a `promote: prod <app> to <version>` PR for human review. Argo CD (prod, `selfHeal:true`) deploys on merge and then defends that version.

## Why this shape

- **No build step** (unlike `staging-deploy.yml`): prod only ships tags already built + released. The promote command refuses a tag absent from the registry, so a typo fails fast instead of `ImagePullBackOff`.
- **`RELEASE_PLEASE_TOKEN`, not `GITHUB_TOKEN`**: a `GITHUB_TOKEN`-opened PR does not trigger `on: pull_request` checks, so required checks would never run and the PR could never merge.
- **Per-app, one run = one app**: web and api carry independent semvers (today `web 1.1.1`, `api 1.1.0`).
- **Injection-safe**: dispatch inputs are routed through `env:` vars and quoted in shell, never interpolated into `run:` blocks.

## Verification

- `actionlint` clean; `yamllint` + full pre-commit suite pass.
- Confirmed `kubelab-web:1.1.1` and `kubelab-api:1.1.0` exist on Docker Hub (200), so the first promotion will be valid.

## Out of scope (follow-up)

The **first gated promotion** (prod `:dev` → `web 1.1.1` / `api 1.1.0`) is intentionally **not** in this PR — it changes prod desired state and is a separate gated action, triggered via this workflow once merged. Keeps the CI change decoupled from a prod deploy.

Refs mlorentedev/knowledge#94 (ARGO-016).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a gated production deployment workflow enabling manual promotion of individual applications with controlled versioning management

* **Documentation**
  * Updated promotion runbook to clarify per-application deployment workflow and independent version tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->