### PR TITLE
fix(toolkit): auto-discover the SOPS age key (no per-shell setup)

### DIFF
--- a/tests/test_sops_age_key.py
+++ b/tests/test_sops_age_key.py
@@ -1,0 +1,61 @@
+"""Tests for SOPS age-key auto-discovery (toolkit/core/sops.py).
+
+Guards the recurrence where a fresh shell without SOPS_AGE_KEY_FILE fails to
+decrypt because the key lives at ~/.config/age/key.txt, not the sops default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from toolkit.core import sops
+
+
+class TestResolveAgeKeyFile:
+    def test_honors_existing_override(self, tmp_path: Path) -> None:
+        key = tmp_path / "explicit.txt"
+        key.write_text("k")
+        assert sops.resolve_age_key_file({"SOPS_AGE_KEY_FILE": str(key)}) == str(key)
+
+    def test_falls_through_when_override_points_nowhere(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        conv = tmp_path / ".config" / "age" / "key.txt"
+        conv.parent.mkdir(parents=True)
+        conv.write_text("k")
+        env = {"SOPS_AGE_KEY_FILE": str(tmp_path / "nope.txt")}
+        assert sops.resolve_age_key_file(env) == str(conv)
+
+    def test_prefers_sops_default_over_repo_convention(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        default = tmp_path / ".config" / "sops" / "age" / "keys.txt"
+        default.parent.mkdir(parents=True)
+        default.write_text("k")
+        conv = tmp_path / ".config" / "age" / "key.txt"
+        conv.parent.mkdir(parents=True)
+        conv.write_text("k")
+        assert sops.resolve_age_key_file({}) == str(default)
+
+    def test_returns_none_when_no_key_anywhere(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        assert sops.resolve_age_key_file({}) is None
+
+
+class TestAgeKeyEnv:
+    def test_sets_var_when_key_found_and_preserves_base_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        conv = tmp_path / ".config" / "age" / "key.txt"
+        conv.parent.mkdir(parents=True)
+        conv.write_text("k")
+        out = sops.age_key_env({"PATH": "/x"})
+        assert out["SOPS_AGE_KEY_FILE"] == str(conv)
+        assert out["PATH"] == "/x"
+
+    def test_returns_base_env_unchanged_when_no_key(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        out = sops.age_key_env({"PATH": "/x"})
+        assert "SOPS_AGE_KEY_FILE" not in out
+        assert out == {"PATH": "/x"}

--- a/toolkit/cli/credentials.py
+++ b/toolkit/cli/credentials.py
@@ -9,6 +9,7 @@ import yaml
 from toolkit.config.constants import MESSAGES, PATH_STRUCTURES
 from toolkit.config.settings import PROJECT_ROOT, settings
 from toolkit.core.logging import logger
+from toolkit.core.sops import age_key_env
 from toolkit.features.credentials import credentials_manager
 from toolkit.features.github_secrets import github_secrets_manager
 
@@ -42,6 +43,7 @@ def _decrypt_secrets_file(env: str) -> dict[str, Any]:
         capture_output=True,
         text=True,
         check=True,
+        env=age_key_env(),  # auto-discover SOPS_AGE_KEY_FILE (toolkit/core/sops.py)
     )
     return yaml.safe_load(result.stdout) or {}
 

--- a/toolkit/cli/secrets.py
+++ b/toolkit/cli/secrets.py
@@ -23,6 +23,7 @@ import typer
 
 from toolkit.config.settings import settings
 from toolkit.core.logging import logger
+from toolkit.core.sops import age_key_env
 
 if TYPE_CHECKING:
     from toolkit.features.secrets_manager import AuditResult, SecretsManager
@@ -81,7 +82,7 @@ def edit(
     logger.info(f"Opening {sops_file.name} with {editor}...")
 
     try:
-        sops_env = {**os.environ, "EDITOR": editor}
+        sops_env = {**age_key_env(), "EDITOR": editor}
         result = subprocess.run(
             ["sops", "edit", str(sops_file)],
             env=sops_env,

--- a/toolkit/core/sops.py
+++ b/toolkit/core/sops.py
@@ -1,0 +1,55 @@
+"""Resolve the SOPS age-key location so decryption works without per-shell setup.
+
+SOPS looks for the age key at its platform-default path
+(``~/.config/sops/age/keys.txt`` on Linux/macOS, ``%APPDATA%\\sops\\age\\keys.txt``
+on Windows). This repo's key lives at ``~/.config/age/key.txt``, so unless
+``SOPS_AGE_KEY_FILE`` is exported, a fresh shell — ``make test``, a cold deploy,
+the agent harness, a new clone — fails to decrypt with a cryptic
+"failed to get the data key" error.
+
+``age_key_env()`` augments an environment with ``SOPS_AGE_KEY_FILE`` pointing at
+the first key it finds, so every sops subprocess in the toolkit is self-sufficient
+regardless of shell configuration. An already-set, existing ``SOPS_AGE_KEY_FILE``
+is always honored first (the override; CI sets it to the ci key); if no key is
+found the environment is returned unchanged and sops emits its own failure.
+"""
+
+import os
+from pathlib import Path
+
+
+def _candidate_key_paths(env: dict[str, str]) -> list[Path]:
+    """Conventional age-key locations, most-standard first."""
+    home = Path.home()
+    candidates = [home / ".config" / "sops" / "age" / "keys.txt"]  # sops default (Linux/macOS)
+    appdata = env.get("APPDATA")
+    if appdata:
+        candidates.append(Path(appdata) / "sops" / "age" / "keys.txt")  # sops default (Windows)
+    candidates.append(home / ".config" / "age" / "key.txt")  # repo convention
+    return candidates
+
+
+def resolve_age_key_file(env: dict[str, str] | None = None) -> str | None:
+    """Return a path to an existing age key, or None if none is found.
+
+    Honors an already-set, existing ``SOPS_AGE_KEY_FILE`` first (the override),
+    then probes the platform-default and repo-convention locations.
+    """
+    src = env if env is not None else dict(os.environ)
+    explicit = src.get("SOPS_AGE_KEY_FILE")
+    if explicit and Path(explicit).expanduser().is_file():
+        return explicit
+    for candidate in _candidate_key_paths(src):
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def age_key_env(base_env: dict[str, str] | None = None) -> dict[str, str]:
+    """Copy ``base_env`` (default ``os.environ``) with ``SOPS_AGE_KEY_FILE`` set if
+    a key is discoverable; otherwise return it unchanged."""
+    env = dict(base_env if base_env is not None else os.environ)
+    key = resolve_age_key_file(env)
+    if key:
+        env["SOPS_AGE_KEY_FILE"] = key
+    return env

--- a/toolkit/features/configuration.py
+++ b/toolkit/features/configuration.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
+from toolkit.core.sops import age_key_env
+
 # Removed top-level logger import to avoid circular dependency
 # from toolkit.core.logging import logger
 
@@ -60,7 +62,7 @@ class ConfigurationManager:
                 capture_output=True,
                 text=True,
                 check=True,
-                env=os.environ,  # Inherit current environment variables
+                env=age_key_env(),  # auto-discover SOPS_AGE_KEY_FILE (toolkit/core/sops.py)
             )
             return yaml.safe_load(result.stdout) or {}
         except subprocess.CalledProcessError as e:
@@ -268,7 +270,7 @@ class ConfigurationManager:
                 text=True,
                 check=True,
                 capture_output=True,
-                env=os.environ,
+                env=age_key_env(),  # auto-discover SOPS_AGE_KEY_FILE (toolkit/core/sops.py)
             )
             self._get_logger().info(f"Created encrypted file: {file_path}")
             return True
@@ -299,7 +301,7 @@ class ConfigurationManager:
                 text=True,
                 check=True,
                 capture_output=True,
-                env=os.environ,
+                env=age_key_env(),  # auto-discover SOPS_AGE_KEY_FILE (toolkit/core/sops.py)
             )
             return True
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Problem (recurring)

A fresh shell — `make test`, a cold deploy, the agent harness, a new clone — fails to decrypt SOPS with a cryptic `failed to get the data key`. Root cause: `configuration.py:_decrypt_sops` (and the other sops calls) pass a bare `env=os.environ`, so sops looks for the age key at its **platform-default path**. This repo's key lives at `~/.config/age/key.txt`, and `SOPS_AGE_KEY_FILE` is never persisted, so without exporting it every cold shell breaks. We've hit this several times.

## Fix

`toolkit/core/sops.age_key_env()` augments the environment handed to every sops subprocess with `SOPS_AGE_KEY_FILE` pointing at the first key it finds:

1. an already-set, existing `SOPS_AGE_KEY_FILE` (the override — CI uses this),
2. the sops platform default (`~/.config/sops/age/keys.txt`, or `%APPDATA%\sops\age\keys.txt`),
3. the repo convention (`~/.config/age/key.txt`).

Wired into all five sops call sites: `configuration` decrypt + two encrypts, `credentials` decrypt, `secrets edit`. The toolkit is now self-sufficient on any machine where the key exists at a conventional path; the env var remains the explicit override.

## Verification

- `make test` (in a shell with **no** `SOPS_AGE_KEY_FILE`): **266 passed, 0 failed**. The previously-failing SOPS-dependent suites (`test_k8s_secrets_users_db`, `test_k8s_secrets_apprise`) now pass via auto-discovery.
- New `tests/test_sops_age_key.py` — 6 tests (override honored, fall-through, default-vs-convention precedence, none-found, env augmentation/preservation).
- pre-commit green (ruff, mypy).

## Scope / follow-up

This is the **toolkit-side** layer: the repo decrypts itself on any machine with the key at a conventional path. The **machine-wide / onboarding** layer (persist the key at the default path + `dotf doctor` decrypt check, for every tool not just kubelab) stays tracked as **dotfiles #518**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SOPS encryption/decryption now includes automatic age key discovery from standard configuration paths, searching platform-specific locations and repository conventions.

* **Tests**
  * Added comprehensive test coverage for age key auto-discovery, resolution, and environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->