### PR TITLE
promote: prod web to 1.1.1

### DIFF
--- a/infra/config/values/prod.yaml
+++ b/infra/config/values/prod.yaml
@@ -82,6 +82,7 @@ apps:
       enable_contact: false
 
   # Third-party services
+      version: 1.1.1
   services:
     core:
       gitea:

--- a/infra/k8s/overlays/prod/generated/deployments.yaml
+++ b/infra/k8s/overlays/prod/generated/deployments.yaml
@@ -35,8 +35,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: api-config
-            - secretRef:
-                name: api-secrets
           livenessProbe:
             httpGet:
               path: /health
@@ -88,8 +86,8 @@ spec:
     spec:
       containers:
         - name: web
-          image: docker.io/mlorentedev/kubelab-web:dev
-          imagePullPolicy: Always
+          image: docker.io/mlorentedev/kubelab-web:1.1.1
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Gated prod promotion of `web` to `1.1.1` (ADR-046). Argo CD (prod) deploys on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the production configuration to set `apps.platform.web` version to **1.1.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->