### PR TITLE
fix(k8s): deterministically mount <app>-secrets (prod api CrashLoop)

### DIFF
--- a/infra/k8s/overlays/prod/generated/deployments.yaml
+++ b/infra/k8s/overlays/prod/generated/deployments.yaml
@@ -35,6 +35,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: api-config
+            - secretRef:
+                name: api-secrets
           livenessProbe:
             httpGet:
               path: /health

--- a/tests/test_k8s_generator_secrets.py
+++ b/tests/test_k8s_generator_secrets.py
@@ -1,0 +1,62 @@
+"""Regression tests for K8sGenerator secret-mount wiring.
+
+Guards the fix for the prod incident where `kubelab-api:1.1.0` CrashLoop'd with
+`panic: SMTP credentials ... required in production`: the api Deployment never
+referenced `api-secrets`, so `INFRA_SMTP_PASS` was provisioned but never injected.
+
+Root cause: the old `_has_secret_vars` heuristic scanned `APPS_PLATFORM_<APP>_*`
+env vars for secret patterns, so its result depended on whether SOPS happened to
+be decrypted at generation time (a non-deterministic generator) and was blind to
+*shared* `INFRA_*` secrets. The fix ties the mount to the secrets SSOT
+(`SECRET_DEFINITIONS`): a Deployment mounts `<app>-secrets` iff that mapping
+exists — deterministic, SOPS-independent, and impossible to silently diverge.
+"""
+
+from __future__ import annotations
+
+from toolkit.config.constants import COMPONENTS
+from toolkit.features.generator_k8s import K8sGenerator
+from toolkit.features.k8s_secrets import SECRET_DEFINITIONS
+
+
+class TestHasSecretVars:
+    """`_has_secret_vars` is driven by the secrets SSOT, not env-var heuristics."""
+
+    def test_api_mounts_its_secret(self) -> None:
+        # api-secrets carries INFRA_SMTP_PASS (shared) + BEEHIIV/ZOHO keys. The
+        # api workload requires them at boot, so the Deployment must envFrom it.
+        assert K8sGenerator()._has_secret_vars("api") is True
+
+    def test_web_has_no_secret_mount(self) -> None:
+        # There is no `web-secrets` mapping; web sends no mail and owns no
+        # secrets. Mounting a non-existent secret would CrashLoop web — this is
+        # the regression the registry approach must never reintroduce.
+        assert K8sGenerator()._has_secret_vars("web") is False
+        assert not any(m.name == "web-secrets" for m in SECRET_DEFINITIONS)
+
+    def test_mount_decision_matches_registry_for_every_platform_app(self) -> None:
+        """The single invariant: mount iff `<app>-secrets` is defined in the SSOT."""
+        registered = {m.name for m in SECRET_DEFINITIONS}
+        gen = K8sGenerator()
+        for app in COMPONENTS.PLATFORM_APPS:
+            expected = f"{app}-secrets" in registered
+            assert gen._has_secret_vars(app) is expected, (
+                f"{app}: mount decision must equal presence of {app}-secrets in "
+                "SECRET_DEFINITIONS (the secrets SSOT)"
+            )
+
+    def test_is_sops_independent(self) -> None:
+        """No env_vars/SOPS input means the result cannot vary by decryption state.
+
+        Repeated calls (and the absence of any env-var argument) make the
+        generator deterministic: CI (no age key) and local (SOPS) now emit
+        identical overlays, so the ADR-027 drift gate is meaningful again.
+        """
+        gen = K8sGenerator()
+        assert gen._has_secret_vars("api") is gen._has_secret_vars("api")
+
+    def test_api_secret_includes_shared_infra_key(self) -> None:
+        """Documents the incident's trigger: api's secret is mostly a *shared*
+        INFRA_ secret, which the old `APPS_PLATFORM_API_*` heuristic could miss."""
+        api_secret = next(m for m in SECRET_DEFINITIONS if m.name == "api-secrets")
+        assert "INFRA_SMTP_PASS" in api_secret.keys

--- a/toolkit/features/generator_k8s.py
+++ b/toolkit/features/generator_k8s.py
@@ -7,6 +7,7 @@ from toolkit.core.logging import logger
 from toolkit.core.templating import create_renderer
 from toolkit.features.configuration import ConfigurationManager
 from toolkit.features.generator_base import BaseGenerator
+from toolkit.features.k8s_secrets import SECRET_DEFINITIONS
 
 
 class K8sGenerator(BaseGenerator):
@@ -215,8 +216,8 @@ class K8sGenerator(BaseGenerator):
             app_env_vars = self._extract_app_env_vars(env_vars, component)
             app_env_vars["ENVIRONMENT"] = env
 
-            # Check if app has secret-pattern vars (needs a K8s Secret)
-            has_secrets = self._has_secret_vars(env_vars, component)
+            # Mount <app>-secrets iff one is defined in the secrets SSOT.
+            has_secrets = self._has_secret_vars(component)
 
             # Middleware list for IngressRoute
             middlewares = self._build_middlewares(env_vars, enable_auth)
@@ -300,29 +301,29 @@ class K8sGenerator(BaseGenerator):
 
         return result
 
