### PR TITLE
docs(lessons): capture non-admin workstation fleet-access gotcha

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -29,6 +29,20 @@ owner: manu
 **Rule**: Pattern to follow going forward
 ```
 
+### [2026-06-20] From the non-admin workstation, "can't reach the node" has three independent causes — not "node down"
+
+**Context**: Validating the new K3s upgrade runbook (OPS-002 #429) against staging needed read-only pre-flight commands on ace1. ace1 was powered on, yet every SSH attempt from this Windows non-admin box (EGW-LEN029) failed — first read as "the on-demand node is off", which was wrong.
+
+**Problem**: Three distinct, stacked blockers, each masquerading as "node down":
+
+1. **Mesh IPs are not locally routable here.** This box runs no native Tailscale, so `ssh ace1` (→ `100.64.0.11:22`, the alias's `Hostname`) just times out — there is no kernel route to `100.64.0.0/10`.
+2. **The `-ext` bastion alias fails as a fallback.** `ace1-ext` (ProxyJump via the public VPS) dies with `deployer@162.55.57.175: Permission denied (publickey)` — the VPS jump host authenticates as user **`deployer`**, and this workstation's key isn't authorized for `deployer` on the VPS. The `-ext` aliases are *not* a drop-in transport from this box.
+3. **ts-bridge + passphrase key block automation.** `ts-bridge connect` tunnels a **single target** (`ace1:22 → 127.0.0.1:33389`), not a general mesh router. And the local key `~/.ssh/id_ed25519` (`dell-egw-len029`) has a **passphrase** with **no ssh-agent** in the automation shell, so non-interactive SSH (the agent harness, Ansible) cannot authenticate even though an interactive shell can. Ansible-over-the-mesh is further blocked because the generated inventory targets the non-routable mesh IPs.
+
+**Solution**: Deferred the empirical validation (tracked as OPS-011 #722) and shipped the runbook on doc-level review only. For interactive single-node access from here: `ts-bridge connect`, then SSH to `127.0.0.1:<bridge-port>` using the node's own user + key. For automation: run it from a native-Tailscale node, or expose a persistent `SSH_AUTH_SOCK` to the automation shell.
+
+**Rule**: From a non-admin / non-native-Tailscale box, diagnose fleet-access failures against all three causes before concluding "node down" — mesh non-routability, the `-ext` bastion authenticating as `deployer` (not your user), and a passphrase key with no agent. `ts-bridge` solves only single-target *interactive* SSH; *automation* needs a native-Tailscale node or an inherited ssh-agent. Procedure: `docs/runbooks/non-admin-workstation-access.md`.
+
 ### [2026-06-15] A generated artifact's content must not depend on whether secrets are decrypted
 
 **Context**: First gated prod promotion (`api` → `1.1.0`, #664) put the new pod in `CrashLoopBackOff` — `panic: SMTP credentials required in production`. The api Deployment's `envFrom` referenced only `configMapRef: api-config`, never `secretRef: api-secrets`, so `INFRA_SMTP_PASS` (present in the cluster Secret for 86 days) was never injected. `:dev` had no such guard; `1.1.0` added one. No outage — the rolling update held the old `:dev` pod Ready while the new one never became Ready.


### PR DESCRIPTION
Adds a `docs/lessons.md` entry from the OPS-002 session: SSH to a powered-on ace1 failed from the non-admin workstation due to **three independent causes**, not a down node —

1. mesh IPs not locally routable (no native Tailscale),
2. the `-ext` bastion alias authenticates as `deployer` (key not authorized there),
3. `ts-bridge` tunnels a single target + the local key has a passphrase with no ssh-agent in the automation shell.

Captures the diagnosis order and the automation-vs-interactive distinction; links to the `non-admin-workstation-access` runbook.

Refs #429, #722

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for connectivity issues on non-admin Windows workstations, covering three common causes and recommended resolution steps for both manual and automated approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->