### PR TITLE
fix(secrets): restore prod — apprise prod channels + n8n encryption key path

### DIFF
--- a/infra/config/secrets/prod.enc.yaml
+++ b/infra/config/secrets/prod.enc.yaml
@@ -42,6 +42,10 @@ apps:
         automation:
             n8n:
                 encryption_key: ENC[AES256_GCM,data:/4A0JFgQy6Co1IuEkgfGZTFwoNU4WbLpWfMQFZ+2fHPhOWQ0nYC3dEes/lZF6VBLcCXt7uPXFRvngTFCyLO9ww==,iv:ZgcZEEa4gGso1YeutscqFfQVbDFbVuifYgbpIzAk7CM=,tag:x3peO5NY2GAoetaS5yGlVA==,type:str]
+            apprise:
+                telegram:
+                    chat_page: ENC[AES256_GCM,data:bOwQvwVPvy1w7rXKpO4=,iv:E9h40+RfkixrqoUmZO8m/arAA0ftUCUgd9WuHs1ZoN0=,tag:5Op5KTxjgOJOpFSnfp28sw==,type:str]
+                    chat_log: ENC[AES256_GCM,data:YZ8n0CoLAZjuf4aRszk=,iv:M4BiJCLmaODmIGcEhPzbFzyeSomg9tyZye6xZ5CBtjI=,tag:Ef9Wqs9RrthNW7f9CvAgrw==,type:str]
     testing:
         authelia_test_password: ENC[AES256_GCM,data:/2ek6DSiAv0/pDbooyRrH5wvnup55KBK2JezIqXuZWw=,iv:RmeSxVjInNRDE332A+Fc/2WXWJWOlTcytCHJrKwPDV0=,tag:AP6KC3HIangLF6oDV1xFyQ==,type:str]
 sops:
@@ -64,7 +68,7 @@ sops:
             ZTM1eklCOXB2MDYvSklyVkx4ZnlwaGMKkmFVL24SN87fiF/KJBt4kAeVV2XDUrLd
             PMrwWiWp9vpTQYJngpXt2POCsFamYzk3s3DOXgDCXniQ2Ef/X01VTA==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2026-06-17T00:49:25Z"
