### PR TITLE
ci: restore add-to-project workflow (drop broken gh CLI step)

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -4,9 +4,6 @@ name: Add to bitácora
 # (GitHub Project #1). Pairs with bitacora-status.yml (which flips an assigned
 # issue to In Progress). Canonical copy for the OPS-002 (#258) multi-repo rollout.
 
-# Note: the add-to-project action handles issues; PRs are added via
-# `gh project item-add` below so behaviour stays explicit across action versions.
-
 on:
   issues:
     types: [opened, reopened]
@@ -15,24 +12,18 @@ on:
 
 jobs:
   add-to-project:
-    # Fork PRs run without repository secrets — BITACORA_PAT would be empty and the
-    # job would fail (Codex review on kubelab#237). Skip them; fork PRs reach the
-    # board via the rollout backfill or a manual item-add.
-    if: github.event_name == 'issues' || github.event.pull_request.head.repo.fork == false
+    # Fork PRs and Dependabot PRs run without repository secrets — BITACORA_PAT would
+    # be empty and the job would fail (Codex review on kubelab#237; Dependabot on
+    # kubelab#614). Skip them; they reach the board via the rollout backfill or a
+    # manual item-add.
+    if: >-
+      github.event_name == 'issues' ||
+      (github.event.pull_request.head.repo.fork == false &&
+       github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
-      # Issues: use the official action
-      - name: Add issue to project
-        if: github.event_name == 'issues'
-        uses: actions/add-to-project@v2.0.0
+      # Pin a real release: actions/add-to-project@v1 does NOT resolve (no floating v1 tag).
+      - uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/users/mlorentedev/projects/1
           github-token: ${{ secrets.BITACORA_PAT }}
-
-      # PRs: use gh CLI directly (the action doesn't support PRs)
-      - name: Add PR to project
-        if: github.event_name == 'pull_request'
-        run: |
-          gh project item-add 1 --owner mlorentedev --url "${{ github.event.pull_request.html_url }}"
-        env:
-          GH_TOKEN: ${{ secrets.BITACORA_PAT }}


### PR DESCRIPTION
## Why

PR #708 inadvertently landed a broken `add-to-project.yml` change:

1. **Broken step** — `gh project item-add` fails with `unknown owner type` (the runner's `BITACORA_PAT` can't resolve the project owner type), red-X-ing the `add-to-project` check on every PR.
2. **Regression** — it dropped the `dependabot[bot]` guard from the job `if:`, reintroducing #614 (Dependabot PRs run without `BITACORA_PAT` → empty token → job fails).

`actions/add-to-project@v2.0.0` (landed via Dependabot #622) already adds PRs natively, so the `gh` CLI step is redundant as well as broken.

## What

Restore `add-to-project.yml` to its pre-#708 known-good state: a single `actions/add-to-project@v2.0.0` step (handles issues + non-fork, non-dependabot PRs) with the fork+dependabot guard intact. The ADR-049 lesson from #708 stays on master (untouched).

## Note

Whether PRs belong on the board at all is deferred to the ADR-050 board-governance follow-up (ADR-050: issues/PRs live in the forges; the board owns status/priority/dates).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored GitHub Actions workflow to consolidate issue and pull request handling into a single conditional step
  * Updated project automation action to version 2.0.0 for improved stability and compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->