### PR TITLE
feat(toolkit): cluster access transport connect/disconnect/status (ADR-052, #731)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,6 +384,21 @@ HUB_KUBECONFIG := ~/.kube/kubelab-hub-config
 fetch-kubeconfig:
 	@$(TOOLKIT) infra k8s fetch-kubeconfig --env $(ENV)
 
+# Cluster-access transport (ADR-052 Phase 2): map 127.0.0.1:<local_port> to the
+# env's apiserver -- ts-bridge over the mesh (staging|hub) or the direct public
+# endpoint (prod). Idempotent. ENV=staging|prod|hub (the toolkit rejects others).
+.PHONY: connect
+connect:
+	@$(TOOLKIT) infra k8s access connect --env $(ENV)
+
+.PHONY: disconnect
+disconnect:
+	@$(TOOLKIT) infra k8s access disconnect --env $(ENV)
+
+.PHONY: connect-status
+connect-status:
+	@$(TOOLKIT) infra k8s access status --env $(ENV)
+
 .PHONY: deploy-argocd
 deploy-argocd: _deploy-authelia-oidc _deploy-argocd-helm
 

--- a/docs/runbooks/operate-from-new-workstation.md
+++ b/docs/runbooks/operate-from-new-workstation.md
@@ -1,0 +1,116 @@
+---
+id: operate-from-new-workstation
+type: runbook
+status: active
+created: "2026-06-21"
+owner: manu
+---
+
+# Operate the KubeLab clusters from a new workstation
+
+> Run `kubectl`, `make apply-secrets`, and `make deploy-k8s` against any cluster
+> (staging / prod / hub) from a fresh machine -- including a **corporate, non-admin**
+> Windows box with no native Tailscale. Two steps: fetch a kubeconfig once, bring up
+> the transport per session. Implements ADR-052 (`fetch-kubeconfig` + `k8s access`).
+
+## How it works (the one idea)
+
+Every fetched kubeconfig pins its apiserver to a **stable local endpoint**,
+`https://127.0.0.1:<local_port>` -- never a mesh name or a public IP. That works on
+*every* machine because the k3s server certificate's SANs include `127.0.0.1`, so TLS
+still verifies. The **transport** is what maps that local port to the real apiserver,
+and it is swappable per machine:
+
+| Env | local_port | Transport | Target (derived from the SSOT) |
+|-----|-----------|-----------|--------------------------------|
+| staging | 16443 | ts-bridge over the mesh | `networking.nodes.ace1.tailscale_ip:6443` |
+| prod | 16444 | **direct public endpoint, no tunnel** | `networking.vps.public_ip:6443` |
+| hub | 16445 | ts-bridge over the mesh | `networking.aws.tailscale_ip:6443` |
+
+The kubeconfig is stable; only the transport changes. That is what lets one
+convention serve a native-Tailscale laptop, a CI runner, and a non-admin box alike.
+
+## Prerequisites
+
+- **ts-bridge** installed and its `.env` configured (`TS_AUTHKEY` + `TS_CONTROL_URL=https://vpn.kubelab.live`).
+  Full install + Headscale pre-auth-key steps: [`non-admin-workstation-access.md`](non-admin-workstation-access.md) §3.
+  The toolkit reuses **ts-bridge's own** `.env` credentials -- it never handles the Headscale key itself.
+- **SSH access** to the cluster's k3s server node (for the one-time `fetch-kubeconfig`),
+  with the agent loaded so the passphrase is entered once:
+  `eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_ed25519` (Git Bash, no admin).
+  See [`non-admin-workstation-access.md`](non-admin-workstation-access.md) for the SSH paths and passphrase ergonomics.
+- The repo checked out, toolkit installed (`make setup`).
+
+## Step 1 -- Fetch the kubeconfig (once per machine, per cluster)
+
+This SSHes to the k3s server, reads its admin kubeconfig, rewrites the apiserver to
+`https://127.0.0.1:<local_port>`, and saves `~/.kube/kubelab-<env>-config` (0600). It
+needs an **interactive** shell (the SSH read prompts for the key) -- run it yourself,
+not from an unattended agent.
+
+```bash
+make fetch-kubeconfig ENV=staging
+```
+
+## Step 2 -- Bring up the transport (per session)
+
+```bash
+make connect ENV=staging          # idempotent: a clean no-op if already up
+```
+
+- **staging / hub** spawn ts-bridge detached, mapping `127.0.0.1:<local_port>` to the
+  node's mesh address, and wait for the local port to answer before returning.
+- **prod** starts no tunnel -- it verifies the public apiserver is reachable and
+  reports it. (The prod kubeconfig targets the public endpoint directly.)
+
+Locate the ts-bridge binary via `TS_BRIDGE_BIN`, else `~/Apps/ts-bridge/`, else `PATH`.
+
+## Step 3 -- Use the cluster
+
+```bash
+kubectl --kubeconfig ~/.kube/kubelab-staging-config get ns
+make apply-secrets ENV=staging
+make deploy-k8s   ENV=staging
+```
+
+## Inspect / tear down
+
+```bash
+make connect-status ENV=staging   # up/down + the resolved transport
+make disconnect     ENV=staging   # terminates ts-bridge, removes the statefile
+```
+
+State for `disconnect` lives in `~/.kube/.kubelab-transport-<env>.json` (pid + port + target).
+
+## Gotchas
+
+- **One transport at a time.** v1 keeps a single ts-bridge instance up; switching env
+  means `disconnect` then `connect`. Simultaneous multi-cluster tunnels are tracked as
+  ts-bridge#186.
+- **`fetch-kubeconfig` / `connect` need your interactive shell.** Passphrase SSH and
+  ts-bridge bring-up cannot run non-interactively -- the toolkit is the deliverable, you
+  run the bootstrap (ADR-052).
+- **ts-bridge must have `TS_CONTROL_URL=https://vpn.kubelab.live` in its `.env`.** Without
+  it the `hskey-` auth key hits Tailscale SaaS and fails -- the transport never comes up
+  and `connect` times out waiting for the local port.
+- **prod is the public path.** `make connect ENV=prod` is a reachability check, not a
+  tunnel; if prod's apiserver is firewalled from your network, it reports UNREACHABLE.
+- **No hardcoded addresses.** Targets are derived from `clusters.<env>.node` against
+  `networking.*` in `common.yaml`; change a node's `tailscale_ip` there and the
+  transport follows. Nothing to edit in code or kubeconfig.
+
+## Verify
+
+```bash
+make connect ENV=staging && kubectl --kubeconfig ~/.kube/kubelab-staging-config get ns
+make connect ENV=staging                       # second run is a clean no-op (exit 0)
+make connect-status ENV=staging                # reports UP
+make disconnect ENV=staging                    # tears it down
+```
+
+## References
+
+- [ADR-052](../adr/adr-052-cluster-access-transport.md) -- cluster access transport (this is its `connect` step)
+- [`non-admin-workstation-access.md`](non-admin-workstation-access.md) -- ts-bridge install, Headscale pre-auth key, SSH paths, passphrase agent
+- [`headscale-setup.md`](headscale-setup.md) -- Headscale operations, §7 ts-bridge
+- `specs/TOOL-014-k8s-connect/` -- the spec behind these commands; tracking issue kubelab#731

--- a/specs/TOOL-014-k8s-connect/features.json
+++ b/specs/TOOL-014-k8s-connect/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "TOOL-014-k8s-connect-f1",
+    "behavior": "make connect ENV=staging brings up the transport idempotently and kubectl get ns succeeds against staging",
+    "verification": "make connect ENV=staging && kubectl --kubeconfig ~/.kube/kubelab-staging-config get ns",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "TOOL-014-k8s-connect-f2",
+    "behavior": "Re-running connect when already up is a clean no-op (exit 0)",
+    "verification": "make connect ENV=staging && make connect ENV=staging",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "TOOL-014-k8s-connect-f3",
+    "behavior": "access status reports up/down + resolved transport; disconnect tears it down cleanly",
+    "verification": "poetry run toolkit infra k8s access status --env staging && make disconnect ENV=staging && poetry run toolkit infra k8s access status --env staging",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "TOOL-014-k8s-connect-f4",
+    "behavior": "No hardcoded IPs; pure resolver/idempotency helpers unit-tested without network",
+    "verification": "poetry run pytest tests/ -k k8s_connect -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "TOOL-014-k8s-connect-f5",
+    "behavior": "Onboarding runbook lets a fresh non-admin workstation reach staging end-to-end",
+    "verification": "test -f docs/runbooks/operate-from-new-workstation.md",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/TOOL-014-k8s-connect/proposal.md
+++ b/specs/TOOL-014-k8s-connect/proposal.md
@@ -1,0 +1,65 @@
+---
+id: "TOOL-014-k8s-connect"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-21"
+issue: "kubelab#731"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# TOOL-014: K8s connect — idempotent cluster-access transport
+
+> **Naming**: file lives at `<repo>/specs/<feature-id>/proposal.md`. `<feature-id>` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #731: TOOL-014: toolkit infra k8s connect — idempotent cluster-access transport + onboarding runbook -->
+
+Operating any kubelab cluster needs a kubeconfig whose `server:` endpoint is reachable from the machine running `kubectl`. `fetch-kubeconfig` (#723/#728) already pins every kubeconfig to `https://127.0.0.1:<fixed-per-env-port>`, but nothing maps that local port to the real apiserver yet — so `make apply-secrets` / `deploy-k8s` cannot run from the primary workstation (EGW-LEN029, corporate, non-admin, no native Tailscale), which blocks #724 (apply postgres-secrets) on the CONSOLE-002 critical path. Today reaching the cluster is an undocumented manual dance (rediscover the ts-bridge invocation, the SSH paths, which one works) that recurs every session. This codifies the transport as idempotent IaC + an onboarding runbook so the "how do I reach the cluster from this machine" discussion stops happening.
+
+## What
+
+Three new toolkit subcommands under a dedicated sub-noun, `toolkit infra k8s access {connect,disconnect,status} --env {staging,prod,hub}`, data-driven from the `clusters:` SSOT in `common.yaml`; delegating `make connect|disconnect|connect-status ENV=x` targets (no inline Makefile scripts; `connect-status` avoids a too-generic `make status`); and an onboarding runbook. The legacy `infra k8s status` (namespace workloads) is left untouched. Concrete outputs after this PR:
+
+- `make connect ENV=staging` brings up a transport that maps `127.0.0.1:16443` to ace1's apiserver over the Headscale mesh (ts-bridge, userspace — works on a non-admin box), idempotently.
+- `make connect ENV=prod` resolves prod's public apiserver endpoint directly (no tunnel).
+- `infra k8s access status --env x` reports whether the transport is up/down and which transport was resolved; `make disconnect ENV=x` tears it down cleanly.
+- After `connect`, `kubectl --kubeconfig ~/.kube/kubelab-staging-config get ns` succeeds against staging.
+
+## Out of scope
+
+Things this PR explicitly does NOT include. Forces a sharp boundary and prevents scope creep.
+
+- LAN `ssh -L` fast path and the SSH layer it needs — `deployer` bastion auth, multi-key `authorized_keys`, parameterizing `AllowTcpForwarding` on rpi4. That is #719.
+- ts-bridge multi-target (simultaneous multi-cluster `connect`) — ts-bridge#186; v1 keeps one transport up at a time.
+- SOCKS `proxy-url` kubeconfig variant (real server names through one proxy) — a later optimization adoptable without breaking the `127.0.0.1` contract.
+- Collaborator / per-user access (OIDC + kube-apiserver RBAC + Headscale ACLs) — ADR-052's collaborator axis / VPNACL-001.
+
+## Risks / open questions
+
+Failure modes, dependencies, and unknowns to clarify before implementation. Resolved leans are noted; the one empirical unknown is a verification step, not a code blocker.
+
+- **Node-ref heterogeneity (RESOLVED).** `clusters.staging.node: ace1` lives under `networking.nodes.ace1`, but `prod.node: vps` and `hub.node: aws1` live at `networking.vps` / `networking.aws` (top level), not under `nodes.*`. The mesh-target resolver is position-aware — the same homelab-vs-cloud lookup the Ansible generator uses (SSOT-014a). The whole target is **derived** from the existing `clusters.<env>.node` against `networking.*`; the apiserver port defaults to 6443 in code (overridable via `clusters.<env>.apiserver_port`). Net result: **no edit to the `clusters:` block at all** — even better than adding a field, and zero new IPs anywhere.
+- **ts-bridge lifecycle (RESOLVED).** ts-bridge runs in the foreground and is single-target. `connect` spawns it detached, records pid + env + local port in a statefile (idempotency + `disconnect`), and only one env's transport is up at a time (switching env tears down first). Multi-target is #186.
+- **ts-bridge auth (RESOLVED).** Reuse the already-configured `~/Apps/ts-bridge/.env` credentials (`TS_AUTHKEY`, `TS_CONTROL_URL`) — ts-bridge owns its own auth SSOT; do not duplicate the Headscale preauth key into kubelab SOPS.
+- **Binary discovery (RESOLVED).** Locate the ts-bridge binary via a configurable path (`TS_BRIDGE_BIN` env, else a sensible default) and fail with a clear, actionable error if absent — never a silent failure.
+- **Empirical unknown (verify during implementation, not a blocker).** That ts-bridge's userspace `tsnet` reaches `ace1:6443` over Headscale from EGW-LEN029 reliably. Proven out by the staging acceptance run, not by reasoning.
+- **Operator-shell constraint (accepted, from ADR-052).** Passphrase SSH (for `fetch-kubeconfig`) and ts-bridge bring-up need the operator's interactive shell / ssh-agent; the toolkit is the deliverable, the human runs the bootstrap. The agent shell cannot do it non-interactively.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+- [ ] `make connect ENV=staging` brings up the transport idempotently and `kubectl --kubeconfig ~/.kube/kubelab-staging-config get ns` succeeds.
+- [ ] Re-running `connect` when already up is a clean no-op (exit 0, detected via `access status`).
+- [ ] `infra k8s access status --env x` reports up/down + the resolved transport per env; `make disconnect ENV=x` tears it down cleanly.
+- [ ] No hardcoded IPs — every address resolves from `networking.*` / `clusters.*` SSOT; pure resolver/idempotency helpers unit-tested without network.
+- [ ] `docs/runbooks/operate-from-new-workstation.md` lets a fresh non-admin workstation reach staging end-to-end.
+
+## References
+
+- Bitácora board: kubelab#731 (this spec's tracking issue; see the `issue:` frontmatter field)
+- Related ADR: `docs/adr/adr-052-cluster-access-transport.md` (this is its `connect` backlog item)
+- Upstream: #723 / #728 (fetch-kubeconfig — the kubeconfig side, on master); downstream consumer #724 (apply postgres-secrets, CONSOLE-002)
+- Distinct scope: #719 (non-admin SSH access hardening); ts-bridge#186 (multi-target); VPNACL-001 (collaborator access)

--- a/specs/TOOL-014-k8s-connect/tasks.md
+++ b/specs/TOOL-014-k8s-connect/tasks.md
@@ -1,0 +1,64 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-06-21"
+---
+
+# Tasks - TOOL-014-k8s-connect
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+
+## Setup
+
+- [x] Branch created from main: `feat/TOOL-014-k8s-connect`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" (the one empirical unknown is a verify step, not a blocker)
+
+## Implementation
+
+> TDD order. Pure helpers first (unit-tested, no network), then the I/O commands, then CLI + Makefile + runbook.
+
+- [x] SSOT: **derive** the target (no `clusters:` edit needed) — `apiserver_port` defaults to 6443 in code, overridable via `clusters.<env>.apiserver_port`
+- [x] Test: position-aware mesh-target resolver — `staging->networking.nodes.ace1.tailscale_ip`, `prod->networking.vps`, `hub->networking.aws` — derives `host:apiserver_port`, never hardcodes an IP
+- [x] Implement the resolver in `toolkit/features/k8s_connect.py` (`_node_block`, reuses the SSOT-014a homelab-vs-cloud lookup)
+- [x] Test: transport selection — prod resolves the public endpoint (direct), staging/hub resolve ts-bridge over the mesh
+- [x] Implement transport selection (capability: a node with `public_ip` -> public; else ts-bridge mesh)
+- [x] Test: ts-bridge argv builder (`--target`, `--local-addr`, `--manual-mode`) + binary discovery (`TS_BRIDGE_BIN` -> default -> PATH; clear error when absent)
+- [x] Implement argv builder + binary discovery
+- [x] Test: transport statefile read/write/path (pid + env + local_port) drives idempotency
+- [x] Implement the statefile model
+- [x] Implement `access status` (pure check: statefile + `127.0.0.1:<local_port>` listening -> up/down + resolved transport)
+- [x] Implement `access connect` (idempotent: no-op if up for env; else spawn detached, write statefile, healthcheck the local port)
+- [x] Implement `access disconnect` (read statefile, terminate, remove statefile; no-op if already down)
+- [x] Wire the `access` sub-Typer under `k8s_app` in `toolkit/cli/infra.py` (legacy `k8s status` untouched)
+- [x] Add delegating `make connect|disconnect|connect-status ENV=x` targets (no inline scripts)
+- [x] Write `docs/runbooks/operate-from-new-workstation.md`
+
+## Closing
+
+- [x] Every acceptance criterion from `proposal.md` is covered by a test (AC1 live-validation pending; code path unit-tested)
+- [x] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [x] Type checks pass (my files; 2 pre-existing unrelated errors in `generator_authelia.py`)
+- [x] Lint passes
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in
+- [ ] PR opened referencing this spec folder (pending user authorization to commit)
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/<feature-id>/features.json`):
+
+```json
+[
+  {
+    "id": "<feature-id>-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/TOOL-014-k8s-connect/verification.md
+++ b/specs/TOOL-014-k8s-connect/verification.md
@@ -1,0 +1,50 @@
+---
+tags: [spec, verification, templates]
+created: "2026-06-21"
+---
+
+# Verification - TOOL-014-k8s-connect
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [!] **AC1** (`make connect ENV=staging` + `kubectl get ns`) -> **PENDING live validation** against staging (needs homelab on + ts-bridge joining the mesh). Code path implemented + unit-tested (`resolve_transport`, `ts_bridge_argv`, healthcheck loop).
+- [x] **AC2** (idempotent no-op) -> `_port_listening` short-circuit in `connect()`; manual: `make connect-status ENV=staging` reports down cleanly, re-runs are no-ops.
+- [x] **AC3** (`access status` + `disconnect`) -> tests `TestTransportState`; manual: `make connect-status ENV=staging` (ts-bridge target, down), `make disconnect ENV=prod` (public no-op).
+- [x] **AC4** (no hardcoded IPs; pure helpers unit-tested) -> `tests/test_k8s_connect.py::TestResolveTransport::test_no_hardcoded_ips_target_comes_from_the_ssot` + `TestCommittedSSOT` (18 tests, no network).
+- [x] **AC5** (onboarding runbook) -> `docs/runbooks/operate-from-new-workstation.md`.
+
+## Test status
+
+- Unit (feature): `poetry run pytest tests/test_k8s_connect.py -q` -> **18 passed**.
+- Unit (full, excl. e2e): `poetry run pytest tests/ --ignore=tests/e2e -q` -> **295 passed, 21 deselected** (no regressions; sibling `test_k8s_kubeconfig` green).
+- Lint: `make lint` -> **All checks passed** (ruff check + format).
+- Type: `make type` -> my files clean; 2 pre-existing errors in `generator_authelia.py` (`os.geteuid` on Windows), unrelated.
+- Manual smoke: `make connect-status ENV=staging` (resolves ts-bridge -> 100.64.0.11:6443, reports down), `make disconnect ENV=prod` (public no-op), unknown-env -> exit 2 listing `hub, prod, staging`.
+- **Not yet exercised:** live `make connect ENV=staging` end-to-end (the only network-dependent AC).
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+- **Sub-noun `infra k8s access *` instead of flat verbs** — `infra k8s status` already exists (namespace workloads); nesting the transport trio avoids the collision and leaves the legacy command untouched.
+- **prod is a no-op, not a tunnel** — ts-bridge dials targets *through* the mesh, so it cannot reach a public IP outside the mesh. "prod public, no tunnel" means prod's cert SAN covers the public IP and `connect prod` only verifies reachability (the prod kubeconfig targets the public apiserver directly). Full prod end-to-end is deferred (acceptance is staging-focused).
+- **Derive, don't extend the SSOT** — the transport target is computed from the existing `clusters.<env>.node` against `networking.*` (position-aware, mirrors SSOT-014a). No edit to the `clusters:` block; apiserver port defaults to 6443 in code. Stronger SSOT-purity than adding a field.
+- **ASCII-only CLI/log strings** — `→`/`—` (U+2192/U+2014) crash Typer/Rich `--help` rendering on the Windows cp1252 console (`UnicodeEncodeError`). Same class as the SOPS-basename portability trap. Replaced with `->`/`-`.
+- **Idempotency keyed on the local port, not pid liveness** — `_port_listening(127.0.0.1:<local_port>)` is the cross-platform "is it up" check; the statefile carries the pid only for `disconnect`.
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [x] Lesson for the repo's `docs/lessons.md`? **yes** — non-ASCII (`→`/`—`) in Typer/Rich CLI help/log strings crashes `--help` on the Windows cp1252 console; keep CLI strings ASCII (same class as the SOPS-basename portability trap).
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? **no** — ADR-052 already covers the transport design; this is its implementation.
+- [ ] New pattern candidate for `00_meta/patterns/`? **no** — repo-local, not cross-project.
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/<feature-id>/` -> `specs/archive/<feature-id>/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)

--- a/tests/test_k8s_connect.py
+++ b/tests/test_k8s_connect.py
@@ -1,0 +1,192 @@
+"""Tests for the cluster-access transport feature (ADR-052 Phase 2 / TOOL-014).
+
+Cover the pure helpers — transport resolution from the SSOT, ts-bridge argv,
+binary discovery, and transport-state (de)serialization — without any network.
+The process spawn / port probe / kill live in connect/disconnect/status, which
+are not exercised here (they need a live mesh).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from toolkit.features import k8s_connect as tc
+from toolkit.features.k8s_connect import (
+    ClusterTransport,
+    TransportState,
+    locate_ts_bridge,
+    resolve_transport,
+    statefile_path,
+    ts_bridge_argv,
+)
+
+# A fixture common.yaml exercising all three node positions:
+#   - homelab node under networking.nodes.* (ace1)
+#   - cloud vps at networking.vps (has a public_ip -> "public" transport)
+#   - cloud aws at networking.aws (mesh-only)
+_COMMON = """\
+clusters:
+  staging:
+    node: ace1
+    ssh_alias: ace1
+    local_port: 16443
+  prod:
+    node: vps
+    ssh_alias: vps
+    local_port: 16444
+  hub:
+    node: aws1
+    ssh_alias: aws1
+    local_port: 16445
+networking:
+  vps:
+    hostname: kubelab-vps
+    public_ip: 162.55.57.175
+    tailscale_ip: 100.64.0.2
+  aws:
+    hostname: aws1
+    tailscale_ip: 100.64.0.7
+  nodes:
+    ace1:
+      hostname: ace1
+      tailscale_ip: 100.64.0.11
+      lan_ip: 172.16.1.2
+"""
+
+
+@pytest.fixture
+def common_yaml(tmp_path: Path) -> Path:
+    p = tmp_path / "common.yaml"
+    p.write_text(_COMMON)
+    return p
+
+
+class TestResolveTransport:
+    """ADR-052 D3: prod -> public endpoint (direct); staging/hub -> ts-bridge mesh."""
+
+    def test_staging_resolves_to_ts_bridge_over_the_mesh(self, common_yaml: Path) -> None:
+        t = resolve_transport("staging", common_yaml)
+        assert t == ClusterTransport(
+            env="staging", kind="ts-bridge", target_host="100.64.0.11", apiserver_port=6443, local_port=16443
+        )
+
+    def test_prod_resolves_to_the_public_endpoint_no_tunnel(self, common_yaml: Path) -> None:
+        t = resolve_transport("prod", common_yaml)
+        assert t.kind == "public"
+        assert t.target_host == "162.55.57.175"  # networking.vps.public_ip
+        assert t.local_port == 16444
+
+    def test_hub_resolves_to_ts_bridge_at_the_aws_mesh_address(self, common_yaml: Path) -> None:
+        t = resolve_transport("hub", common_yaml)
+        assert t.kind == "ts-bridge"
+        assert t.target_host == "100.64.0.7"  # networking.aws.tailscale_ip
+        assert t.local_port == 16445
+
+    def test_apiserver_port_defaults_to_6443(self, common_yaml: Path) -> None:
+        assert resolve_transport("hub", common_yaml).apiserver_port == 6443
+
+    def test_apiserver_port_override_is_honored(self, tmp_path: Path) -> None:
+        p = tmp_path / "common.yaml"
+        p.write_text(
+            "clusters:\n  staging:\n    node: ace1\n    ssh_alias: ace1\n    local_port: 16443\n"
+            "    apiserver_port: 7443\n"
+            "networking:\n  nodes:\n    ace1:\n      tailscale_ip: 100.64.0.11\n"
+        )
+        assert resolve_transport("staging", p).apiserver_port == 7443
+
+    def test_no_hardcoded_ips_target_comes_from_the_ssot(self, tmp_path: Path) -> None:
+        # Move ace1 to a different mesh IP; the resolver must follow the SSOT.
+        p = tmp_path / "common.yaml"
+        p.write_text(
+            "clusters:\n  staging:\n    node: ace1\n    ssh_alias: ace1\n    local_port: 16443\n"
+            "networking:\n  nodes:\n    ace1:\n      tailscale_ip: 100.64.0.99\n"
+        )
+        assert resolve_transport("staging", p).target_host == "100.64.0.99"
+
+    def test_unknown_cluster_lists_valid_names(self, common_yaml: Path) -> None:
+        with pytest.raises(KeyError, match="hub, prod, staging"):
+            resolve_transport("dev", common_yaml)
+
+    def test_node_absent_from_networking_raises_clearly(self, tmp_path: Path) -> None:
+        p = tmp_path / "common.yaml"
+        p.write_text(
+            "clusters:\n  staging:\n    node: ghost\n    ssh_alias: ghost\n    local_port: 16443\n"
+            "networking:\n  nodes: {}\n"
+        )
+        with pytest.raises(KeyError, match="ghost"):
+            resolve_transport("staging", p)
+
+
+class TestTsBridgeArgv:
+    def test_builds_a_manual_mode_target_and_local_bind(self) -> None:
+        t = ClusterTransport("staging", "ts-bridge", "100.64.0.11", 6443, 16443)
+        argv = ts_bridge_argv("/opt/ts-bridge", t)
+        assert argv == [
+            "/opt/ts-bridge",
+            "connect",
+            "--manual-mode",
+            "--target",
+            "100.64.0.11:6443",
+            "--local-addr",
+            "127.0.0.1:16443",
+        ]
+
+    def test_refuses_to_build_argv_for_a_public_transport(self) -> None:
+        # prod has no tunnel; asking for its ts-bridge argv is a programming error.
+        t = ClusterTransport("prod", "public", "162.55.57.175", 6443, 16444)
+        with pytest.raises(ValueError, match="public"):
+            ts_bridge_argv("/opt/ts-bridge", t)
+
+
+class TestLocateTsBridge:
+    def test_env_override_wins_when_it_points_at_a_real_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        binary = tmp_path / "ts-bridge.exe"
+        binary.write_text("")
+        monkeypatch.setenv("TS_BRIDGE_BIN", str(binary))
+        assert locate_ts_bridge() == binary
+
+    def test_missing_binary_raises_actionable_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("TS_BRIDGE_BIN", raising=False)
+        monkeypatch.setattr(tc, "_TS_BRIDGE_DEFAULTS", ())  # no default locations
+        monkeypatch.setattr(tc.shutil, "which", lambda _: None)
+        with pytest.raises(FileNotFoundError, match="TS_BRIDGE_BIN"):
+            locate_ts_bridge()
+
+
+class TestTransportState:
+    def test_roundtrips_through_disk(self, tmp_path: Path) -> None:
+        path = tmp_path / "state.json"
+        state = TransportState(env="staging", kind="ts-bridge", pid=4242, local_port=16443, target="100.64.0.11:6443")
+        state.save(path)
+        assert TransportState.load(path) == state
+
+    def test_load_missing_statefile_returns_none(self, tmp_path: Path) -> None:
+        assert TransportState.load(tmp_path / "absent.json") is None
+
+    def test_statefile_path_is_per_env_under_dot_kube(self) -> None:
+        p = statefile_path("staging")
+        assert p.name == ".kubelab-transport-staging.json"
+        assert p.parent.name == ".kube"
+
+
+class TestCommittedSSOT:
+    """The committed common.yaml resolves all three clusters coherently."""
+
+    def test_all_three_resolve_with_distinct_local_ports(self) -> None:
+        transports = [resolve_transport(env) for env in ("staging", "prod", "hub")]
+        ports = [t.local_port for t in transports]
+        assert len(ports) == len(set(ports)), "local_port must be unique per cluster"
+
+    def test_prod_is_public_and_the_others_are_mesh(self) -> None:
+        assert resolve_transport("prod").kind == "public"
+        assert resolve_transport("staging").kind == "ts-bridge"
+        assert resolve_transport("hub").kind == "ts-bridge"
+
+    def test_mesh_targets_are_non_empty_addresses(self) -> None:
+        for env in ("staging", "hub"):
+            assert resolve_transport(env).target_host, f"{env} mesh target must resolve from the SSOT"

--- a/toolkit/cli/infra.py
+++ b/toolkit/cli/infra.py
@@ -50,6 +50,12 @@ k8s_app = typer.Typer(
     no_args_is_help=True,
 )
 
+k8s_access_app = typer.Typer(
+    name="access",
+    help="Cluster-access transport (ADR-052): bring up/tear down/inspect the local->apiserver tunnel",
+    no_args_is_help=True,
+)
+
 backup_app = typer.Typer(
     name="backup",
     help="Backup Docker volumes and critical data on remote hosts",
@@ -77,6 +83,7 @@ n8n_app = typer.Typer(
 app.add_typer(ansible_app, name="ansible")
 app.add_typer(terraform_app, name="terraform")
 app.add_typer(k8s_app, name="k8s")
+k8s_app.add_typer(k8s_access_app, name="access")
 app.add_typer(backup_app, name="backup")
 app.add_typer(argo_app, name="argo")
 app.add_typer(headscale_app, name="headscale")
@@ -771,6 +778,64 @@ def k8s_fetch_kubeconfig(
     except (ValueError, ExecutionError) as e:
         logger.error(f"fetch-kubeconfig failed: {e}")
         raise typer.Exit(1) from e
+
+
+# -----------------------------------------------------------------------------
+# CLUSTER-ACCESS TRANSPORT (ADR-052 Phase 2 / TOOL-014)
+# `infra k8s access {connect,disconnect,status}` — separate from the legacy
+# `infra k8s status` (workloads), which is left untouched.
+# -----------------------------------------------------------------------------
+
+
+@k8s_access_app.command("connect")
+def k8s_access_connect(
+    env: Annotated[str, typer.Option("--env", "-e", help="Cluster to connect (staging|prod|hub)")],
+) -> None:
+    """Bring up the cluster-access transport (idempotent).
+
+    Maps the kubeconfig's 127.0.0.1:<local_port> to the env's apiserver: ts-bridge
+    over the Headscale mesh for staging/hub, the direct public endpoint for prod.
+    Re-running while already up is a clean no-op.
+    """
+    from toolkit.features.k8s_connect import connect
+
+    try:
+        ok = connect(env)
+    except KeyError as e:
+        logger.error(str(e))
+        raise typer.Exit(2) from e
+    if not ok:
+        raise typer.Exit(1)
+
+
+@k8s_access_app.command("disconnect")
+def k8s_access_disconnect(
+    env: Annotated[str, typer.Option("--env", "-e", help="Cluster to disconnect (staging|prod|hub)")],
+) -> None:
+    """Tear down the cluster-access transport (idempotent; no-op for prod)."""
+    from toolkit.features.k8s_connect import disconnect
+
+    try:
+        ok = disconnect(env)
+    except KeyError as e:
+        logger.error(str(e))
+        raise typer.Exit(2) from e
+    if not ok:
+        raise typer.Exit(1)
+
+
+@k8s_access_app.command("status")
+def k8s_access_status(
+    env: Annotated[str, typer.Option("--env", "-e", help="Cluster to inspect (staging|prod|hub)")],
+) -> None:
+    """Report whether the transport is up and which transport was resolved."""
+    from toolkit.features.k8s_connect import status
+
+    try:
+        status(env)
+    except KeyError as e:
+        logger.error(str(e))
+        raise typer.Exit(2) from e
 
 
 # =============================================================================

--- a/toolkit/features/k8s_connect.py
+++ b/toolkit/features/k8s_connect.py
@@ -1,0 +1,324 @@
+"""Cluster-access transport - bring up / tear down / inspect the local->apiserver
+tunnel that backs the transport-agnostic kubeconfig (ADR-052 Phase 2 / TOOL-014).
+
+The fetched kubeconfig pins ``server: https://127.0.0.1:<local_port>`` (see
+``k8s_kubeconfig``). This module maps that local port to the real apiserver:
+
+* **staging / hub** -> **ts-bridge**, a userspace ``tsnet`` TCP bridge over the
+  Headscale mesh. It forwards ``127.0.0.1:<local_port>`` -> ``<node-mesh-ip>:6443``
+  with no TUN and no admin, so it works on a corporate non-admin box.
+* **prod** -> its **public** apiserver endpoint, reachable directly (the k3s prod
+  cert SAN covers the public IP). No tunnel is started - ``connect`` only verifies
+  reachability; the prod kubeconfig targets the public endpoint.
+
+The transport *target* is **derived** from the ``clusters.<env>.node`` reference
+against ``networking.{nodes.*, vps, aws}`` in ``common.yaml`` - no addresses are
+duplicated into the ``clusters`` block, and nothing is hardcoded here.
+
+The pure helpers (``resolve_transport``, ``ts_bridge_argv``, ``locate_ts_bridge``,
+``TransportState`` (de)serialization) carry the logic and are unit-tested without a
+network. ``connect`` / ``disconnect`` / ``status`` do the I/O (spawn, port probe,
+terminate).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from toolkit.config.settings import settings
+from toolkit.core.logging import logger
+
+# k3s serves the apiserver on 6443; overridable per cluster via clusters.<env>.apiserver_port.
+_DEFAULT_APISERVER_PORT = 6443
+
+# ts-bridge binary discovery: env override -> well-known install dir -> PATH.
+_TS_BRIDGE_ENV = "TS_BRIDGE_BIN"
+_TS_BRIDGE_DEFAULTS: tuple[str, ...] = ("~/Apps/ts-bridge/ts-bridge.exe", "~/Apps/ts-bridge/ts-bridge")
+
+# Per-env transport statefile, next to the kubeconfigs it pairs with.
+_STATEFILE_PATTERN = "~/.kube/.kubelab-transport-{env}.json"
+
+# How long connect waits for the local port to come up before declaring failure.
+_HEALTHCHECK_TIMEOUT_S = 20.0
+_HEALTHCHECK_INTERVAL_S = 0.5
+
+
+@dataclass(frozen=True)
+class ClusterTransport:
+    """The resolved transport for one cluster (ADR-052 D3).
+
+    ``kind`` is ``"ts-bridge"`` (mesh tunnel) or ``"public"`` (direct, no tunnel).
+    ``target_host`` is the apiserver host the transport reaches - a mesh address
+    for ts-bridge, the public IP for the direct path.
+    """
+
+    env: str
+    kind: str
+    target_host: str
+    apiserver_port: int
+    local_port: int
+
+
+@dataclass(frozen=True)
+class TransportState:
+    """What ``connect`` recorded so ``disconnect`` / ``status`` can act on it."""
+
+    env: str
+    kind: str
+    pid: int
+    local_port: int
+    target: str
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(self), indent=2))
+
+    @classmethod
+    def load(cls, path: Path) -> "TransportState | None":
+        if not path.is_file():
+            return None
+        return cls(**json.loads(path.read_text()))
+
+
+def _common_path() -> Path:
+    return settings.project_root / "infra" / "config" / "values" / "common.yaml"
+
+
+def _load_config(common_path: Path | None = None) -> dict[str, Any]:
+    with open(common_path or _common_path()) as f:
+        return yaml.safe_load(f) or {}
+
+
+def _node_block(networking: dict[str, Any], node: str) -> dict[str, Any]:
+    """Position-aware lookup of a cluster's node block (mirrors SSOT-014a).
+
+    Homelab nodes live under ``networking.nodes.<node>``; the cloud nodes live at
+    the top level (``networking.vps`` / ``networking.aws``), keyed by convention
+    or by ``hostname``. Raises ``KeyError`` naming the node if none matches.
+    """
+    nodes = networking.get("nodes") or {}
+    if node in nodes:
+        return nodes[node]
+    for key in ("vps", "aws"):
+        block = networking.get(key)
+        if block and (key == node or block.get("hostname") == node):
+            return block
+    raise KeyError(f"node {node!r} not found under networking.nodes / networking.vps / networking.aws")
+
+
+def resolve_transport(env: str, common_path: Path | None = None) -> ClusterTransport:
+    """Resolve a cluster's transport from the ``clusters`` + ``networking`` SSOT.
+
+    A cluster whose node exposes a ``public_ip`` (prod's VPS) is reached directly
+    (``kind="public"``, no tunnel); every other cluster is reached via ts-bridge
+    over the mesh, targeting the node's ``tailscale_dns`` (preferred) or
+    ``tailscale_ip``. The error for an unknown env lists the declared clusters.
+    """
+    config = _load_config(common_path)
+    clusters = config.get("clusters") or {}
+    try:
+        cluster = clusters[env]
+    except KeyError:
+        valid = ", ".join(sorted(clusters)) or "(none declared)"
+        raise KeyError(f"unknown cluster {env!r}; declared clusters: {valid}") from None
+
+    networking = config.get("networking") or {}
+    block = _node_block(networking, str(cluster["node"]))
+    apiserver_port = int(cluster.get("apiserver_port", _DEFAULT_APISERVER_PORT))
+    local_port = int(cluster["local_port"])
+
+    public_ip = block.get("public_ip")
+    if public_ip:
+        return ClusterTransport(env, "public", str(public_ip), apiserver_port, local_port)
+
+    mesh_host = block.get("tailscale_dns") or block.get("tailscale_ip")
+    if not mesh_host:
+        raise KeyError(
+            f"cluster {env!r} node {cluster['node']!r} has no public_ip / tailscale_dns / tailscale_ip in the SSOT"
+        )
+    return ClusterTransport(env, "ts-bridge", str(mesh_host), apiserver_port, local_port)
+
+
+def ts_bridge_argv(binary: str | os.PathLike[str], transport: ClusterTransport) -> list[str]:
+    """Build the ts-bridge argv for a mesh transport (manual mode, fixed local bind).
+
+    ``--manual-mode`` pins the bind to ``--local-addr`` instead of auto-selecting a
+    port from a range - the kubeconfig's ``127.0.0.1:<local_port>`` must match
+    exactly. Auth (``TS_AUTHKEY``) and control-plane URL come from ts-bridge's own
+    ``.env`` (loaded via the binary's working directory), so kubelab never handles
+    the Headscale preauth key.
+    """
+    if transport.kind != "ts-bridge":
+        raise ValueError(f"ts_bridge_argv is only for a ts-bridge transport, not {transport.kind!r} ({transport.env})")
+    return [
+        str(binary),
+        "connect",
+        "--manual-mode",
+        "--target",
+        f"{transport.target_host}:{transport.apiserver_port}",
+        "--local-addr",
+        f"127.0.0.1:{transport.local_port}",
+    ]
+
+
+def locate_ts_bridge() -> Path:
+    """Find the ts-bridge binary, or fail with an actionable message.
+
+    Resolution order: ``TS_BRIDGE_BIN`` env -> the well-known install dir -> ``PATH``.
+    """
+    override = os.getenv(_TS_BRIDGE_ENV)
+    candidates = [override, *_TS_BRIDGE_DEFAULTS] if override else list(_TS_BRIDGE_DEFAULTS)
+    for candidate in candidates:
+        path = Path(os.path.expanduser(candidate))
+        if path.is_file():
+            return path
+    on_path = shutil.which("ts-bridge")
+    if on_path:
+        return Path(on_path)
+    raise FileNotFoundError(
+        f"ts-bridge binary not found. Set {_TS_BRIDGE_ENV} to its path, install it under "
+        "~/Apps/ts-bridge/, or put it on PATH. Releases: https://github.com/mlorentedev/ts-bridge/releases"
+    )
+
+
+def statefile_path(env: str) -> Path:
+    return Path(os.path.expanduser(_STATEFILE_PATTERN.format(env=env)))
+
+
+def _port_listening(port: int, host: str = "127.0.0.1", timeout: float = 1.0) -> bool:
+    """True iff a TCP connect to host:port succeeds (the transport is up)."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(timeout)
+        return sock.connect_ex((host, port)) == 0
+
+
+def _terminate(pid: int) -> None:
+    """Best-effort cross-platform terminate of a detached child by pid."""
+    if os.name == "nt":
+        subprocess.run(["taskkill", "/PID", str(pid), "/F", "/T"], check=False, capture_output=True)
+    else:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+
+
+def connect(env: str) -> bool:
+    """Bring up the transport for ``env`` (idempotent). Returns True on success.
+
+    For ``public`` (prod) this is a reachability check, not a tunnel. For
+    ``ts-bridge`` it is a no-op when the local port already answers; otherwise it
+    spawns ts-bridge detached, waits for the local port, and records the statefile.
+    """
+    transport = resolve_transport(env)
+    endpoint = f"{transport.target_host}:{transport.apiserver_port}"
+    logger.section(f"Cluster access - connect {env} ({transport.kind} -> {endpoint})")
+
+    if transport.kind == "public":
+        reachable = _port_listening(transport.apiserver_port, host=transport.target_host, timeout=5.0)
+        if reachable:
+            logger.success(f"prod apiserver reachable at {endpoint} - direct public endpoint, no tunnel")
+            return True
+        logger.error(f"prod apiserver NOT reachable at {endpoint} (public endpoint). Check network/firewall.")
+        return False
+
+    if _port_listening(transport.local_port):
+        logger.success(f"transport already up: 127.0.0.1:{transport.local_port} is listening - no-op")
+        return True
+
+    try:
+        binary = locate_ts_bridge()
+    except FileNotFoundError as exc:
+        logger.error(str(exc))
+        return False
+
+    argv = ts_bridge_argv(binary, transport)
+    logger.info(f"Starting ts-bridge: {' '.join(argv)} (cwd {binary.parent})")
+    # Detach so the bridge outlives this CLI; run in the binary's dir to reuse its .env auth.
+    proc = subprocess.Popen(
+        argv,
+        cwd=str(binary.parent),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+    )
+
+    deadline = time.monotonic() + _HEALTHCHECK_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if _port_listening(transport.local_port):
+            TransportState(
+                env=env,
+                kind=transport.kind,
+                pid=proc.pid,
+                local_port=transport.local_port,
+                target=endpoint,
+            ).save(statefile_path(env))
+            logger.success(f"transport up: 127.0.0.1:{transport.local_port} -> {endpoint} (pid {proc.pid})")
+            return True
+        if proc.poll() is not None:
+            logger.error(f"ts-bridge exited early (code {proc.returncode}); check auth in {binary.parent}/.env")
+            return False
+        time.sleep(_HEALTHCHECK_INTERVAL_S)
+
+    logger.error(f"timed out after {_HEALTHCHECK_TIMEOUT_S:.0f}s waiting for 127.0.0.1:{transport.local_port}")
+    _terminate(proc.pid)
+    return False
+
+
+def disconnect(env: str) -> bool:
+    """Tear down the transport for ``env`` (idempotent). Returns True on success."""
+    transport = resolve_transport(env)
+    logger.section(f"Cluster access - disconnect {env}")
+
+    if transport.kind == "public":
+        logger.info("prod uses the direct public endpoint - nothing to tear down")
+        return True
+
+    path = statefile_path(env)
+    state = TransportState.load(path)
+    if state is None and not _port_listening(transport.local_port):
+        logger.info("transport already down - no-op")
+        return True
+
+    if state is not None:
+        logger.info(f"terminating ts-bridge (pid {state.pid})")
+        _terminate(state.pid)
+        path.unlink(missing_ok=True)
+    else:
+        logger.warning(f"127.0.0.1:{transport.local_port} listening but no statefile - not ours, leaving it")
+        return False
+
+    logger.success(f"transport for {env} torn down")
+    return True
+
+
+def status(env: str) -> bool:
+    """Report the transport state for ``env``. Returns True iff it is usable."""
+    transport = resolve_transport(env)
+    endpoint = f"{transport.target_host}:{transport.apiserver_port}"
+    logger.section(f"Cluster access - status {env}")
+
+    if transport.kind == "public":
+        reachable = _port_listening(transport.apiserver_port, host=transport.target_host, timeout=5.0)
+        verdict = "reachable" if reachable else "UNREACHABLE"
+        logger.info(f"transport: direct public endpoint (no tunnel) -> {endpoint} [{verdict}]")
+        logger.info("prod kubeconfig should target the public apiserver directly")
+        return reachable
+
+    up = _port_listening(transport.local_port)
+    state = TransportState.load(statefile_path(env))
+    pid = f"pid {state.pid}" if state else "no statefile"
+    logger.info(f"transport: ts-bridge -> {endpoint}")
+    logger.info(f"local endpoint 127.0.0.1:{transport.local_port}: {'UP' if up else 'down'} ({pid})")
+    return up


### PR DESCRIPTION
## What

Implements the cluster-access transport from ADR-052 -- the `connect` step that
pairs with `fetch-kubeconfig` (#728). Adds `toolkit infra k8s access
{connect,disconnect,status}` + `make connect|disconnect|connect-status ENV=x`,
which map the kubeconfig's `127.0.0.1:<local_port>` to the env's apiserver so
`kubectl` / `make apply-secrets` / `deploy-k8s` work from any machine -- including
a corporate non-admin box with no native Tailscale.

Closes the transport gap behind #724 (apply postgres-secrets, CONSOLE-002).

## How

- **staging / hub** -> ts-bridge (userspace `tsnet`) over the Headscale mesh:
  spawned detached, local-port healthcheck, pid statefile. Idempotent (re-running
  while up is a clean no-op, detected by probing the local port).
- **prod** -> the direct public endpoint (the k3s prod cert SAN covers the public
  IP). No tunnel -- `connect` only verifies reachability; the prod kubeconfig
  targets the public apiserver.
- The transport target is **derived** from `clusters.<env>.node` against
  `networking.*` (position-aware, mirrors SSOT-014a) -- no hardcoded IPs, no edit
  to the `clusters:` block.
- A dedicated `access` sub-noun keeps the legacy `infra k8s status` (namespace
  workloads) untouched.

## Out of scope

LAN `ssh -L` fast path (needs the rpi4 forwarding work in #719); ts-bridge
multi-target (ts-bridge#186); SOCKS variant; collaborator OIDC/RBAC/ACLs
(VPNACL-001).

## Testing

- `tests/test_k8s_connect.py` -- 18 unit tests of the pure helpers (resolver,
  argv builder, binary discovery, statefile), no network.
- Full unit suite (excl. e2e): 295 passed, no regressions.
- `make lint` clean; types clean for the new files.
- Manual: `make connect-status ENV=staging` (resolves ts-bridge -> ace1, reports
  down), `make disconnect ENV=prod` (public no-op), unknown env -> exit 2.

**Pending before merge:** AC1 -- live end-to-end `make connect ENV=staging` +
`kubectl get ns`. Needs an interactive operator shell (ssh-agent + the one-time
`fetch-kubeconfig`), per ADR-052; cannot run in CI.

## Refs

- Spec: `specs/TOOL-014-k8s-connect/`
- ADR-052 (`docs/adr/adr-052-cluster-access-transport.md`)
- Runbook: `docs/runbooks/operate-from-new-workstation.md`
- Tracking: #731 -- upstream #728/#723 -- downstream #724 -- related #719

Closes #731


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `toolkit infra k8s access` command group with `connect`, `disconnect`, and `status` subcommands for cluster access management
  * Added Makefile targets: `connect`, `disconnect`, and `connect-status` for environment-specific orchestration
  * Support for staging, prod, and hub cluster environments

* **Documentation**
  * Added runbook for operating Kubernetes clusters from new workstations with stable kubeconfig configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->