-    mac: ENC[AES256_GCM,data:IGU78f1WRUtPjjneaULedW3rLmkAs7JJDVi/F6xvKhCH/lJg3XHpi0WuPagw0xRFhUHkoMr9vfNgk0n+MEfyjQUYouf8c9FHciNDIYXyvVpmpJX/PEdh0mnu5RlytiOv1voq5ulQTVGQpl8E5bpnYiT+xxbCkPQnuVEO6tYzvWA=,iv:4Pc2QO3/obB8eCipkddg82tre8dMLlDCF5x0pwEvhoI=,tag:LH9v5Ld9ogzG+JnDRU6faw==,type:str]
+    lastmodified: "2026-06-17T02:36:49Z"
+    mac: ENC[AES256_GCM,data:wKDC4TfdqgFXpiVGyfrk2rfvL22sKedTW1OtP6x944rn11VCZbghs6p7KlydyzScQOfrU1aRUldOp8HbDF2WOM552SO/kRraPSzPZ9bgDOOZf9mv/OT1fkIBr4NWEvDeB3oqOCQ26dmcAWMSAElIJvvKvexmg7qi9oNzUOZxN70=,iv:8A/OLL8Exu4h6E/d8+02MrmNGrufO5JZ6iudIPisi28=,tag:S5jMxv1cq9SfajngRG7c+Q==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.11.0

--- a/toolkit/features/k8s_secrets.py
+++ b/toolkit/features/k8s_secrets.py
@@ -76,7 +76,8 @@ SECRET_DEFINITIONS: list[SecretMapping] = [
     SecretMapping(
         name="n8n-secrets",
         keys={
-            "N8N_ENCRYPTION_KEY": "APPS_SERVICES_CORE_N8N_ENCRYPTION_KEY",
+            # n8n moved core -> automation (#670); env var prefix follows the new path
+            "N8N_ENCRYPTION_KEY": "APPS_SERVICES_AUTOMATION_N8N_ENCRYPTION_KEY",
         },
     ),
     SecretMapping(

--- a/toolkit/features/secrets_manager.py
+++ b/toolkit/features/secrets_manager.py
@@ -317,10 +317,11 @@ SECRET_CATALOG: list[SecretSpec] = [
         services=("github-runner",),
         rotate_note="Re-provision ace2 (Ansible). Token must have repo + workflow scope.",
     ),
-    # Apprise notification gateway (NOTIFY-001, ADR-044). staging-only until the
-    # fabric is promoted to prod; broaden `envs` at promotion. Under Option B the
-    # bot-token / chat IDs are read at `secrets apply` time to render the Apprise
-    # routing table (kubelab.yml); n8n no longer holds Telegram creds.
+    # Apprise notification gateway (NOTIFY-001, ADR-044). Promoted to staging+prod.
+    # bot-token is shared (common SOPS); chat IDs are per-env (dedicated Telegram
+    # channels per environment so prod alerts stay separate from staging). Under
+    # Option B the bot-token / chat IDs are read at `secrets apply` time to render
+    # the Apprise routing table (kubelab.yml); n8n no longer holds Telegram creds.
     SecretSpec(
         key_path="apps.services.automation.apprise.telegram.bot_token",
         description="Telegram bot token for the Apprise notification gateway",
@@ -328,7 +329,7 @@ SECRET_CATALOG: list[SecretSpec] = [
         services=("apprise",),
         format_hint="<bot_id>:<auth_token> from @BotFather",
         rotate_note="Re-issue via @BotFather, then `secrets apply` (re-renders kubelab.yml). No pod restart needed.",
-        envs=("staging",),
+        envs=("staging", "prod"),
     ),
     SecretSpec(
         key_path="apps.services.automation.apprise.telegram.chat_page",
@@ -337,7 +338,7 @@ SECRET_CATALOG: list[SecretSpec] = [
         services=("apprise",),
         format_hint="-100… channel ID (dedicated, not the hermes chat — ADR-044 C5)",
         rotate_note="Update the PAGE channel, then `secrets apply` (re-renders kubelab.yml).",
-        envs=("staging",),
+        envs=("staging", "prod"),
     ),
     SecretSpec(
         key_path="apps.services.automation.apprise.telegram.chat_log",
@@ -346,7 +347,7 @@ SECRET_CATALOG: list[SecretSpec] = [
         services=("apprise",),
         format_hint="-100… channel ID (archive tier; kubelab_bot admin — ADR-044 C4/C5)",
         rotate_note="Update the LOG channel, then `secrets apply` (re-renders kubelab.yml).",
-        envs=("staging",),
+        envs=("staging", "prod"),
     ),
     # Shared secret for the n8n /webhook/notify ingress (NOTIFY-001 criterion #4).
     # Lives in the n8n encrypted credential store (Header Auth, ADR-044 webhook-auth);


### PR DESCRIPTION
## Context

#670 squash-merged to master and Argo CD prod (`selfHeal: true`, ADR-037) auto-synced the notification-fabric manifests to prod. Two latent issues surfaced because **manifests sync via Argo CD but Secrets are applied out-of-band** (`make apply-secrets`):

## Bug 1 — apprise Degraded in prod
- `apprise.yaml` lives in `infra/k8s/base/` (deploys to all envs) but its secret was catalog-marked staging-only. Prod got the Deployment, never the Secret → initContainer `FailedMount: secret "apprise-secrets" not found` → pod stuck `Init:0/1` → Argo CD *Degraded*. (prod was never *down* — apprise is internal notify.)
- **Fix:** dedicated prod Telegram channels in SOPS (PAGE/LOG, separate from staging so prod alerts are distinguishable); `bot_token` stays shared via `common`. Broadened the three apprise telegram specs to `envs=(staging, prod)`.

## Bug 2 — apply-secrets broken in every env
- #670 moved n8n `core`→`automation`; the flattened env var became `APPS_SERVICES_AUTOMATION_N8N_ENCRYPTION_KEY`, but `n8n-secrets` still mapped the old `CORE` prefix → value unresolved → `n8n-secrets` skipped → `apply-secrets` exited non-zero, breaking `deploy-k8s`.
- **Fix:** point the mapping at the automation path. The value is unchanged (migration preserved it), so re-applying is a no-op for the running n8n.

## Verification
- `make apply-secrets ENV=prod` → EXIT=0, all secrets configured (incl. `apprise-secrets created`, `n8n-secrets configured`).
- prod: `apprise` now `1/1 Running` (was Init:0/1); `n8n` still `1/1 Running` (no restart — no-op confirmed by comparing live secret vs SOPS).
- `make test` → 232 passed; ruff + mypy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated n8n automation service secret configuration references.
  * Extended Apprise Telegram notification gateway availability to production environments in addition to staging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->