### PR TITLE
promote: prod api to 1.1.0

### DIFF
--- a/infra/config/values/prod.yaml
+++ b/infra/config/values/prod.yaml
@@ -67,6 +67,7 @@ apps:
       site_domain: kubelab.live
       site_url: https://kubelab.live
 
+      version: 1.1.0
     blog:
       domain: blog.kubelab.live
 

--- a/infra/k8s/overlays/prod/generated/deployments.yaml
+++ b/infra/k8s/overlays/prod/generated/deployments.yaml
@@ -26,8 +26,8 @@ spec:
     spec:
       containers:
         - name: api
-          image: docker.io/mlorentedev/kubelab-api:dev
-          imagePullPolicy: Always
+          image: docker.io/mlorentedev/kubelab-api:1.1.0
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 8080
@@ -35,8 +35,6 @@ spec:
           envFrom:
             - configMapRef:
                 name: api-config
-            - secretRef:
-                name: api-secrets
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
Gated prod promotion of `api` to `1.1.0` (ADR-046). Argo CD (prod) deploys on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production configuration with version 1.1.0 for the platform API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->