### PR TITLE
fix(ansible): load SOPS secrets under any tag selection in provision-bee

### DIFF
--- a/infra/ansible/playbooks/provision-bee.yml
+++ b/infra/ansible/playbooks/provision-bee.yml
@@ -85,6 +85,7 @@
       changed_when: false
       check_mode: false
       no_log: true
+      tags: [always]   # secrets must load for any tag selection (e.g. --tags runner)
 
     - name: Decrypt env secrets (controller-side)
       command: sops -d {{ playbook_dir }}/../../config/secrets/{{ deploy_env }}.enc.yaml
@@ -94,11 +95,13 @@
       changed_when: false
       check_mode: false
       no_log: true
+      tags: [always]   # secrets must load for any tag selection (e.g. --tags runner)
 
     - name: Merge secrets (env overrides common)
       set_fact:
         secrets: "{{ (sops_common.stdout | from_yaml) | combine(sops_env.stdout | from_yaml, recursive=True) }}"
       no_log: true
+      tags: [always]   # secrets must load for any tag selection (e.g. --tags runner)
 
     - name: Generate Headscale pre-auth key (via VPS)
       command: >


### PR DESCRIPTION
## Problem

The secret-decryption pre_tasks in `provision-bee.yml` (`Decrypt common secrets`, `Decrypt env secrets`, `Merge secrets`) were untagged. With any tag filter (e.g. `--tags runner`) Ansible skips untagged tasks, leaving the `secrets` fact undefined. The `beelink_services` role then fails with `'secrets' is undefined`, breaking targeted re-deploys.

This surfaced while re-applying a rotated GitHub runner PAT: `make provision NODE=bee ENV=staging TAGS=runner` could not load secrets, so the runner stayed on the revoked token (401 → CrashLoop, runner offline).

## Fix

Tag the three secret-loading pre_tasks `always` so they run regardless of the selected tags. This makes targeted re-deploys (`--tags runner`, `--tags minio`, etc.) work and keeps secret rotation to a single command.

## Verification

`make provision NODE=bee ENV=staging TAGS=runner` now loads secrets, recreates the runner with the new PAT, and the runner registers online (`kubelab-bee`, Listening for Jobs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed provisioning workflow to ensure secret decryption tasks always execute, regardless of which provisioning tags are selected. This improves deployment reliability and prevents provisioning failures when using selective task execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->