### PR TITLE
fix(toolkit): interactive prompt for secrets set --stdin (no Ctrl-D)

### DIFF
--- a/tests/test_secrets_input_hardening.py
+++ b/tests/test_secrets_input_hardening.py
@@ -153,3 +153,28 @@ class TestInitIdempotent:
         with _patch_gen():
             generated = SecretsManager().init_machine_secrets(self.ENV, dry_run=True, rotate=[non_machine])
         assert generated == {}, "rotating a non-machine-generable key must error"
+
+
+# ───────────────── secrets set --stdin: interactive prompt (no Ctrl-D) ─────────────────
+
+
+class TestStdinValueResolution:
+    """_stdin_value: interactive TTY prompts once (Enter submits); pipe reads until EOF."""
+
+    def test_interactive_tty_uses_getpass_no_ctrl_d(self, monkeypatch) -> None:
+        import toolkit.cli.secrets as sec
+
+        fake_stdin = MagicMock()
+        fake_stdin.isatty.return_value = True
+        monkeypatch.setattr(sec.sys, "stdin", fake_stdin)
+        monkeypatch.setattr(sec.getpass, "getpass", lambda *a, **k: "-1004406031115")
+        assert sec._stdin_value() == "-1004406031115"
+        fake_stdin.read.assert_not_called()  # interactive must NOT read-until-EOF (no Ctrl-D)
+
+    def test_piped_stdin_reads_until_eof(self, monkeypatch) -> None:
+        import io
+
+        import toolkit.cli.secrets as sec
+
+        monkeypatch.setattr(sec.sys, "stdin", io.StringIO("piped-value\n"))
+        assert sec._stdin_value() == "piped-value"  # trailing newline stripped

--- a/toolkit/cli/secrets.py
+++ b/toolkit/cli/secrets.py
@@ -13,6 +13,7 @@ Single entry point for all secret operations:
 
 from __future__ import annotations
 
+import getpass
 import os
 import subprocess
 import sys
@@ -38,6 +39,17 @@ def _get_manager() -> SecretsManager:
     from toolkit.features.secrets_manager import secrets_manager
 
     return secrets_manager
+
+
+def _stdin_value() -> str:
+    """Read a secret value from stdin.
+
+    Interactive TTY → prompt once with hidden input (Enter submits; no Ctrl-D).
+    Piped (non-TTY) → read until EOF. A trailing newline is stripped either way.
+    """
+    if sys.stdin.isatty():
+        return getpass.getpass("Secret value (hidden, Enter to submit): ").rstrip("\r\n")
+    return sys.stdin.read().rstrip("\r\n")
 
 
 # =============================================================================
@@ -325,17 +337,19 @@ def set_secret(
         bool,
         typer.Option(
             "--stdin",
-            help="Read the value from stdin (pipeable; required for values starting with '-')",
+            help="Read the value from stdin: prompts if interactive (Enter submits), reads the pipe otherwise",
         ),
     ] = False,
 ) -> None:
     """Set a secret value in the SOPS vault.
 
-    The value can be passed as an argument or piped via --stdin. Use --stdin for
+    The value can be passed as an argument or supplied via --stdin. Use --stdin for
     values that start with '-' (e.g. Telegram chat IDs) and to keep secrets out of
-    shell history and process args:
+    shell history and process args. On a terminal, --stdin prompts once with hidden
+    input (Enter submits — no Ctrl-D); piped, it reads until EOF:
 
-      printf -- '-1004…' | toolkit secrets set <key> --env staging --stdin
+      toolkit secrets set <key> --env staging --stdin            # interactive prompt
+      printf -- '-1004…' | toolkit secrets set <key> --env staging --stdin   # piped
 
     Example:
       toolkit secrets set aws.access_key_id AKIA... --env common
@@ -350,9 +364,9 @@ def set_secret(
         logger.error("Pass the value as an argument OR via --stdin, not both")
         raise typer.Exit(1)
     if use_stdin:
-        value = sys.stdin.read().rstrip("\r\n")
+        value = _stdin_value()
         if not value:
-            logger.error("--stdin given but no value was provided on stdin")
+            logger.error("--stdin given but no value was provided")
             raise typer.Exit(1)
     elif value is None:
         logger.error("Provide a VALUE argument or use --stdin")


### PR DESCRIPTION
## What

Follow-up to TOOL-008. `secrets set --stdin` read until EOF, so interactive use needed Ctrl-D to submit a single-line value — unintuitive (hit in practice).

Now: when stdin is a **TTY**, `--stdin` prompts once with hidden input (Enter submits, no Ctrl-D) via `getpass`. When **piped**, it reads until EOF as before (CI/pipes unchanged).

## Tests

- `tests/test_secrets_input_hardening.py::TestStdinValueResolution` — interactive (getpass, no read-until-EOF) + piped (read EOF).
- Full file: 11 tests green. `make test` → 187 passed, 0 regressions.

Refs mlorentedev/knowledge#110

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `toolkit secrets set --stdin` to support both interactive prompts (hidden input when connected to terminal) and piped input (reading until EOF with newline stripping).

* **Tests**
  * Added test coverage for stdin value resolution in different input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->