### PR TITLE
feat(ci): toolkit-driven image-tag cleanup + shared registry module (ADR-046 PR-E)

### DIFF
--- a/.github/workflows/ci-cleanup.yml
+++ b/.github/workflows/ci-cleanup.yml
@@ -1,194 +1,51 @@
 ---
-name: Cleanup RC Tags
-
+name: Cleanup Image Tags
+# Janitor for ephemeral Docker Hub tags (ADR-046). Staging runs immutable
+# `sha-<short>` tags (one per app per merge), so they accumulate forever unless
+# pruned. Delegates to `toolkit registry prune` — the retention policy and the
+# Docker Hub client live in the toolkit (unit-tested, shared with promotion),
+# not reimplemented in YAML.
+#
+# Keeps the N most recent `sha-*` per app + deletes the rest and any leftover
+# `-rc.*` (dropped scheme). Prod runs immutable semver and is never touched.
 on:
-  pull_request:
-    branches: [master]
-    types: [closed]
+  schedule:
+    - cron: '0 4 * * 1'  # Mondays 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: List what would be deleted, delete nothing
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
-jobs:
+concurrency:
+  group: cleanup-image-tags
+  cancel-in-progress: false
 
-  detect-changes:
-    name: Detect Changes
-    runs-on: >-
-      ${{ github.event.pull_request.head.repo.fork
-          && 'ubuntu-latest'
-          || fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
-    outputs:
-      changed_apps: ${{ steps.list.outputs.apps }}
-      any_changed: ${{ steps.check.outputs.any_changed }}
+jobs:
+  cleanup:
+    name: Cleanup Image Tags
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
     steps:
       - uses: actions/checkout@v4
-
-      - id: filter
-        uses: dorny/paths-filter@v3
+      - uses: actions/setup-python@v5
         with:
-          filters: |
-            api:
-              - 'apps/api/**'
-            web:
-              - 'apps/web/**'
-            errors:
-              - 'edge/errors/**'
-
-      - name: Check if any app changed
-        id: check
-        env:
-          API: ${{ steps.filter.outputs.api }}
-          WEB: ${{ steps.filter.outputs.web }}
-          ERRORS: ${{ steps.filter.outputs.errors }}
+          python-version: '3.12'
+      - name: Install toolkit
         run: |
-          if [[ "$API" == "true" || "$WEB" == "true" \
-            || "$ERRORS" == "true" ]]; then
-            echo "any_changed=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "any_changed=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: List changed apps
-        id: list
-        env:
-          API: ${{ steps.filter.outputs.api }}
-          WEB: ${{ steps.filter.outputs.web }}
-          ERRORS: ${{ steps.filter.outputs.errors }}
-        run: |
-          apps=()
-          [[ "$API" == "true" ]] && apps+=("api")
-          [[ "$WEB" == "true" ]] && apps+=("web")
-          [[ "$ERRORS" == "true" ]] && apps+=("errors")
-          apps_json=$(printf '%s\n' "${apps[@]}" \
-            | jq -R . | jq -c -s .)
-          echo "apps=${apps_json}" >> "$GITHUB_OUTPUT"
-
-  cleanup-rc-tags:
-    name: Cleanup RC Tags
-    needs: detect-changes
-    if: needs.detect-changes.outputs.any_changed == 'true'
-    runs-on: >-
-      ${{ github.event.pull_request.head.repo.fork
-          && 'ubuntu-latest'
-          || fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
-    env:
-      REGISTRY_PREFIX: ${{ vars.REGISTRY_PREFIX || 'kubelab' }}
-    steps:
-      - name: Authenticate with Docker Hub
-        id: auth
+          python -m pip install "poetry>=1.8,<2.0"
+          poetry install --only main
+      - name: Prune stale image tags
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+          RETENTION: ${{ vars.SHA_TAG_RETENTION || '15' }}
+          PREFIX: ${{ vars.REGISTRY_PREFIX || 'kubelab' }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
-          TOKEN=$(curl -s -X POST \
-            "https://hub.docker.com/v2/users/login" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\
-          \"password\":\"${DOCKERHUB_TOKEN}\"}" \
-            | jq -r '.token')
-
-          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-            echo "::error::Failed to authenticate"
-            exit 1
-          fi
-
-          echo "::add-mask::${TOKEN}"
-          echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"
-
-      - name: Delete RC tags for changed apps
-        env:
-          HUB_TOKEN: ${{ steps.auth.outputs.token }}
-          CHANGED_APPS: ${{ needs.detect-changes.outputs.changed_apps }}
-          NAMESPACE: ${{ secrets.DOCKERHUB_USERNAME }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_MERGED: ${{ github.event.pull_request.merged }}
-        run: |
-          {
-            echo "## RC Tag Cleanup Summary"
-            echo ""
-            echo "**PR:** #${PR_NUMBER}"
-            if [ "$PR_MERGED" = "true" ]; then
-              echo "**Status:** Merged"
-            else
-              echo "**Status:** Closed"
-            fi
-            echo ""
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          TOTAL_DELETED=0
-
-          for APP in $(echo "$CHANGED_APPS" | jq -r '.[]'); do
-            REPO="${REGISTRY_PREFIX}-${APP}"
-            echo "--- Processing ${NAMESPACE}/${REPO} ---"
-            echo "### ${REPO}" >> "$GITHUB_STEP_SUMMARY"
-
-            # Paginate through all tags
-            PAGE=1
-            RC_TAGS=()
-            while true; do
-              URL="https://hub.docker.com/v2/repositories"
-              URL="${URL}/${NAMESPACE}/${REPO}/tags"
-              RESPONSE=$(curl -s \
-                "${URL}/?page_size=100&page=${PAGE}" \
-                -H "Authorization: Bearer ${HUB_TOKEN}")
-
-              TAGS=$(echo "$RESPONSE" \
-                | jq -r '.results[]?.name // empty' \
-                | grep -E '\-rc\.' || true)
-
-              if [ -n "$TAGS" ]; then
-                while IFS= read -r tag; do
-                  RC_TAGS+=("$tag")
-                done <<< "$TAGS"
-              fi
-
-              NEXT=$(echo "$RESPONSE" \
-                | jq -r '.next // empty')
-              if [ -z "$NEXT" ] || [ "$NEXT" = "null" ]; then
-                break
-              fi
-              PAGE=$((PAGE + 1))
-            done
-
-            if [ ${#RC_TAGS[@]} -eq 0 ]; then
-              echo "No RC tags found for ${REPO}"
-              echo "No RC tags found." >> "$GITHUB_STEP_SUMMARY"
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-              continue
-            fi
-
-            echo "Found ${#RC_TAGS[@]} RC tag(s) to delete"
-            DELETED=0
-            FAILED=0
-
-            for TAG in "${RC_TAGS[@]}"; do
-              URL="https://hub.docker.com/v2/repositories"
-              URL="${URL}/${NAMESPACE}/${REPO}/tags/${TAG}/"
-              HTTP_CODE=$(curl -s -o /dev/null \
-                -w "%{http_code}" -X DELETE "${URL}" \
-                -H "Authorization: Bearer ${HUB_TOKEN}")
-
-              if [ "$HTTP_CODE" -eq 204 ] \
-                || [ "$HTTP_CODE" -eq 404 ]; then
-                echo "  Deleted: ${TAG}"
-                DELETED=$((DELETED + 1))
-              else
-                echo "  Failed: ${TAG} (HTTP ${HTTP_CODE})"
-                FAILED=$((FAILED + 1))
-              fi
-            done
-
-            TOTAL_DELETED=$((TOTAL_DELETED + DELETED))
-            {
-              echo "Deleted ${DELETED}/${#RC_TAGS[@]} tags"
-              if [ "$FAILED" -gt 0 ]; then
-                echo "(${FAILED} failed)"
-              fi
-              echo ""
-            } >> "$GITHUB_STEP_SUMMARY"
-          done
-
-          {
-            echo "---"
-            echo "**Total deleted: ${TOTAL_DELETED}**"
-          } >> "$GITHUB_STEP_SUMMARY"
+          ARGS=(--retention "$RETENTION" --registry-prefix "$PREFIX")
+          [ "$DRY_RUN" = "true" ] && ARGS+=(--dry-run)
+          poetry run toolkit registry prune "${ARGS[@]}"

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from toolkit.features import promotion
+from toolkit.features import promotion, registry
 
 _VALUES = """\
 # top-of-file comment must survive a round-trip edit
@@ -45,7 +45,8 @@ def env_patched(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> tuple[Path, 
 
 
 def _mock_registry(monkeypatch: pytest.MonkeyPatch, status_code: int) -> None:
-    monkeypatch.setattr(promotion.httpx, "get", MagicMock(return_value=MagicMock(status_code=status_code)))
+    # The tag-existence check now lives in the registry module (promotion reuses it).
+    monkeypatch.setattr(registry.httpx, "get", MagicMock(return_value=MagicMock(status_code=status_code)))
 
 
 class TestPromote:

--- a/tests/test_registry_prune.py
+++ b/tests/test_registry_prune.py
@@ -1,0 +1,118 @@
+"""Tests for registry — Docker Hub client + tag-prune policy (ADR-046).
+
+The retention policy (`select_stale_tags`) is pure and gets the bulk of the
+coverage; the client and orchestration are exercised with httpx mocked / a fake
+client so no network is touched.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from toolkit.features import registry
+from toolkit.features.registry import DockerHubClient, TagInfo, prune, select_stale_tags
+
+
+def _tag(name: str, ts: str = "2026-01-01T00:00:00Z") -> TagInfo:
+    return TagInfo(name=name, last_updated=ts)
+
+
+class TestSelectStaleTags:
+    """Keep newest N sha-*, delete the rest + all -rc.*; never touch semver/mutable."""
+
+    def test_keeps_newest_n_sha_deletes_older(self) -> None:
+        tags = [
+            _tag("sha-aaaaaaa", "2026-06-01T00:00:00Z"),
+            _tag("sha-bbbbbbb", "2026-06-03T00:00:00Z"),
+            _tag("sha-ccccccc", "2026-06-02T00:00:00Z"),
+        ]
+        # newest two (bbb, ccc) retained; oldest (aaa) is stale.
+        assert select_stale_tags(tags, retention=2) == ["sha-aaaaaaa"]
+
+    def test_deletes_all_rc(self) -> None:
+        tags = [_tag("1.2.0-rc.1"), _tag("1.2.0-rc.2"), _tag("1.2.0")]
+        assert set(select_stale_tags(tags, retention=10)) == {"1.2.0-rc.1", "1.2.0-rc.2"}
+
+    def test_never_touches_semver_or_mutable(self) -> None:
+        tags = [_tag("1.1.0"), _tag("latest"), _tag("dev")]
+        assert select_stale_tags(tags, retention=0) == []
+
+    def test_retention_zero_deletes_all_sha(self) -> None:
+        assert set(select_stale_tags([_tag("sha-a"), _tag("sha-b")], retention=0)) == {"sha-a", "sha-b"}
+
+    def test_fewer_than_retention_keeps_all(self) -> None:
+        assert select_stale_tags([_tag("sha-a"), _tag("sha-b")], retention=15) == []
+
+    def test_negative_retention_rejected(self) -> None:
+        with pytest.raises(ValueError, match="retention"):
+            select_stale_tags([], retention=-1)
+
+
+class TestDockerHubClient:
+    def test_list_tags_paginates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        pages = [
+            MagicMock(
+                status_code=200,
+                **{"json.return_value": {"results": [{"name": "sha-a", "last_updated": "t1"}], "next": "url2"}},
+            ),
+            MagicMock(
+                status_code=200,
+                **{"json.return_value": {"results": [{"name": "sha-b", "last_updated": "t2"}], "next": None}},
+            ),
+        ]
+        get = MagicMock(side_effect=pages)
+        monkeypatch.setattr(registry.httpx, "get", get)
+
+        tags = DockerHubClient(namespace="ns", token="t").list_tags("kubelab-api")
+
+        assert [t.name for t in tags] == ["sha-a", "sha-b"]
+        assert get.call_count == 2
+
+    def test_list_tags_missing_repo_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(registry.httpx, "get", MagicMock(return_value=MagicMock(status_code=404)))
+        assert DockerHubClient(namespace="ns").list_tags("nope") == []
+
+    def test_delete_tag_treats_204_and_404_as_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        for code in (204, 404):
+            monkeypatch.setattr(registry.httpx, "delete", MagicMock(return_value=MagicMock(status_code=code)))
+            assert DockerHubClient(namespace="ns", token="t").delete_tag("repo", "sha-x") is True
+
+    def test_delete_tag_failure_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(registry.httpx, "delete", MagicMock(return_value=MagicMock(status_code=401)))
+        assert DockerHubClient(namespace="ns", token="t").delete_tag("repo", "sha-x") is False
+
+    def test_from_env_requires_credentials(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("DOCKERHUB_USERNAME", raising=False)
+        monkeypatch.delenv("DOCKERHUB_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="DOCKERHUB_USERNAME"):
+            DockerHubClient.from_env()
+
+
+class TestPrune:
+    def _client(self, tags: list[TagInfo], delete_ok: bool = True) -> MagicMock:
+        c = MagicMock()
+        c.list_tags.return_value = tags
+        c.delete_tag.return_value = delete_ok
+        return c
+
+    def test_dry_run_deletes_nothing(self) -> None:
+        client = self._client([_tag("sha-a", "t1"), _tag("sha-b", "t2"), _tag("sha-c", "t3")])
+        n = prune(["api"], "kubelab", retention=1, dry_run=True, client=client)
+        client.delete_tag.assert_not_called()
+        assert n == 2  # two stale would be deleted
+
+    def test_deletes_stale_keeps_newest_and_semver(self) -> None:
+        tags = [_tag("sha-a", "t1"), _tag("sha-b", "t3"), _tag("sha-c", "t2"), _tag("1.0.0", "t9")]
+        client = self._client(tags)
+        n = prune(["api"], "kubelab", retention=1, dry_run=False, client=client)
+        deleted = {call.args[1] for call in client.delete_tag.call_args_list}
+        assert n == 2
+        assert deleted == {"sha-a", "sha-c"}  # sha-b (newest) and 1.0.0 (semver) kept
+
+    def test_repo_name_uses_prefix(self) -> None:
+        client = self._client([])
+        prune(["api", "web"], "kubelab", retention=15, dry_run=False, client=client)
+        repos = {call.args[0] for call in client.list_tags.call_args_list}
+        assert repos == {"kubelab-api", "kubelab-web"}

--- a/toolkit/cli/registry.py
+++ b/toolkit/cli/registry.py
@@ -1,0 +1,49 @@
+"""Container registry commands."""
+
+from typing import Annotated
+
+import typer
+
+from toolkit.core.logging import logger
+from toolkit.features import registry
+
+app = typer.Typer(
+    name="registry",
+    help="Container registry maintenance (tag pruning).",
+    no_args_is_help=True,
+)
+
+
+@app.command()
+def prune(
+    apps: Annotated[
+        str,
+        typer.Option("--apps", help="Comma-separated app names (repo = <prefix>-<app>)"),
+    ] = "api,web,errors",
+    retention: Annotated[
+        int,
+        typer.Option("--retention", "-n", help="Keep this many most-recent sha-* tags per app"),
+    ] = 15,
+    registry_prefix: Annotated[
+        str,
+        typer.Option("--registry-prefix", help="Image repo prefix"),
+    ] = "kubelab",
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="List what would be deleted without deleting"),
+    ] = False,
+) -> None:
+    """
+    Prune ephemeral image tags (ADR-046).
+
+    Keeps the N most recent immutable ``sha-*`` tags per app (rollback headroom)
+    and deletes the rest, plus any leftover ``-rc.*`` tags. Prod runs semver and
+    is never touched. Needs ``DOCKERHUB_USERNAME``/``DOCKERHUB_TOKEN`` in the env.
+    """
+    logger.section(f"Registry Prune{' (dry-run)' if dry_run else ''}")
+    app_list = [a.strip() for a in apps.split(",") if a.strip()]
+    try:
+        registry.prune(app_list, registry_prefix, retention, dry_run)
+    except Exception as e:
+        logger.error(f"Registry prune failed: {e}")
+        raise typer.Exit(1) from None

--- a/toolkit/features/promotion.py
+++ b/toolkit/features/promotion.py
@@ -14,7 +14,6 @@ ruamel round-trip (comment- and order-preserving) rather than a PyYAML rewrite.
 
 from __future__ import annotations
 
-import httpx
 from ruamel.yaml import YAML
 
 from toolkit.config.constants import COMPONENTS
@@ -22,8 +21,7 @@ from toolkit.config.settings import settings
 from toolkit.core.logging import logger
 from toolkit.features.configuration import ConfigurationManager
 from toolkit.features.generator_k8s import K8sGenerator
-
-_DOCKERHUB_TAGS_API = "https://hub.docker.com/v2/repositories/{namespace}/{repo}/tags/{tag}"
+from toolkit.features.registry import tag_exists
 
 
 def _resolve_image(env: str, app: str) -> tuple[str, str]:
@@ -34,20 +32,6 @@ def _resolve_image(env: str, app: str) -> tuple[str, str]:
     if not image_name:
         raise ValueError(f"No image_name configured for platform app '{app}'")
     return registry, image_name
-
-
-def _tag_exists(registry: str, image_name: str, tag: str) -> bool | None:
-    """Whether ``tag`` exists on the registry. Returns None (skip) for non-Docker-Hub registries."""
-    if not registry.startswith("docker.io/"):
-        return None
-    namespace = registry.split("/", 1)[1]
-    url = _DOCKERHUB_TAGS_API.format(namespace=namespace, repo=image_name, tag=tag)
-    try:
-        resp = httpx.get(url, timeout=15.0)
-    except httpx.HTTPError as exc:
-        logger.warning(f"Could not reach registry to verify tag ({exc}); skipping check")
-        return None
-    return resp.status_code == 200
 
 
 def promote(env: str, app: str, version: str) -> None:
@@ -66,7 +50,7 @@ def promote(env: str, app: str, version: str) -> None:
 
     registry, image_name = _resolve_image(env, app)
 
-    exists = _tag_exists(registry, image_name, version)
+    exists = tag_exists(registry, image_name, version)
     if exists is False:
         raise ValueError(
             f"Tag '{version}' not found for {registry}/{image_name} — refusing to promote a "

--- a/toolkit/features/registry.py
+++ b/toolkit/features/registry.py
@@ -1,0 +1,168 @@
+"""Docker Hub registry client + ephemeral-tag pruning (ADR-046).
+
+The one place the project performs *authenticated* registry operations. The
+read-only tag-existence check used by promotion lives in ``promotion.py``; this
+module adds login/list/delete so the CI janitor can prune ephemeral tags.
+
+Staging runs immutable ``sha-<short>`` tags (one per app per merge to master),
+so they accumulate forever. ``prune`` keeps the N most recent per app (rollback
+headroom) and deletes the rest, plus any leftover ``-rc.*`` (the RC scheme was
+dropped — release-please is the sole semver authority). Prod runs immutable
+semver and is never touched here.
+
+The decision of *what* to delete is the pure ``select_stale_tags``; everything
+else is I/O. That split keeps the policy unit-testable without a network.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import httpx
+
+from toolkit.core.logging import logger
+
+_HUB = "https://hub.docker.com/v2"
+SHA_TAG_PREFIX = "sha-"  # immutable per-commit staging tag scheme (ADR-046)
+_RC_MARKER = "-rc."  # dropped scheme; any remaining are dead
+
+
+@dataclass(frozen=True)
+class TagInfo:
+    """A registry tag and its last-push time (ISO8601 sorts chronologically)."""
+
+    name: str
+    last_updated: str
+
+
+def select_stale_tags(tags: list[TagInfo], retention: int) -> list[str]:
+    """Pure policy: which tag names to delete.
+
+    Keep the ``retention`` most recent ``sha-*`` tags (newest first by
+    ``last_updated``); the rest are stale. Every ``-rc.*`` tag is stale. Returns
+    stale sha (oldest first) followed by rc tags.
+    """
+    if retention < 0:
+        raise ValueError(f"retention must be >= 0, got {retention}")
+    sha = sorted(
+        (t for t in tags if t.name.startswith(SHA_TAG_PREFIX)),
+        key=lambda t: t.last_updated,
+        reverse=True,
+    )
+    stale_sha = [t.name for t in sha[retention:]]
+    rc = [t.name for t in tags if _RC_MARKER in t.name]
+    return stale_sha + rc
+
+
+def tag_exists(registry: str, image_name: str, tag: str) -> bool | None:
+    """Whether ``tag`` exists for an image. ``None`` (skip) for non-Docker-Hub registries.
+
+    Anonymous read — used by promotion to refuse promoting a tag that does not
+    exist (it would ``ImagePullBackOff``). Lives here so all registry access has
+    one home; promotion no longer carries its own copy of the Docker Hub URL.
+    """
+    if not registry.startswith("docker.io/"):
+        return None
+    namespace = registry.split("/", 1)[1]
+    url = f"{_HUB}/repositories/{namespace}/{image_name}/tags/{tag}"
+    try:
+        resp = httpx.get(url, timeout=15.0)
+    except httpx.HTTPError as exc:
+        logger.warning(f"Could not reach registry to verify tag ({exc}); skipping check")
+        return None
+    return resp.status_code == 200
+
+
+class DockerHubClient:
+    """Minimal authenticated Docker Hub v2 client (login, list, delete)."""
+
+    def __init__(self, namespace: str, token: str | None = None) -> None:
+        self.namespace = namespace
+        self._token = token
+
+    @classmethod
+    def from_env(cls) -> DockerHubClient:
+        """Build a client from ``DOCKERHUB_USERNAME``/``DOCKERHUB_TOKEN`` (CI secrets)."""
+        user = os.environ.get("DOCKERHUB_USERNAME")
+        password = os.environ.get("DOCKERHUB_TOKEN")
+        if not user or not password:
+            raise ValueError("DOCKERHUB_USERNAME and DOCKERHUB_TOKEN must be set in the environment")
+        return cls(namespace=user, token=cls._login(user, password))
+
+    @staticmethod
+    def _login(user: str, password: str) -> str:
+        resp = httpx.post(f"{_HUB}/users/login", json={"username": user, "password": password}, timeout=30.0)
+        resp.raise_for_status()
+        token = resp.json().get("token")
+        if not token:
+            raise ValueError("Docker Hub login returned no token")
+        return token
+
+    def _headers(self) -> dict[str, str]:
+        return {"Authorization": f"Bearer {self._token}"} if self._token else {}
+
+    def list_tags(self, repo: str) -> list[TagInfo]:
+        """All tags for ``<namespace>/<repo>``. A missing repo yields ``[]`` (nothing to prune)."""
+        tags: list[TagInfo] = []
+        url: str | None = f"{_HUB}/repositories/{self.namespace}/{repo}/tags/?page_size=100"
+        while url:
+            resp = httpx.get(url, headers=self._headers(), timeout=30.0)
+            if resp.status_code == 404:
+                return []
+            resp.raise_for_status()
+            data = resp.json()
+            for result in data.get("results", []):
+                name = result.get("name")
+                if name:
+                    tags.append(TagInfo(name=name, last_updated=result.get("last_updated") or ""))
+            url = data.get("next")
+        return tags
+
+    def delete_tag(self, repo: str, tag: str) -> bool:
+        """Delete one tag. 204 (deleted) and 404 (already gone) are both success."""
+        resp = httpx.delete(
+            f"{_HUB}/repositories/{self.namespace}/{repo}/tags/{tag}/",
+            headers=self._headers(),
+            timeout=30.0,
+        )
+        if resp.status_code in (204, 404):
+            return True
+        logger.warning(f"Failed to delete {repo}:{tag} (HTTP {resp.status_code})")
+        return False
+
+
+def prune(
+    apps: list[str],
+    registry_prefix: str,
+    retention: int,
+    dry_run: bool,
+    client: DockerHubClient | None = None,
+) -> int:
+    """Prune stale tags for each ``<registry_prefix>-<app>`` repo.
+
+    Returns the count deleted (or, in ``dry_run``, that would be deleted).
+    """
+    client = client or DockerHubClient.from_env()
+    total = 0
+    for app in apps:
+        repo = f"{registry_prefix}-{app}"
+        tags = client.list_tags(repo)
+        stale = select_stale_tags(tags, retention)
+        sha_count = sum(1 for t in tags if t.name.startswith(SHA_TAG_PREFIX))
+        kept = min(sha_count, retention)
+        if not stale:
+            logger.info(f"{repo}: nothing to prune ({sha_count} sha-* tags, all {kept} retained)")
+            continue
+        deleted = 0
+        for tag in stale:
+            if dry_run:
+                logger.info(f"{repo}: would delete {tag}")
+                deleted += 1
+            elif client.delete_tag(repo, tag):
+                logger.info(f"{repo}: deleted {tag}")
+                deleted += 1
+        logger.info(f"{repo}: {deleted} deleted, kept {kept} of {sha_count} sha-*")
+        total += deleted
+    logger.success(f"Prune complete{' (dry-run)' if dry_run else ''}: {total} tag(s)")
+    return total

--- a/toolkit/main.py
+++ b/toolkit/main.py
@@ -14,6 +14,7 @@ from toolkit.cli import (
     deployment,
     infra,
     monitoring,
+    registry,
     secrets,
     services,
     sync,
@@ -124,6 +125,7 @@ app.add_typer(dashboard.app, name="dashboard")
 app.add_typer(deployment.app, name="deployment")
 app.add_typer(infra.app, name="infra")
 app.add_typer(monitoring.app, name="monitoring")
+app.add_typer(registry.app, name="registry")
 app.add_typer(secrets.app, name="secrets")
 app.add_typer(services.app, name="services")
 app.add_typer(sync.app, name="sync")


### PR DESCRIPTION
Closes the last ARGO-016 work item: prune ephemeral image tags. Replaces the dead **"Cleanup RC Tags"** workflow — the RC scheme was dropped (release-please is the sole semver authority), so it cleaned nothing.

## What

A `toolkit registry prune` janitor (scheduled weekly + `workflow_dispatch` with `dry_run`):
- Keeps the **N most recent** immutable `sha-*` tags per app (staging's continuous-deployment tags accumulate one-per-merge); deletes the rest.
- Sweeps any leftover `-rc.*` tags.
- **Prod is never touched** — it runs immutable semver.

## Why this shape (answering "should CI use the toolkit?")

The retention policy + Docker Hub client live in the **toolkit**, unit-tested — not reimplemented in bash. The workflow is a thin `poetry run toolkit registry prune`, consistent with `staging-deploy.yml` / `promote-prod.yml`. Pagination + retention + authenticated delete is domain logic; YAML is the wrong place for it (untestable, and it duplicated registry knowledge already in `promotion.py`).

**Consolidation done in-PR:** `promotion.py`'s tag-existence check now calls the shared `registry.tag_exists` instead of its own copy of the Docker Hub URL. All registry access has one home (`toolkit/features/registry.py`).

## Safety

- `select_stale_tags` is a **pure function**, unit-tested without a network. It only ever selects `sha-*` (beyond retention) and `-rc.*`; **semver / `latest` / `dev` are never selectable**.
- Staging always tracks the newest sha, so the deployed image is inherently retained. (Holding staging on an older sha for rollback → bump `SHA_TAG_RETENTION` or re-push before it ages out.)
- `dry_run` lists without deleting.

## Verification

- New `tests/test_registry_prune.py` (14 tests: retention, pagination, 404, delete codes, dry-run, prefix). `test_promotion.py` updated for the shared module. Full suite + `ruff`/`mypy` green.
- `actionlint` clean.
- **Live smoke** (anonymous, read-only) against `mlorentedev/kubelab-api`: reads `[latest, 1.1.0, dev, 1.0.0]`, selects nothing (no `sha-*` yet), missing repo → `[]`.

## Net

-199 lines of bash → +378 (mostly unit-tested Python). Registry knowledge consolidated to one module.

## Notes (tracked, not in this PR)

- `argocd-image-updater` descope follow-up filed separately (ARGO-016 requirement).
- Future "when it hurts": a prebuilt toolkit Docker image to cut CI `poetry install` latency (built from the repo — no version skew); publish+pin only when a second repo consumes the toolkit.

Refs mlorentedev/knowledge#94 (ARGO-016).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated scheduled cleanup of stale container registry image tags (weekly on Mondays at 04:00 UTC, with manual trigger available)
  * Dry-run mode to safely preview cleanup operations before execution
  * New registry maintenance command-line tools

* **Refactor**
  * Consolidated tag verification logic across components

* **Tests**
  * Added comprehensive test coverage for registry tag pruning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->