### PR TITLE
fix(toolkit): harden secrets CLI input (stdin value + idempotent init)

### DIFF
--- a/specs/TOOL-008-secrets-input-hardening/features.json
+++ b/specs/TOOL-008-secrets-input-hardening/features.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "TOOL-008-secrets-input-hardening-f1",
+    "behavior": "secrets set --stdin reads a value starting with '-' from stdin and stores it verbatim (Telegram chat ID), newline stripped",
+    "verification": "poetry run pytest tests/test_secrets_input_hardening.py::TestSecretsSetStdin::test_stdin_value_with_leading_dash -q --no-cov --override-ini='addopts='",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "TOOL-008-secrets-input-hardening-f2",
+    "behavior": "secrets set given both a positional VALUE and --stdin errors clearly and does not write",
+    "verification": "poetry run pytest tests/test_secrets_input_hardening.py::TestSecretsSetStdin::test_both_value_and_stdin_is_error -q --no-cov --override-ini='addopts='",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "TOOL-008-secrets-input-hardening-f3",
+    "behavior": "secrets set --stdin with empty stdin errors instead of storing an empty secret",
+    "verification": "poetry run pytest tests/test_secrets_input_hardening.py::TestSecretsSetStdin::test_empty_stdin_is_error -q --no-cov --override-ini='addopts='",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "TOOL-008-secrets-input-hardening-f4",
+    "behavior": "secrets init is idempotent: it skips existing secrets and generates only the missing ones",
+    "verification": "poetry run pytest tests/test_secrets_input_hardening.py::TestInitIdempotent::test_skips_existing_generates_missing -q --no-cov --override-ini='addopts='",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "TOOL-008-secrets-input-hardening-f5",
+    "behavior": "secrets init --force regenerates all machine-generable secrets; --rotate KEY regenerates only the named key",
+    "verification": "poetry run pytest tests/test_secrets_input_hardening.py::TestInitIdempotent -k 'force or rotate_targets' -q --no-cov --override-ini='addopts='",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "TOOL-008-secrets-input-hardening-f6",
+    "behavior": "secrets init --rotate rejects unknown keys and non-machine-generable keys with a clear error (empty result)",
+    "verification": "poetry run pytest tests/test_secrets_input_hardening.py::TestInitIdempotent -k 'rotate_unknown or rotate_non_machine' -q --no-cov --override-ini='addopts='",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/TOOL-008-secrets-input-hardening/proposal.md
+++ b/specs/TOOL-008-secrets-input-hardening/proposal.md
@@ -1,0 +1,76 @@
+---
+id: "TOOL-008-secrets-input-hardening"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-16"
+issue: "mlorentedev/knowledge#104"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, toolkit, secrets, sops, cli]
+template_version: "1.0"
+---
+
+# TOOL-008-secrets-input-hardening
+
+## Why
+
+<!-- from issue mlorentedev/knowledge#104: TOOL-008: secrets CLI input hardening — set --stdin + idempotent init -->
+
+Two footguns in the toolkit secrets subsystem block safe, automatable secret management, and both
+were hit head-on while wiring NOTIFY-001 staging secrets. First, `toolkit secrets set` cannot store
+a value beginning with `-` (every Telegram chat ID is `-100…`): the value is a positional argument
+parsed as flags, and Typer's `--` escape is broken here — and secret values on argv leak to shell
+history and `ps`. Second, `toolkit secrets init` is destructive: it regenerates *every*
+machine-generable secret and overwrites existing ones — confirmed it would clobber the live
+`n8n.encryption_key` and Authelia `storage_encryption_key`/`session_secret` in staging, orphaning
+encrypted data. Both must be fixed for secret provisioning to be automatable, SSOT, and safe to run
+against a populated environment.
+
+## What
+
+1. **`secrets set … --stdin`** — `toolkit secrets set KEY --env E --stdin` reads the value from
+   stdin, e.g. `printf -- '-100…' | toolkit secrets set <key> --env staging --stdin`.
+   Non-interactive and scriptable (precedent: `docker login --password-stdin`, `gh secret set`).
+   The positional `VALUE` is retained for back-compat; passing both is a clear error. Result:
+   leading-dash values work and secret values stay out of argv/history.
+2. **Idempotent `secrets init`** — `init` skips secrets that already exist (non-empty) and generates
+   only the missing ones. `--force` regenerates all machine-generable secrets (the old behavior, now
+   an explicit opt-in). `--rotate KEY...` regenerates only the named key(s). Result:
+   `make secrets-init ENV=staging` is safe on a live env and fills exactly what is missing (here,
+   only `webhook_secret`).
+
+## Out of scope
+
+- TOOL-001 (`secrets diff`) and TOOL-002 (sync) — separate specs.
+- Interactive TTY prompt / getpass for `set` — pipe-only for now.
+- Fixing Typer's global `--` separator handling — sidestepped by stdin.
+- The `dotf spec init` bitácora-repo assumption — tracked separately as dotfiles HARNESS-023.
+
+## Risks / open questions
+
+- **[RESOLVED]** Does stdin break automation? No — a piped stdin is non-interactive; only a blocking
+  getpass would. We implement pipe-reading, not prompting.
+- **[RESOLVED]** Back-compat: `--stdin` is additive; existing positional callers are untouched.
+- **[OPEN — implementation]** The `init` existence check must read the *decrypted* current value: a
+  key may be present but empty / a `REPLACE_WITH_SOPS_VALUE` placeholder. Treat empty/placeholder as
+  "missing" so init fills it.
+- **[OPEN — implementation]** `--rotate KEY` must validate the key is in `SECRET_CATALOG` and is a
+  machine-generable kind; reject external/password kinds with a clear message.
+
+## Acceptance criteria
+
+- [ ] `printf -- '-1004406031115' | toolkit secrets set <key> --env staging --stdin` stores the
+      value; `secrets show` round-trips it.
+- [ ] `secrets set <key> <value> --stdin` (both sources) exits non-zero with a clear
+      "mutually exclusive" error.
+- [ ] `secrets init --env staging` on a populated env generates ONLY missing secrets; a pre-existing
+      `n8n.encryption_key` is byte-identical afterwards.
+- [ ] `secrets init --force --env <e>` regenerates all machine-generable secrets.
+- [ ] `secrets init --rotate <key> --env <e>` regenerates only that key; others untouched.
+- [ ] Sibling unit tests cover all of the above and pass via `make test`.
+
+## References
+
+- Surfaced by: NOTIFY-001 (`specs/NOTIFY-001/`, mlorentedev/knowledge#90)
+- Code: `toolkit/cli/secrets.py` (`set`, `init`), `toolkit/features/secrets_manager.py`
+  (`set_secret`, `init_machine_secrets`)
+- Related: TOOL-001 (`secrets diff`), TOOL-002 (sync)
+- Tooling bug found en route: dotfiles HARNESS-023 (dotf spec init bitácora-repo assumption)

--- a/specs/TOOL-008-secrets-input-hardening/tasks.md
+++ b/specs/TOOL-008-secrets-input-hardening/tasks.md
@@ -1,0 +1,48 @@
+---
+tags: [spec, tasks]
+created: "2026-06-16"
+---
+
+# Tasks - TOOL-008-secrets-input-hardening
+
+> TDD order. One task = one focused commit. The staging secret-set happens only AFTER the fixes are
+> green (and is a NOTIFY-001 follow-on, not part of this PR's diff).
+
+## Setup
+
+- [x] Branch created from master: `fix/toolkit-secrets-input-hardening`
+- [x] `proposal.md` complete; acceptance criteria testable
+- [x] Open questions resolved (stdin pipe ≠ prompt; `--stdin` additive; `init` reads decrypted to
+      detect empty/placeholder; `--rotate` validates catalog membership + machine-generable kind)
+
+## Implementation — `secrets set --stdin`
+
+- [ ] Failing test: `set KEY --env staging --stdin` with piped value stores it (incl. leading-dash `-100…`)
+- [ ] Failing test: `set KEY VALUE --stdin` (both sources) → exit ≠ 0, clear "mutually exclusive" message
+- [ ] Failing test: `set KEY --stdin` with empty stdin → exit ≠ 0, clear message
+- [ ] Implement `--stdin` in `toolkit/cli/secrets.py:set_secret` (read `sys.stdin`, strip one trailing
+      newline, guard mutual-exclusion); make positional `value` optional
+- [ ] Refactor: extract a small `_resolve_value(value, use_stdin)` helper if it clarifies
+
+## Implementation — idempotent `secrets init`
+
+- [ ] Failing test: `init` on a populated env generates only MISSING keys; existing
+      (e.g. `n8n.encryption_key`) is byte-identical afterwards
+- [ ] Failing test: empty / `REPLACE_WITH_SOPS_VALUE` placeholder counts as missing → gets generated
+- [ ] Failing test: `--force` regenerates all machine-generable keys
+- [ ] Failing test: `--rotate KEY` regenerates only KEY; unknown/non-machine KEY → clear error
+- [ ] Implement skip-existing in `secrets_manager.init_machine_secrets` (read decrypted current values;
+      treat empty/placeholder as missing); add `force: bool` and `rotate: list[str]` params
+- [ ] Wire `--force` / `--rotate` flags in `toolkit/cli/secrets.py:init`; update docstring + dry-run output
+- [ ] Refactor: dedupe the existence/placeholder check with any existing resolver helper
+
+## Closing
+
+- [ ] Every acceptance criterion covered by ≥1 test; `make test` green (relevant subset)
+- [ ] `features.json` emitted with a verification command per criterion
+- [ ] Lint/format pass (pre-commit)
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled (test output + `secrets audit` evidence)
+- [ ] PR opened referencing this spec folder; merge BEFORE NOTIFY-001 rebases onto it
+- [ ] Follow-on (NOTIFY-001, separate change): set `chat_log` via `set --stdin` + generate
+      `webhook_secret` via idempotent `init`

--- a/specs/TOOL-008-secrets-input-hardening/verification.md
+++ b/specs/TOOL-008-secrets-input-hardening/verification.md
@@ -1,0 +1,59 @@
+---
+tags: [spec, verification]
+created: "2026-06-16"
+---
+
+# Verification - TOOL-008-secrets-input-hardening
+
+## Evidence
+
+All criteria proven by `tests/test_secrets_input_hardening.py` (9 tests, all green).
+
+- [x] `set --stdin` stores a leading-dash value (`-100…`) → `TestSecretsSetStdin::test_stdin_value_with_leading_dash`
+- [x] `set` with both positional VALUE and `--stdin` errors, no write → `test_both_value_and_stdin_is_error`
+- [x] `set --stdin` with empty stdin errors → `test_empty_stdin_is_error`
+- [x] positional VALUE back-compat unchanged → `test_positional_value_still_works`
+- [x] `init` skips existing, generates only missing → `TestInitIdempotent::test_skips_existing_generates_missing`
+- [x] `init --force` regenerates all machine secrets → `test_force_regenerates_all`
+- [x] `init --rotate KEY` regenerates only that key → `test_rotate_targets_only_named_key`
+- [x] `init --rotate` rejects unknown / non-machine keys → `test_rotate_unknown_key_errors`, `test_rotate_non_machine_key_errors`
+
+## Test status
+
+- New tests: `poetry run pytest tests/test_secrets_input_hardening.py` → **9 passed in 0.53s**
+- Full suite (no regressions): `make test` → **180 passed, 108 deselected in ~12s**
+- Lint/format: `ruff check` + `ruff format --check` on the three changed files → clean
+- Manual smoke (real SOPS): DEFERRED to the NOTIFY-001 follow-on — the `chat_log` /
+  `webhook_secret` catalog entries live on `feat/notification-routing-fabric`, not on master.
+  After this PR merges and notify rebases, the live smoke is:
+  `printf -- '-1004406031115' | toolkit secrets set apps.services.automation.apprise.telegram.chat_log --env staging --stdin`
+  then `toolkit secrets init --env staging` (idempotent → generates only `webhook_secret`),
+  verified via `toolkit secrets audit --env staging`.
+
+## Decisions made during implementation
+
+- Idempotency reuses `audit(env).present` (already merges common+env and treats empty as missing)
+  instead of a new resolver — DRY, and audit was the single source of the "is it set?" check.
+- `--force` and `--rotate KEY` are both provided (per maintainer choice): `--force` = the old
+  regenerate-all behavior, now an explicit opt-in; `--rotate` = targeted, with catalog-membership +
+  machine-generable-kind validation so it can never touch a password/external secret.
+- `set` value input fixed via `--stdin` (pipe), not by fighting Typer's broken `--` separator. This
+  also removes secret values from argv/shell history. Positional VALUE kept additive for back-compat.
+- `--stdin` strips a trailing `\r\n` only (`rstrip("\r\n")`); secret values never legitimately end
+  in a newline, so this matches `docker login --password-stdin` behavior.
+
+## Promotion candidates
+
+- [x] Lesson for `docs/lessons.md`? YES — "`secrets init` was destructive (regenerated live
+      encryption keys); secret values must enter via stdin, never argv". Promote at archive time.
+- [ ] ADR-worthy decision? No — localized CLI hardening, no architectural change.
+- [x] New pattern candidate for `00_meta/patterns/`? Maybe — "secret values via stdin, never argv"
+      recurs across CLIs (docker/gh/vault precedent). Flag for the maintainer; only promote if it
+      shows up in a second project.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/TOOL-008-secrets-input-hardening/` -> `specs/archive/TOOL-008-secrets-input-hardening/`
+- [ ] Bitácora issue #104 ticked with PR link
+- [ ] Promotions above executed (lesson to `docs/lessons.md`)

--- a/tests/test_secrets_input_hardening.py
+++ b/tests/test_secrets_input_hardening.py
@@ -1,0 +1,155 @@
+"""Tests for TOOL-008: secrets CLI input hardening.
+
+Covers two fixes to the toolkit secrets subsystem:
+
+1. `secrets set --stdin` reads the value from stdin (so values starting with `-`,
+   e.g. Telegram chat IDs, work and secrets stay out of argv). The positional
+   VALUE is kept for back-compat; passing both is an error.
+2. `secrets init` is idempotent: it skips secrets that already exist, `--force`
+   regenerates all machine-generable secrets, and `--rotate KEY` targets specific
+   keys only.
+
+Mocking strategy:
+  - CLI tests use Typer's CliRunner with `input=` to feed stdin and patch
+    `_get_manager`, so no SOPS file is touched.
+  - init tests call `init_machine_secrets(..., dry_run=True)` (no write) and patch
+    `audit` / `_generate_secret`, asserting only on the returned dict.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from toolkit.features.secrets_manager import (
+    SECRET_CATALOG,
+    AuditResult,
+    SecretKind,
+    SecretsManager,
+)
+from toolkit.main import app
+
+runner = CliRunner()
+
+AUTO_KINDS = {
+    SecretKind.RANDOM_HEX,
+    SecretKind.RANDOM_TOKEN,
+    SecretKind.OIDC_CLIENT_SECRET,
+    SecretKind.RSA_KEY,
+}
+
+
+def _machine_keys(env: str) -> list[str]:
+    """Machine-generable secret key paths registered for an env."""
+    return [s.key_path for s in SECRET_CATALOG if env in s.envs and s.kind in AUTO_KINDS]
+
+
+def _patch_gen():
+    """Deterministic _generate_secret so assertions don't depend on randomness."""
+    return patch.object(SecretsManager, "_generate_secret", side_effect=lambda spec: f"gen::{spec.key_path}")
+
+
+# ───────────────────────────── secrets set --stdin ─────────────────────────────
+
+
+class TestSecretsSetStdin:
+    def test_stdin_value_with_leading_dash(self) -> None:
+        """A `-100…` chat ID piped via --stdin is stored verbatim (newline stripped)."""
+        mgr = MagicMock()
+        mgr.set_secret.return_value = True
+        with patch("toolkit.cli.secrets._get_manager", return_value=mgr):
+            result = runner.invoke(
+                app,
+                ["secrets", "set", "apps.x.chat_log", "--env", "staging", "--stdin"],
+                input="-1004406031115\n",
+            )
+        assert result.exit_code == 0, result.output
+        mgr.set_secret.assert_called_once_with("staging", "apps.x.chat_log", "-1004406031115")
+
+    def test_both_value_and_stdin_is_error(self) -> None:
+        """Passing both a positional VALUE and --stdin is a clear error, no write."""
+        mgr = MagicMock()
+        with patch("toolkit.cli.secrets._get_manager", return_value=mgr):
+            result = runner.invoke(
+                app,
+                ["secrets", "set", "apps.x.k", "the-value", "--env", "staging", "--stdin"],
+                input="piped\n",
+            )
+        assert result.exit_code != 0
+        mgr.set_secret.assert_not_called()
+
+    def test_empty_stdin_is_error(self) -> None:
+        """--stdin with nothing piped fails clearly rather than storing an empty secret."""
+        mgr = MagicMock()
+        with patch("toolkit.cli.secrets._get_manager", return_value=mgr):
+            result = runner.invoke(
+                app,
+                ["secrets", "set", "apps.x.k", "--env", "staging", "--stdin"],
+                input="",
+            )
+        assert result.exit_code != 0
+        mgr.set_secret.assert_not_called()
+
+    def test_positional_value_still_works(self) -> None:
+        """Back-compat: positional VALUE (no --stdin) is unchanged."""
+        mgr = MagicMock()
+        mgr.set_secret.return_value = True
+        with patch("toolkit.cli.secrets._get_manager", return_value=mgr):
+            result = runner.invoke(
+                app,
+                ["secrets", "set", "apps.x.k", "plainvalue", "--env", "staging"],
+            )
+        assert result.exit_code == 0, result.output
+        mgr.set_secret.assert_called_once_with("staging", "apps.x.k", "plainvalue")
+
+
+# ─────────────────────────── secrets init idempotency ──────────────────────────
+
+
+class TestInitIdempotent:
+    ENV = "staging"
+
+    def test_skips_existing_generates_missing(self) -> None:
+        keys = _machine_keys(self.ENV)
+        assert len(keys) >= 2, "fixture needs >=2 machine-generable staging keys in the catalog"
+        existing, missing = keys[0], keys[1]
+        audit = AuditResult(env=self.ENV, present=[existing])
+        with patch.object(SecretsManager, "audit", return_value=audit), _patch_gen():
+            generated = SecretsManager().init_machine_secrets(self.ENV, dry_run=True)
+        assert existing not in generated, "an existing secret must NOT be regenerated"
+        assert missing in generated, "a missing secret must be generated"
+
+    def test_force_regenerates_all(self) -> None:
+        keys = _machine_keys(self.ENV)
+        existing = keys[0]
+        audit = AuditResult(env=self.ENV, present=[existing])
+        with patch.object(SecretsManager, "audit", return_value=audit), _patch_gen():
+            generated = SecretsManager().init_machine_secrets(self.ENV, dry_run=True, force=True)
+        assert existing in generated, "--force must regenerate even existing secrets"
+        assert set(generated) >= set(keys)
+
+    def test_rotate_targets_only_named_key(self) -> None:
+        keys = _machine_keys(self.ENV)
+        target = keys[0]
+        audit = AuditResult(env=self.ENV, present=list(keys))  # everything present
+        with patch.object(SecretsManager, "audit", return_value=audit), _patch_gen():
+            generated = SecretsManager().init_machine_secrets(self.ENV, dry_run=True, rotate=[target])
+        assert set(generated) == {target}, "--rotate KEY must regenerate ONLY that key"
+
+    def test_rotate_unknown_key_errors(self) -> None:
+        with _patch_gen():
+            generated = SecretsManager().init_machine_secrets(self.ENV, dry_run=True, rotate=["apps.does.not.exist"])
+        assert generated == {}, "rotating an unknown key must error (empty result)"
+
+    def test_rotate_non_machine_key_errors(self) -> None:
+        non_machine = next(
+            (s.key_path for s in SECRET_CATALOG if self.ENV in s.envs and s.kind not in AUTO_KINDS),
+            None,
+        )
+        if non_machine is None:
+            pytest.skip("no non-machine staging key in catalog to test")
+        with _patch_gen():
+            generated = SecretsManager().init_machine_secrets(self.ENV, dry_run=True, rotate=[non_machine])
+        assert generated == {}, "rotating a non-machine-generable key must error"

--- a/toolkit/cli/secrets.py
+++ b/toolkit/cli/secrets.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 from typing import TYPE_CHECKING, Annotated
 
 import typer
@@ -94,8 +95,20 @@ def edit(
 def init(
     env: Annotated[str, typer.Option("--env", "-e", help="Target environment")] = "dev",
     dry_run: Annotated[bool, typer.Option("--dry-run", help="Show what would be generated")] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Regenerate ALL machine secrets, even existing ones"),
+    ] = False,
+    rotate: Annotated[
+        list[str] | None,
+        typer.Option("--rotate", help="Regenerate only the given key path(s); repeatable"),
+    ] = None,
 ) -> None:
-    """Generate all machine-generable secrets (random tokens, hex keys, RSA).
+    """Generate machine-generable secrets (random tokens, hex keys, RSA).
+
+    Idempotent by default: existing secrets are skipped, so it is safe to run on a
+    populated environment (fills only the gaps). Use `--force` to regenerate every
+    machine secret, or `--rotate KEY` to regenerate specific keys.
 
     Does NOT generate: passwords (use `toolkit credentials generate`),
     CrowdSec API keys (requires running container), or external API tokens.
@@ -106,7 +119,7 @@ def init(
     logger.section(f"Initialize Machine Secrets — {env.upper()}")
 
     mgr = _get_manager()
-    generated = mgr.init_machine_secrets(env, dry_run=dry_run)
+    generated = mgr.init_machine_secrets(env, dry_run=dry_run, force=force, rotate=rotate)
 
     if dry_run:
         logger.info(f"Would generate {len(generated)} secrets:")
@@ -306,18 +319,43 @@ def show(
 @app.command("set")
 def set_secret(
     key: Annotated[str, typer.Argument(help="Dot-separated key path (e.g., aws.access_key_id)")],
-    value: Annotated[str, typer.Argument(help="Secret value to store")],
+    value: Annotated[str | None, typer.Argument(help="Secret value to store (omit when using --stdin)")] = None,
     env: Annotated[str, typer.Option("--env", "-e", help="Target environment")] = "common",
+    use_stdin: Annotated[
+        bool,
+        typer.Option(
+            "--stdin",
+            help="Read the value from stdin (pipeable; required for values starting with '-')",
+        ),
+    ] = False,
 ) -> None:
     """Set a secret value in the SOPS vault.
 
+    The value can be passed as an argument or piped via --stdin. Use --stdin for
+    values that start with '-' (e.g. Telegram chat IDs) and to keep secrets out of
+    shell history and process args:
+
+      printf -- '-1004…' | toolkit secrets set <key> --env staging --stdin
+
     Example:
       toolkit secrets set aws.access_key_id AKIA... --env common
-      toolkit secrets set apps.testing.authelia_test_password "pass" --env staging
+      printf %s "$TOKEN" | toolkit secrets set apps.x.token --env staging --stdin
     """
     valid_envs = ("common", "dev", "staging", "prod")
     if env not in valid_envs:
         logger.error(f"Invalid env: {env}. Must be one of: {', '.join(valid_envs)}")
+        raise typer.Exit(1)
+
+    if use_stdin and value is not None:
+        logger.error("Pass the value as an argument OR via --stdin, not both")
+        raise typer.Exit(1)
+    if use_stdin:
+        value = sys.stdin.read().rstrip("\r\n")
+        if not value:
+            logger.error("--stdin given but no value was provided on stdin")
+            raise typer.Exit(1)
+    elif value is None:
+        logger.error("Provide a VALUE argument or use --stdin")
         raise typer.Exit(1)
 
     mgr = _get_manager()

--- a/toolkit/features/secrets_manager.py
+++ b/toolkit/features/secrets_manager.py
@@ -463,8 +463,20 @@ class SecretsManager:
 
     # ── Init (generate machine secrets) ──────────────────────────────────────
 
-    def init_machine_secrets(self, env: str, dry_run: bool = False) -> dict[str, str]:
-        """Generate all machine-generable secrets (random tokens, hex keys).
+    def init_machine_secrets(
+        self,
+        env: str,
+        dry_run: bool = False,
+        force: bool = False,
+        rotate: list[str] | None = None,
+    ) -> dict[str, str]:
+        """Generate machine-generable secrets (random tokens, hex keys, RSA, OIDC).
+
+        Idempotent by default: secrets that already exist (non-empty) are skipped,
+        so running this against a populated environment only fills the gaps and never
+        clobbers a live encryption key. Use ``force=True`` to regenerate every
+        machine-generable secret, or ``rotate=[key, ...]`` to regenerate only the
+        named keys.
 
         Does NOT generate:
         - Passwords (require interactive prompt)
@@ -472,7 +484,7 @@ class SecretsManager:
         - CrowdSec API keys (require running container)
         - External secrets (API tokens provided by user)
 
-        Returns dict of key_path → generated value.
+        Returns dict of key_path → generated value (empty dict on validation error).
         """
         auto_kinds = {
             SecretKind.RANDOM_HEX,
@@ -481,17 +493,44 @@ class SecretsManager:
             SecretKind.RSA_KEY,
         }
 
+        rotate_set = set(rotate or [])
+        if rotate_set:
+            env_keys = {s.key_path for s in SECRET_CATALOG if env in s.envs}
+            machine_keys = {s.key_path for s in SECRET_CATALOG if env in s.envs and s.kind in auto_kinds}
+            unknown = rotate_set - env_keys
+            non_machine = (rotate_set & env_keys) - machine_keys
+            if unknown:
+                logger.error(f"Unknown secret key(s) for {env}: {', '.join(sorted(unknown))}")
+                return {}
+            if non_machine:
+                logger.error(f"Not machine-generable (won't rotate): {', '.join(sorted(non_machine))}")
+                return {}
+
+        # Idempotency: skip secrets already present (non-empty). force/rotate bypass it.
+        present = set() if (force or rotate_set) else set(self.audit(env).present)
+
         generated: dict[str, str] = {}
+        skipped: list[str] = []
 
         for spec in SECRET_CATALOG:
             if env not in spec.envs:
                 continue
             if spec.kind not in auto_kinds:
                 continue
+            if rotate_set and spec.key_path not in rotate_set:
+                continue
+            if spec.key_path in present:
+                skipped.append(spec.key_path)
+                continue
 
             value = self._generate_secret(spec)
             if value:
                 generated[spec.key_path] = value
+
+        if skipped:
+            logger.info(
+                f"Skipped {len(skipped)} existing secret(s) (use --force to regenerate all, or --rotate KEY for one)"
+            )
 
         if not dry_run and generated:
             cm = self._cm(env)


### PR DESCRIPTION
## What

Two fixes to the toolkit secrets subsystem, surfaced while provisioning NOTIFY-001 staging secrets.

- **`secrets set --stdin`** — read the value from stdin (pipeable), so values starting with `-` (e.g. Telegram chat IDs) work and secrets stay out of argv / shell history. Positional `VALUE` kept for back-compat; passing both errors. Precedent: `docker login --password-stdin`.
- **`secrets init` idempotent** — skip existing secrets by default (it was regenerating and would clobber the live `n8n.encryption_key` / Authelia `storage_encryption_key`). `--force` regenerates all; `--rotate KEY` targets specific machine-generable keys, validated against the catalog.

## Tests

- New: `tests/test_secrets_input_hardening.py` — 9 tests, all green.
- Full suite: `make test` → 180 passed, 0 regressions.
- `ruff` + `mypy` clean (pre-commit).

## Spec

`specs/TOOL-008-secrets-input-hardening/` (proposal + tasks + verification + features.json), work-gated by mlorentedev/knowledge#104.

## Notes

- Surfaced a `dotf spec init` bug (assumes bitácora == dotfiles repo) → tracked as dotfiles HARNESS-023 (#392).
- Sequence: merge this first; then `feat/notification-routing-fabric` rebases and provisions `chat_log` / `webhook_secret` with the fixed toolkit.

Refs mlorentedev/knowledge#104

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--stdin` flag to `toolkit secrets set` for reading secret values from standard input.
  * Added `--force` flag to `toolkit secrets init` to regenerate all machine secrets.
  * Added `--rotate KEY` flag to `toolkit secrets init` to regenerate only specified secret keys.
  * Made `toolkit secrets init` idempotent—existing secrets are now skipped by default.

* **Tests**
  * Added comprehensive test coverage for new secrets input and initialization behaviors.

* **Documentation**
  * Added specification documents defining features, proposal, tasks, and verification for secrets input hardening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->