### PR TITLE
feat(toolkit): cluster access transport + fetch-kubeconfig (ADR-052, #723)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ help:
 	@echo "  make flush-sessions ENV=x  Flush Authelia sessions (Redis FLUSHDB)"
 	@echo ""
 	@echo "Hub (Argo CD):"
-	@echo "  make fetch-kubeconfig-hub      Fetch kubeconfig from aws1"
+	@echo "  make fetch-kubeconfig ENV=x   Fetch a cluster kubeconfig (staging|prod|hub)"
 	@echo "  make deploy-argocd             Install/upgrade Argo CD (deploys Authelia OIDC first)"
 	@echo "  make deploy-apps               Deploy Argo CD Applications to hub"
 	@echo "  make check-apps                Check Application sync status"
@@ -377,17 +377,12 @@ secrets-audit:
 # -----------------------------------------------------------------------------
 HUB_KUBECONFIG := ~/.kube/kubelab-hub-config
 
-# Fetch kubeconfig from aws1 — auto-accepts new host key (Spot instances rotate)
-# Also cleans stale keys for aws1.kubelab.internal from known_hosts
-.PHONY: fetch-kubeconfig-hub
-fetch-kubeconfig-hub:
-	@echo "=== Fetching kubeconfig from aws1 via Tailscale ==="
-	@ssh-keygen -R aws1.kubelab.internal 2>/dev/null || true
-	@ssh -o StrictHostKeyChecking=accept-new aws1.kubelab.internal "sudo cat /etc/rancher/k3s/k3s.yaml" | \
-		sed "s/127.0.0.1/aws1.kubelab.internal/" > $(HUB_KUBECONFIG)
-	@chmod 600 $(HUB_KUBECONFIG)
-	@echo "✓ Hub kubeconfig saved to $(HUB_KUBECONFIG)"
-	@kubectl --kubeconfig $(HUB_KUBECONFIG) get nodes
+# Fetch a cluster's kubeconfig (ADR-052): transport-agnostic server
+# (https://127.0.0.1:<local_port>) -> ~/.kube/kubelab-<ENV>-config.
+# Unifies the old inline hub-only fetch. ENV=staging|prod|hub.
+.PHONY: fetch-kubeconfig
+fetch-kubeconfig:
+	@$(TOOLKIT) infra k8s fetch-kubeconfig --env $(ENV)
 
 .PHONY: deploy-argocd
 deploy-argocd: _deploy-authelia-oidc _deploy-argocd-helm

--- a/docs/adr/adr-052-cluster-access-transport.md
+++ b/docs/adr/adr-052-cluster-access-transport.md
@@ -1,0 +1,98 @@
+---
+id: "adr-052"
+type: adr
+status: accepted
+owner: manu
+date: "2026-06-21"
+issue: "kubelab#723"
+tags: [architecture, decision, kubeconfig, transport, ts-bridge, tailscale, headscale, mesh, onboarding, non-admin, cluster-access]
+depends_on: [adr-047-cluster-wide-bootstrap-ssot, adr-036-shared-infra-namespace, adr-025-magicdns-internal-naming, adr-023-hub-spoke-multicloud-gitops, adr-014-secrets-management-strategy, adr-028-operational-topology, adr-030-self-hosted-ci-runner]
+created: "2026-06-21"
+---
+
+# ADR-052: Cluster access transport — operate K3s from any machine (incl. non-mesh / non-admin)
+
+## Status
+
+Accepted — 2026-06-21. Establishes the convention for **how an operator machine obtains and uses a kubeconfig** for each kubelab cluster (staging/prod/hub), so deploy/apply works identically on the home LAN, off-network over the VPN, from CI, and from a corporate **non-admin box with no native Tailscale**. Scopes the implementation of #723 (`fetch-kubeconfig`) and the follow-on `connect` helper. **Owner-bootstrap only** — per-user collaborator access is explicitly deferred (D5).
+
+## Context
+
+Operating any cluster needs a kubeconfig whose `server:` endpoint is *reachable from the machine running `kubectl`*. The repo's only precedent is `make fetch-kubeconfig-hub`: an inline `ssh … sudo cat /etc/rancher/k3s/k3s.yaml | sed 's/127.0.0.1/aws1.kubelab.internal/'` that rewrites the server to the node's **MagicDNS** name. That convention silently assumes the consuming machine has **native Tailscale** (a TUN device routing `100.64.0.0/10` + MagicDNS resolution).
+
+The primary operator workstation (EGW-LEN029) breaks that assumption: it is a **corporate, non-admin** box that cannot install Tailscale (no TUN, no admin). Its only mesh transport is **ts-bridge** — a userspace `tsnet` bridge (no TUN) that forwards a **local TCP port** to a mesh target. Because `tsnet` installs no system route, a separate process (`kubectl`) can reach a mesh service **only via a forwarded `127.0.0.1:<port>`**, never via `100.64.0.11` or `ace1.kubelab.internal`. So "rewrite server → MagicDNS" produces a kubeconfig that does not work on this machine.
+
+Requirement (clarified): operate **from anywhere**, on-LAN *and* off-network. Off-network the home-LAN SSH jump (`rpi4-lan`) is unreachable; only the mesh (public Headscale control-plane `vpn.kubelab.live` + public VPS bastion) reaches staging/hub. So the **mesh is the universal transport**; LAN and prod's public IP are opportunistic fast paths.
+
+## Reference audit (Regla del 3, ADR-015)
+
+This decision governs **cross-machine reuse** (operator laptops, a corporate non-admin box, CI runners) → the gate fires.
+
+| Dimension | R1 · repo precedent | R2 · k3s/kubectl mechanics | R3 · ts-bridge / non-admin reality |
+|---|---|---|---|
+| Get kubeconfig | `fetch-kubeconfig-hub`: ssh+sed, `server`→MagicDNS; `_K8S_KUBECONFIG_PATTERN` = `~/.kube/kubelab-{env}-config`; addresses are SSOT in `common.yaml` | k3s server cert SAN includes `127.0.0.1`, `localhost`, node IP + `tls-san` ⇒ `server: https://127.0.0.1:<port>` validates TLS | userspace `tsnet` has **no TUN** ⇒ only `127.0.0.1:<port>` port-forwards are reachable by `kubectl` |
+| Use kubeconfig | assumes native Tailscale (MagicDNS) on the consumer | `kubectl` `cluster.proxy-url` supports `socks5://` ⇒ a SOCKS proxy can keep real server names | ts-bridge forwards one target today; multi-target / SOCKS are open (ts-bridge #186 / new) |
+| Address source | `networking.*` in `common.yaml` (never hardcode IPs) | n/a | two separate meshes; prod VPS apiserver reachable by public IP (break-glass) |
+
+### Divergence log
+
+- **Intersection (reused):** the hub mechanic — fetch `k3s.yaml`, rewrite `server`, save to `~/.kube/kubelab-{env}-config` — is sound and kept.
+- **Divergence (the fix):** the **server value** must be transport-agnostic, not MagicDNS. `https://127.0.0.1:<fixed-per-env-port>` is a **superset** convention: it works on userspace/non-admin boxes (the hard case) *and* on native-Tailscale machines and CI (a trivial local forward, or the direct fast path). MagicDNS-in-`server` is Linux/native-TS-only — effectively the same portability trap as the `.sops.yaml` basename lesson.
+- **Strategic finding:** making the kubeconfig name a **stable local endpoint** and the reachability a **swappable transport** decouples two things the hub target fused — which is what lets one convention serve every machine.
+
+## Constraints
+
+| # | Constraint | Origin |
+|---|---|---|
+| C1 | kubeconfig embeds cluster-admin **client certs** (secret) → never committed; fetched per machine | ADR-014 |
+| C2 | consumer may have **no native Tailscale / no admin** (ts-bridge userspace) → transport must not assume a system mesh route | non-admin workstation reality |
+| C3 | every cluster/network address is **SSOT in `common.yaml`**, never hardcoded in code/manifests | repo rule (CLAUDE.md) |
+| C4 | must work **on and off** the home network → mesh is the universal path; LAN/public are fast paths | this ADR's requirement |
+| C5 | **no inline scripts in the Makefile** → logic in the toolkit, target delegates | repo rule (CLAUDE.md) |
+
+## Options Considered
+
+**kubeconfig `server:` convention**
+
+| Option | Verdict |
+|---|---|
+| `https://127.0.0.1:<fixed-per-env-port>` + pluggable local forward | **Chosen** — transport-agnostic; TLS valid via k3s `127.0.0.1` SAN; works on every machine |
+| MagicDNS / mesh name (the hub pattern) | Rejected for general use — requires native Tailscale on the consumer; breaks on userspace/non-admin |
+| `proxy-url: socks5://127.0.0.1:<port>` + real server name | **Deferred** — cleanest for multi-cluster (one proxy, real names), but needs ts-bridge to expose SOCKS; adopt later as a kubeconfig-field swap, no redesign |
+| Public IP for every cluster | Rejected — only prod exposes a public apiserver; exposing staging/hub publicly is unacceptable surface |
+
+**transport selection**
+
+| Option | Verdict |
+|---|---|
+| Data-driven, default = mesh, with detected fast paths (prod→public IP; staging→LAN `ssh -L` when `rpi4-lan` answers; else ts-bridge) | **Chosen** — universal by default, cheap when possible, declared in SSOT |
+| Hardcode env→transport in Python branches | Rejected — adding a cluster = code edit; violates the SSOT rule (C3) |
+| Always ts-bridge | Rejected — ignores prod's public path and the LAN fast path, and makes ts-bridge a SPOF where it is avoidable |
+
+## Decision
+
+- **D1 — Transport-agnostic kubeconfig.** Every fetched kubeconfig uses `server: https://127.0.0.1:<fixed-per-env-port>` (e.g. staging `16443`, prod `16444`, hub `16445` — declared in SSOT, not magic numbers). The **transport** maps that local port to the env's apiserver; the kubeconfig never encodes *how*. TLS verifies against the k3s cert's `127.0.0.1` SAN. The SOCKS variant (`proxy-url` + real server name) is a future optimization adoptable without breaking this contract.
+- **D2 — Per-cluster access metadata is SSOT in `common.yaml`.** A declarative block (per cluster: apiserver node ref, SSH alias, mesh DNS name, fixed local port, optional public endpoint) drives both fetch and connect. Adding/altering a cluster is a YAML edit; the toolkit stays data-driven (no env→transport branches).
+- **D3 — Transport is capability-selected, default mesh.** Resolution order per cluster: declared **public endpoint** (prod, direct, no tunnel) → **LAN `ssh -L`** when the LAN jump answers (home fast path) → **ts-bridge** (universal mesh, on/off-network). CI (native Tailscale, ADR-030) may take the direct mesh path; the `127.0.0.1` convention still holds if it runs `connect`.
+- **D4 — One unified fetch command.** `toolkit infra k8s fetch-kubeconfig --env {staging,prod,hub}` (Makefile target delegates) **retires** the bespoke inline `fetch-kubeconfig-hub` target — one pattern, no inline Makefile shell (C5).
+- **D5 — Owner-bootstrap only; collaborator access is a separate axis.** This ADR covers the single operator fetching an **admin** kubeconfig and tunneling to it. Onboarding *other people* by copying admin client-certs has **no per-user identity and no revocation** — wrong by design. Per-user access is deferred to a separate spec built on **Authelia OIDC + kube-apiserver RBAC + Headscale ACLs (VPNACL-001)**, not in scope here.
+
+## Consequences
+
+**Positive:** one convention works on the non-admin box, native-Tailscale laptops, and CI; the kubeconfig is stable while the transport is swappable; cluster access becomes data-driven (SSOT) and the inline hub target's smell is retired; the design names the owner-vs-collaborator split instead of conflating it.
+
+**Negative:** using a cluster now requires a running transport (`connect`) for staging/hub, so ts-bridge lifecycle becomes load-bearing — it needs robust start/teardown/health, not a bare subprocess. Simultaneous multi-cluster `connect` depends on **ts-bridge multi-target (#186)**; the optional SOCKS variant needs a further ts-bridge feature. Both are tracked in the ts-bridge repo.
+
+**Neutral:** single-cluster ops work **today** with ts-bridge single-target, so the immediate staging unblock (#724 → CONSOLE-002 PR-1b) does not wait on #186. The agent/automation shell cannot do passphrase SSH non-interactively — the toolkit is the deliverable; the human (or a mesh-native CI node with an ssh-agent) runs the interactive bootstrap.
+
+## Implementation / backlog
+
+- **Phase 1 (now — unblocks CONSOLE-002):** this ADR + **#723** `fetch-kubeconfig --env {staging,prod,hub}` (data-driven from D2 SSOT, server per D1, unit-tested) + per-cluster SSOT block in `common.yaml`; then `apply-secrets` to staging via single-target ts-bridge → **#724**.
+- **Phase 2 (tracked):** `toolkit infra k8s connect --env` with real ts-bridge lifecycle + healthcheck; owner-focused onboarding runbook (`docs/runbooks/operate-from-new-workstation.md`); **ts-bridge #186** (multi-target) and a SOCKS ticket in the ts-bridge repo.
+- **Phase 3 (separate spec):** collaborator access — Authelia OIDC + RBAC + Headscale ACLs (intersects **VPNACL-001**).
+
+## References
+
+- [[adr-047-cluster-wide-bootstrap-ssot]] (bootstrap SSOT), [[adr-036-shared-infra-namespace]] (`common.yaml` SSOT), [[adr-025-magicdns-internal-naming]] (MagicDNS), [[adr-023-hub-spoke-multicloud-gitops]] (hub/spoke kubeconfigs), [[adr-014-secrets-management-strategy]] (kubeconfig = secret), [[adr-028-operational-topology]] (on-demand nodes), [[adr-030-self-hosted-ci-runner]] (CI native Tailscale)
+- Tickets: kubelab #723 (fetch-kubeconfig), #724 (apply postgres-secrets); ts-bridge #186 (multi-target); VPNACL-001 (fleet segmentation / ACLs)
+- Lessons: `docs/lessons.md` — non-admin workstation fleet-access; SOPS basename portability (same class of "ambient-state" trap)

--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -321,6 +321,31 @@ argocd:
       node: vps    # → networking.vps.tailscale_ip
 
 # ===========================================================================
+# CLUSTER ACCESS (operator transport — ADR-052)
+# ===========================================================================
+# How an operator machine fetches and reaches each cluster's kubeconfig, so
+# deploy/apply works on the home LAN, off-network over the VPN, from CI, and
+# from a non-admin box with no native Tailscale. Addresses are NOT duplicated
+# here: `node` references networking.* (same convention as argocd.spokes).
+#   ssh_alias  — ~/.ssh/config alias used to fetch /etc/rancher/k3s/k3s.yaml
+#   local_port — the kubeconfig server is https://127.0.0.1:<local_port> (D1);
+#                the transport (`k8s connect`, Phase 2) maps it to the real
+#                apiserver. Distinct per cluster so several tunnels coexist.
+clusters:
+  staging:
+    node: ace1        # → networking.nodes.ace1
+    ssh_alias: ace1   # mesh alias; ace1-lan / ace1-ext are fast-path/fallback
+    local_port: 16443
+  prod:
+    node: vps         # → networking.vps (public apiserver = networking.vps.public_ip)
+    ssh_alias: vps
+    local_port: 16444
+  hub:
+    node: aws1        # → networking.aws (mesh-only: no LAN/public fallback)
+    ssh_alias: aws1
+    local_port: 16445
+
+# ===========================================================================
 # EDGE SERVICES (Reverse Proxy, Gateway, CDN)
 # ===========================================================================
 edge:

--- a/tests/test_k8s_kubeconfig.py
+++ b/tests/test_k8s_kubeconfig.py
@@ -1,0 +1,144 @@
+"""Tests for the fetch-kubeconfig feature (ADR-052 / #723).
+
+Cover the pure helpers — SSOT load, server rewrite, ssh argv, output path —
+without any network. The actual SSH read is the only side effect and lives in
+`fetch_kubeconfig`, which is not exercised here.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from toolkit.features import k8s_kubeconfig as kc
+from toolkit.features.k8s_kubeconfig import (
+    ClusterAccess,
+    fetch_argv,
+    load_cluster_access,
+    load_clusters,
+    output_path,
+    rewrite_server,
+)
+
+# A minimal but realistic k3s admin kubeconfig (apiserver on the 127.0.0.1 default).
+_K3S_YAML = """\
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: REDACTED
+    server: https://127.0.0.1:6443
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+kind: Config
+users:
+- name: default
+  user:
+    client-certificate-data: REDACTED
+    client-key-data: REDACTED
+"""
+
+
+class TestRewriteServer:
+    """ADR-052 D1: only the port changes; the host stays 127.0.0.1."""
+
+    def test_rewrites_only_the_port_keeping_localhost(self) -> None:
+        out = rewrite_server(_K3S_YAML, 16443)
+        assert "server: https://127.0.0.1:16443" in out
+        assert "https://127.0.0.1:6443" not in out
+
+    def test_distinct_ports_isolate_clusters(self) -> None:
+        # Distinct local ports are what let several tunnels coexist.
+        assert rewrite_server(_K3S_YAML, 16444) != rewrite_server(_K3S_YAML, 16445)
+
+    def test_preserves_certs_and_line_count(self) -> None:
+        out = rewrite_server(_K3S_YAML, 16443)
+        assert "client-key-data: REDACTED" in out
+        assert out.count("\n") == _K3S_YAML.count("\n")  # only the server substring changed
+
+    def test_raises_when_default_server_absent(self) -> None:
+        with pytest.raises(ValueError, match="refusing to write"):
+            rewrite_server("server: https://10.0.0.1:6443\n", 16443)
+
+
+class TestClusterSSOT:
+    """`clusters.<name>` is read from common.yaml and validated."""
+
+    @pytest.fixture
+    def common_yaml(self, tmp_path: Path) -> Path:
+        p = tmp_path / "common.yaml"
+        p.write_text(
+            "clusters:\n"
+            "  staging:\n"
+            "    node: ace1\n"
+            "    ssh_alias: ace1\n"
+            "    local_port: 16443\n"
+            "  hub:\n"
+            "    node: aws1\n"
+            "    ssh_alias: aws1\n"
+            "    local_port: 16445\n"
+        )
+        return p
+
+    def test_load_clusters_parses_entries(self, common_yaml: Path) -> None:
+        clusters = load_clusters(common_yaml)
+        assert clusters["staging"] == ClusterAccess("staging", "ace1", "ace1", 16443)
+        assert clusters["hub"].local_port == 16445
+
+    def test_unknown_cluster_lists_valid_names(self, common_yaml: Path) -> None:
+        with pytest.raises(KeyError, match="hub, staging"):
+            load_cluster_access("dev", common_yaml)
+
+    def test_missing_required_key_raises(self, tmp_path: Path) -> None:
+        p = tmp_path / "common.yaml"
+        p.write_text("clusters:\n  staging:\n    node: ace1\n")  # no ssh_alias / local_port
+        with pytest.raises(KeyError, match="ssh_alias"):
+            load_clusters(p)
+
+
+class TestArgvAndPath:
+    def test_fetch_argv_is_a_remote_cat(self) -> None:
+        assert fetch_argv("ace1") == ["ssh", "ace1", "sudo", "cat", "/etc/rancher/k3s/k3s.yaml"]
+
+    def test_output_path_follows_kubeconfig_pattern(self) -> None:
+        assert output_path("staging").name == "kubelab-staging-config"
+        assert output_path("staging").parent.name == ".kube"
+
+
+class TestFetchKubeconfig:
+    """The orchestrator: mock the SSH read, redirect output, assert the file."""
+
+    def test_writes_rewritten_kubeconfig(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mocker) -> None:
+        common = tmp_path / "common.yaml"
+        common.write_text(
+            "clusters:\n  staging:\n    node: ace1\n    ssh_alias: ace1\n    local_port: 16443\n"
+        )
+        dest = tmp_path / ".kube" / "kubelab-staging-config"
+        monkeypatch.setattr(kc, "_common_path", lambda: common)
+        monkeypatch.setattr(kc, "output_path", lambda env: dest)
+        run = mocker.patch.object(
+            kc.command, "run_list", return_value=subprocess.CompletedProcess([], 0, _K3S_YAML, "")
+        )
+
+        out = kc.fetch_kubeconfig("staging")
+
+        assert out == dest
+        assert run.call_args.args[0] == ["ssh", "ace1", "sudo", "cat", "/etc/rancher/k3s/k3s.yaml"]
+        assert "server: https://127.0.0.1:16443" in dest.read_text()
+        assert "https://127.0.0.1:6443" not in dest.read_text()
+
+
+class TestCommittedSSOT:
+    """The committed common.yaml declares the three clusters coherently."""
+
+    def test_declares_staging_prod_hub_with_distinct_ports(self) -> None:
+        clusters = load_clusters()  # real common.yaml via settings.project_root
+        assert {"staging", "prod", "hub"} <= set(clusters)
+        ports = [c.local_port for c in clusters.values()]
+        assert len(ports) == len(set(ports)), "local_port must be unique per cluster"

--- a/toolkit/cli/infra.py
+++ b/toolkit/cli/infra.py
@@ -745,6 +745,34 @@ def k8s_status(
     logger.console.print(result.stdout)
 
 
+@k8s_app.command("fetch-kubeconfig")
+def k8s_fetch_kubeconfig(
+    env: Annotated[str, typer.Option("--env", "-e", help="Cluster to fetch (staging|prod|hub)")],
+) -> None:
+    """Fetch a cluster's kubeconfig with a transport-agnostic server (ADR-052).
+
+    Unifies and replaces the bespoke `fetch-kubeconfig-hub` Makefile target.
+    SSHes to the cluster's k3s server via its `clusters.<env>.ssh_alias`
+    (common.yaml SSOT), rewrites the apiserver to https://127.0.0.1:<local_port>,
+    and saves ~/.kube/kubelab-<env>-config (0600). The local port is mapped to the
+    real apiserver by the transport layer (`k8s connect`, ADR-052 Phase 2) -- direct
+    for prod's public IP, an SSH local-forward on the LAN, or ts-bridge over the
+    mesh -- so one kubeconfig works from any machine, including a non-admin box with
+    no native Tailscale.
+    """
+    from toolkit.core.logging import ExecutionError
+    from toolkit.features.k8s_kubeconfig import fetch_kubeconfig
+
+    try:
+        fetch_kubeconfig(env)
+    except KeyError as e:
+        logger.error(str(e))
+        raise typer.Exit(2) from e
+    except (ValueError, ExecutionError) as e:
+        logger.error(f"fetch-kubeconfig failed: {e}")
+        raise typer.Exit(1) from e
+
+
 # =============================================================================
 # ANSIBLE COMMANDS
 # =============================================================================

--- a/toolkit/features/k8s_kubeconfig.py
+++ b/toolkit/features/k8s_kubeconfig.py
@@ -1,0 +1,132 @@
+"""Fetch a per-cluster kubeconfig with a transport-agnostic server (ADR-052).
+
+Reads the ``clusters`` SSOT in ``common.yaml``, SSHes to the cluster's k3s
+server to read ``/etc/rancher/k3s/k3s.yaml``, rewrites the apiserver to a
+stable local endpoint (``https://127.0.0.1:<local_port>``), and saves it to
+``~/.kube/kubelab-<env>-config``.
+
+The local port is mapped to the real apiserver by the *transport*
+(``k8s connect``, ADR-052 Phase 2): direct for prod's public IP, an SSH
+local-forward on the LAN, or ts-bridge over the mesh. Pinning the kubeconfig
+to ``127.0.0.1`` is what lets one kubeconfig work from any machine — including
+a non-admin box with no native Tailscale — because k3s' server certificate
+SANs include ``127.0.0.1``, so TLS still verifies.
+
+The pure helpers (``load_cluster_access``, ``rewrite_server``, ``fetch_argv``,
+``output_path``) carry the logic and are unit-tested without a network; only
+``fetch_kubeconfig`` does I/O (the SSH read needs interactive key auth).
+"""
+
+import os
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from toolkit.config.settings import settings
+from toolkit.core.logging import logger
+from toolkit.features import command
+
+# k3s writes its admin kubeconfig here; the apiserver defaults to 127.0.0.1:6443.
+_K3S_KUBECONFIG_PATH = "/etc/rancher/k3s/k3s.yaml"
+_K3S_DEFAULT_SERVER = "https://127.0.0.1:6443"
+_KUBECONFIG_OUT_PATTERN = "~/.kube/kubelab-{env}-config"
+_REQUIRED_KEYS = ("node", "ssh_alias", "local_port")
+
+
+@dataclass(frozen=True)
+class ClusterAccess:
+    """Operator-access metadata for one cluster (the ``clusters.<name>`` SSOT)."""
+
+    name: str
+    node: str
+    ssh_alias: str
+    local_port: int
+
+    @classmethod
+    def from_dict(cls, name: str, data: dict[str, Any]) -> "ClusterAccess":
+        missing = [k for k in _REQUIRED_KEYS if k not in data]
+        if missing:
+            raise KeyError(f"clusters.{name} is missing required keys: {', '.join(missing)}")
+        return cls(
+            name=name,
+            node=str(data["node"]),
+            ssh_alias=str(data["ssh_alias"]),
+            local_port=int(data["local_port"]),
+        )
+
+
+def _common_path() -> Path:
+    return settings.project_root / "infra" / "config" / "values" / "common.yaml"
+
+
+def load_clusters(common_path: Path | None = None) -> dict[str, ClusterAccess]:
+    """Load every ``clusters.<name>`` entry from the common.yaml SSOT."""
+    path = common_path or _common_path()
+    with open(path) as f:
+        config = yaml.safe_load(f) or {}
+    raw = config.get("clusters") or {}
+    return {name: ClusterAccess.from_dict(name, data) for name, data in raw.items()}
+
+
+def load_cluster_access(env: str, common_path: Path | None = None) -> ClusterAccess:
+    """Resolve one cluster's access metadata; the error lists the valid names."""
+    clusters = load_clusters(common_path)
+    try:
+        return clusters[env]
+    except KeyError:
+        valid = ", ".join(sorted(clusters)) or "(none declared)"
+        raise KeyError(f"unknown cluster {env!r}; declared clusters: {valid}") from None
+
+
+def rewrite_server(kubeconfig_text: str, local_port: int) -> str:
+    """Repoint the apiserver to the stable local endpoint (ADR-052 D1).
+
+    ``k3s.yaml`` ships ``server: https://127.0.0.1:6443``. Only the port is
+    rewritten (the host stays ``127.0.0.1``) so TLS still verifies against the
+    k3s cert's ``127.0.0.1`` SAN. Raises if the expected default is absent —
+    failing loudly beats writing a kubeconfig that points nowhere.
+    """
+    if _K3S_DEFAULT_SERVER not in kubeconfig_text:
+        raise ValueError(
+            f"expected {_K3S_DEFAULT_SERVER!r} in the fetched kubeconfig; the k3s "
+            "default may have changed — refusing to write an unverified server"
+        )
+    return kubeconfig_text.replace(_K3S_DEFAULT_SERVER, f"https://127.0.0.1:{local_port}")
+
+
+def fetch_argv(ssh_alias: str) -> list[str]:
+    """SSH argv that prints the remote k3s admin kubeconfig to stdout."""
+    return ["ssh", ssh_alias, "sudo", "cat", _K3S_KUBECONFIG_PATH]
+
+
+def output_path(env: str) -> Path:
+    """Local kubeconfig path for a cluster (``~/.kube/kubelab-<env>-config``)."""
+    return Path(os.path.expanduser(_KUBECONFIG_OUT_PATTERN.format(env=env)))
+
+
+def fetch_kubeconfig(env: str) -> Path:
+    """Fetch, rewrite, and save the kubeconfig for one cluster. Returns the path.
+
+    The SSH read uses the operator's ``~/.ssh/config`` and needs interactive key
+    auth (passphrase / ssh-agent), so this runs from an operator shell, not an
+    unattended one.
+    """
+    access = load_cluster_access(env)
+    logger.section(f"Fetch kubeconfig — {env} (node {access.node}, ssh {access.ssh_alias})")
+
+    result = command.run_list(fetch_argv(access.ssh_alias))
+    rewritten = rewrite_server(result.stdout, access.local_port)
+
+    dest = output_path(env)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(rewritten)
+    dest.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600 — kubeconfig holds admin certs
+
+    logger.success(
+        f"Saved {dest} (server https://127.0.0.1:{access.local_port}). "
+        f"Bring up the transport for {env} before using kubectl (ADR-052 `k8s connect`)."
+    )
+    return dest


### PR DESCRIPTION
## What

Establishes how an operator machine **obtains and uses a kubeconfig per cluster** so deploy/apply works identically on the home LAN, off-network over the VPN, from CI, and from a corporate **non-admin box with no native Tailscale**. Ratifies the convention as **ADR-052** and ships its first implementation, **#723** (`fetch-kubeconfig`). Owner-bootstrap only — per-user collaborator access is deferred (ADR-052 D5).

Closes #723.

## Why

The only precedent (`make fetch-kubeconfig-hub`) rewrites the kubeconfig `server` to the node's **MagicDNS** name, which silently assumes the consuming machine has native Tailscale. The primary workstation is a non-admin box whose only mesh transport is **ts-bridge** (userspace `tsnet`, no TUN) — it can reach a mesh service **only via a forwarded `127.0.0.1:<port>`**, so MagicDNS-in-`server` produces a kubeconfig that does not work there.

## ADR-052 decisions

- **D1** — transport-agnostic kubeconfig: `server: https://127.0.0.1:<fixed-per-env-port>` (TLS valid via k3s' `127.0.0.1` SAN). The transport maps that local port to the apiserver; the kubeconfig never encodes *how*. SOCKS `proxy-url` noted as a future variant.
- **D2** — per-cluster access metadata is **SSOT in `common.yaml`** (`clusters.<name>`: node ref, ssh alias, local port). Adding a cluster is a YAML edit; addresses are referenced from `networking.*`, never duplicated.
- **D3** — capability-selected transport, default mesh, detected fast paths (prod→public IP; staging→LAN `ssh -L`; else ts-bridge).
- **D4** — one unified `fetch-kubeconfig --env {staging,prod,hub}`; the inline `fetch-kubeconfig-hub` target is retired (one pattern, no inline Makefile shell). `HUB_KUBECONFIG` (the path var used by `deploy-argocd`) is unchanged.
- **D5** — owner-bootstrap only; collaborator access (Authelia OIDC + RBAC + Headscale ACLs / VPNACL-001) is a separate spec.

## Changes

- `docs/adr/adr-052-cluster-access-transport.md` — the decision (Regla del 3 audit, options, consequences).
- `infra/config/values/common.yaml` — `clusters:` SSOT block (staging/prod/hub).
- `toolkit/features/k8s_kubeconfig.py` — pure helpers (load SSOT / rewrite server / ssh argv / output path) + the `fetch_kubeconfig` orchestrator.
- `toolkit/cli/infra.py` — `infra k8s fetch-kubeconfig` command.
- `Makefile` — `fetch-kubeconfig` delegates to the toolkit; retires `fetch-kubeconfig-hub`.
- `tests/test_k8s_kubeconfig.py` — 11 tests (server rewrite, SSOT load/validation, argv/path, mocked orchestrator, committed-SSOT coherence). Feature module at 100% coverage.

## Verification

- `tests/test_k8s_kubeconfig.py` → 11 passed; `k8s_kubeconfig.py` coverage 100%.
- `toolkit infra k8s fetch-kubeconfig --help` registers and renders.
- pre-commit green (ruff, mypy, yamllint).
- The actual SSH fetch + cluster apply are **not** exercised here — they need interactive key auth from a mesh-capable context (run by the operator or a Tailscale-native CI node). This unblocks #724 (apply postgres-secrets) using single-target ts-bridge; the ergonomic `k8s connect` helper + ts-bridge #186 are Phase 2.

## Follow-ups (tracked, not in this PR)

- Phase 2: `k8s connect` (ts-bridge lifecycle) + onboarding runbook + ts-bridge #186 (multi-target) / SOCKS.
- Phase 3: collaborator OIDC/RBAC (separate spec, VPNACL-001).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified `fetch-kubeconfig` command supporting staging, prod, and hub environments with transport-agnostic cluster connectivity.

* **Refactor**
  * Replaced environment-specific kubeconfig retrieval with generalized, configuration-driven approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->