-    def _has_secret_vars(self, env_vars: dict[str, str], component: str) -> bool:
-        """Check if a component has any secret-pattern environment variables.
+    def _has_secret_vars(self, component: str) -> bool:
+        """Whether a K8s Secret is defined for this component (→ mount it via envFrom).
+
+        The single source of truth for which secrets exist is SECRET_DEFINITIONS
+        (``k8s_secrets.py``). The deployment mounts ``<component>-secrets`` iff a
+        mapping of that name is registered there.
+
+        This deliberately replaces an env-var-pattern heuristic that was blind to
+        *shared* ``INFRA_*`` secrets: ``INFRA_SMTP_PASS`` lives under the ``INFRA_``
+        prefix, not ``APPS_PLATFORM_<COMPONENT>_``, so the heuristic returned False
+        for ``api`` and the deployment never referenced ``api-secrets`` — the
+        secret was provisioned but never injected, panicking images that require it
+        at boot. Tying the mount to the registry keeps provisioning and consumption
+        from silently diverging.
 
         Args:
-            env_vars: Flattened environment variables
             component: Component name
 
         Returns:
-            True if the component has vars matching SECRET_PATTERNS
+            True if a ``<component>-secrets`` mapping exists in SECRET_DEFINITIONS
         """
-        component_upper = component.upper().replace("-", "_")
-        prefix = f"APPS_PLATFORM_{component_upper}_"
-
-        for key in env_vars:
-            if not key.startswith(prefix):
-                continue
-            suffix = key[len(prefix) :]
-            if suffix in self._METADATA_SUFFIXES or suffix.startswith("RESOURCES_"):
-                continue
-            parts = suffix.split("_")
-            if any(part in VALIDATION_RULES.SECRET_PATTERNS for part in parts):
-                return True
-        return False
+        secret_name = f"{component}-secrets"
+        return any(mapping.name == secret_name for mapping in SECRET_DEFINITIONS)
 
     def _build_middlewares(self, env_vars: dict[str, str], enable_auth: bool) -> list[str]:
         """Build IngressRoute middleware list.


### PR DESCRIPTION
## Incident

Merging the first gated prod promotion (`api` → `1.1.0`, #664) put the new pod into `CrashLoopBackOff`:

```
panic: SMTP credentials (INFRA_SMTP_HOST, USER, PASS) are required in production
  at internal/services/beehiiv.go:24 (init)
```

No outage — the rolling update held the old `:dev` pod (Ready) while the new one never became Ready, so the Service kept serving. `web 1.1.1` was unaffected.

## Root cause — a non-deterministic generator

The api `Deployment` referenced **only** `configMapRef: api-config`, never `secretRef: api-secrets`, so `INFRA_SMTP_PASS` (present in the cluster Secret for 86d) was never injected. `1.1.0` added an init guard requiring it; `:dev` had none, which is why nothing failed before.

The old `_has_secret_vars` scanned `APPS_PLATFORM_<APP>_*` env vars for secret patterns. That made the result **depend on whether SOPS was decrypted at generation time**:

- The prod overlay was committed from a **SOPS-less** generate → the api secret keys were absent → `has_secrets=False` → **no `secretRef`**.
- Staging was generated **with** SOPS → it had the `secretRef` all along.
- The ADR-027 drift check runs in CI **without** SOPS, so it regenerated the same secret-less output and **went green** — the gate shared the blind spot.

It was also blind to *shared* `INFRA_*` secrets (`INFRA_SMTP_PASS` lives under `INFRA_`, not `APPS_PLATFORM_API_`).

## Fix

Tie the mount to the secrets SSOT: a `Deployment` mounts `<app>-secrets` **iff** that mapping exists in `SECRET_DEFINITIONS`. Deterministic and SOPS-independent → CI and local emit identical overlays and the drift gate is meaningful again. Regenerates the prod overlay to add the missing `secretRef` (`+2` lines); staging unchanged. `web` stays correct (no `web-secrets` → no mount).

## Verification

- New `tests/test_k8s_generator_secrets.py` (5 tests): mount decision == registry presence for every platform app; web never mounts; SOPS-independence; api-secret carries the shared `INFRA_SMTP_PASS`. Full suite + `ruff`/`mypy` green.
- **Validated on staging**: rolled `api:1.1.0` onto staging (which has the `secretRef`) → `successfully rolled out`, `INFRA_SMTP_PASS` injected (`SET`), `/health` 200, no panic. Argo reverted staging to declared `:dev` after.

On merge, Argo regenerates prod with the `secretRef` → `api:1.1.0` boots → prod heals.

## Follow-ups (filed separately, do not let this hide them)

1. Staging runs `:dev`, not the candidate immutable build — it never exercises the artifact promoted to prod (ADR-046 loose end).
2. Staging runs `ENVIRONMENT=staging`, so `production`-gated guards don't fire there — staging can't catch production-only failures.
3. Drift check runs without SOPS; audit for other SOPS-dependent generation that could green falsely.

Refs mlorentedev/knowledge#94 (ARGO-016).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test suite validating deterministic Kubernetes secret mounting decisions.

* **Refactor**
  * Updated secret mounting logic to use centralized registry instead of environment variable pattern inspection, improving consistency and reliability of secret mount decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->