### PR TITLE
docs(adr): ADR-053 platform-vs-product repo structure + WEB-020 pilot spec

### DIFF
--- a/docs/adr/adr-053-platform-product-repos.md
+++ b/docs/adr/adr-053-platform-product-repos.md
@@ -1,0 +1,83 @@
+---
+id: "adr-053"
+type: adr
+status: proposed
+owner: manu
+date: "2026-06-23"
+issue: "kubelab#744"   # repo#NNN — issue-gate (per ADR-018)
+tags: [architecture, decision, repo-structure, gitops, idp, platform]
+created: "2026-06-23"
+---
+
+# ADR-053: Platform↔Product Repository Structure & Deployment Topology
+
+## Status
+
+Proposed 2026-06-23. **Extends [[adr-048-platform-consumer-repo-boundary|ADR-048]]** (which separated only the `web` frontend). Consumes [[adr-046-gitops-delivery-promotion-strategy|ADR-046]] (CI-driven promotion; Argo CD Image Updater descoped, #692) and [[adr-029-intelligence-layer|ADR-029]] (Go API as the platform gateway). Reaffirms [[adr-037-environment-promotion-strategy|ADR-037]] (conditional selfHeal per env).
+
+## Context
+
+ADR-048 drew the platform-vs-consumer line and extracted only the `web` frontend, leaving the general pattern unspecified. As the portfolio grows (imaging-suite, cubernautas, L3 tools…), three placement questions recur per product: where does its **code** live, where do its **K8s manifests** live, and how is a new image **promoted** into the cluster? Constraints:
+
+- **Single operator.** Polyrepo coordination overhead is real and must be minimized (ADR-048 rationale).
+- **Reusable for my own products**, not (yet) sold to clients. A scaffold / golden-path is a *consequence* of a proven pattern, not a starting point.
+- **GitOps already decided** ([[adr-046-gitops-delivery-promotion-strategy|ADR-046]]): immutable tags (`sha-<short>` staging, semver prod), CI-driven promotion via `toolkit deployment promote`, Argo CD hub on AWS, staging→prod flow. Registry polling (Argo CD Image Updater) was explicitly descoped (#692) for footprint, git-honesty, and solo-operator simplicity.
+- **Verified deploy reality.** mlorente.dev runs in prod on **VPS-K3s** (Deployment `web` + IngressRoute, image promoted by CI); staging runs on the homelab K3s (ace1). The API is exposed at `api.kubelab.live` (`api.mlorente.dev` is migration residue).
+
+## Options Considered
+
+1. **Everything per-product repo** (code + manifests + own CI/CD per product). Rejected: re-creates ADR-017's manual-sync pain; N CI pipelines and N Argo CD wirings; for one operator the overhead outweighs isolation.
+2. **Everything in the kubelab monorepo** (no product repos). Rejected: keeps each product's lifecycle entangled with L0 infra; no path to a reusable per-product template.
+3. **Code per-product repo; manifests centralized in kubelab; shared bases in kubelab; Argo CD app-of-apps.** Chosen. A config-repo-central pattern: kubelab is platform + config repo; products own only code + image.
+
+## Decision
+
+1. **Split by axis, not by project.**
+   - **Product code** → its own repo (`web`, future products).
+   - **K8s manifests** (overlays, domains, env) → **centralized in kubelab** (`infra/k8s`).
+   - **Reusable bases** (Kustomize "a landing" base, middlewares, the golden path) → kubelab.
+   - **Go API** stays in kubelab as the platform gateway, serving every product's landing (ADR-029/048).
+   - **Argo CD (AWS hub)** runs app-of-apps and promotes staging→prod (the existing flow).
+
+2. **Image promotion is push, event-driven — never polling.**
+   - Each product's CI publishes an immutable `sha-<short>` image, then fires a **`repository_dispatch`** to kubelab, whose workflow runs `toolkit deployment promote` (ADR-046).
+   - **Rejected — registry polling** (Argo CD Image Updater *or* an n8n registry poller). It reintroduces exactly what ADR-046 descoped (#692): a pull loop and non-git-honest state; for n8n it would also put a non-critical service on the delivery path (n8n down → no deploys). We control the image producers, so push is strictly better than pull.
+
+3. **Pipeline events flow through the notification fabric (NOTIFY), separate from the trigger.**
+   - *Delivery* (how it promotes) ≠ *observability* (how the operator finds out). Argo CD sync/health/degraded and deploy success/failure are routed via the n8n/NOTIFY fabric (Argo CD Notifications → NOTIFY-006, #685). n8n is a **notification channel, not a delivery orchestrator**.
+
+4. **Per-repo dev/local is mandatory; the cluster is the outer loop.**
+   - Each product repo ships an autonomous inner loop (`make dev` / `npm run dev`) that needs no cluster: frontend = `astro dev` pointing at the staging API via env var; API = docker-compose with local Postgres. Outer loop = staging homelab. Per-PR ephemeral previews (Argo CD ApplicationSet PR generator) are **deferred** until they hurt.
+
+5. **The scaffold / golden-path template is distilled after 2–3 products (Rule of Three), not designed up front.**
+
+## Rationale
+
+For a single operator the dividing line is platform-vs-consumer (ADR-048); the cheapest maintainable shape is one config repo (kubelab) that owns deploy + shared bases, with products owning only code + image. Push-based cross-repo promotion preserves the git-honest, CI-driven delivery ADR-046 already chose instead of re-adding a poller the project deliberately removed. Centralizing manifests means the frontend dev loop carries zero Kubernetes — a concrete inner-loop win. Deferring the scaffold avoids encoding assumptions that the second product would break.
+
+## Consequences
+
+### Positive
+
+- Maintainable for one operator; one source of truth for deploy.
+- The reusable template emerges from real instances (Rule of Three), not speculation.
+- The Go API serves all landings (multi-consumer), per ADR-029.
+- Frontend development needs no cluster.
+
+### Negative
+
+- A change touching both frontend behavior and its manifest spans two repos (code in the product repo, overlay in kubelab).
+- A cross-repo `repository_dispatch` trigger (PAT-scoped) to build and maintain.
+
+### Neutral
+
+- Scaffold/golden-path and per-PR previews deferred (revisit at ~3 products).
+- The `api.mlorente.dev` healthcheck in `toolkit/orchestrator.py` is migration residue → cleanup task.
+
+## References
+
+- Extends [[adr-048-platform-consumer-repo-boundary|ADR-048]] (platform-vs-consumer boundary)
+- Consumes [[adr-046-gitops-delivery-promotion-strategy|ADR-046]] (CI-driven promotion; Image Updater descoped #692)
+- [[adr-029-intelligence-layer|ADR-029]] (Go API = platform gateway)
+- Reaffirms [[adr-037-environment-promotion-strategy|ADR-037]] (conditional selfHeal per env)
+- First implemented under WEB-020 (#697): the `web` extraction is the pilot product

--- a/specs/WEB-020-web-repo-extraction/proposal.md
+++ b/specs/WEB-020-web-repo-extraction/proposal.md
@@ -1,0 +1,57 @@
+---
+id: "WEB-020-web-repo-extraction"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-06-23"
+issue: "kubelab#697"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal, web, repo-structure, gitops]
+template_version: "1.0"
+---
+
+# WEB-020-web-repo-extraction
+
+> Pilot product for [[adr-053-platform-product-repos|ADR-053]]. Implements [[adr-048-platform-consumer-repo-boundary|ADR-048]].
+
+## Why
+
+<!-- from issue #697: WEB-020: Extract web frontends to own `web` repo (mlorente.dev + kubelab.live) per ADR-048 -->
+
+`apps/web/site` (mlorente.dev) is a consumer product living inside the platform monorepo. ADR-048 decided to extract it; ADR-053 fixed *how* a product repo relates to the platform: **code in its own repo, manifests centralized in kubelab, push-based cross-repo promotion**. This spec extracts mlorente.dev as the **first product to exercise that pattern**, so the kinks are found on a low-risk frontend before any other product follows. Not extracting it keeps the brand product entangled with L0 and leaves the ADR-053 pattern untested.
+
+## What
+
+1. **New `web` repo** (`mlorentedev/web`) holding the mlorente.dev frontend, **migrated WITH git history** (`git filter-repo` on `apps/web/site`), preserving `git blame`.
+2. **CI in `web`**: build an immutable `sha-<short>` image → push to Docker Hub (`mlorentedev/kubelab-web`) → fire a **`repository_dispatch`** to kubelab on success.
+3. **Receiver workflow in kubelab**: on the dispatch, run `toolkit deployment promote --env staging --app web --version sha-<short>` (ADR-046 path). Prod promotion stays the existing gated `promote-prod.yml`.
+4. **Inner loop in `web`**: `make dev` / `npm run dev` (`astro dev`) pointing at the API via env var (`PUBLIC_API_URL`, default `https://api.kubelab.live`). No cluster needed to develop.
+5. **Disconnect from kubelab**: remove `apps/web/site` (the Go API and the K8s manifests/overlays STAY in kubelab per ADR-053).
+6. **Keep** the `kubelab.live → mlorente.dev` 301 redirect until the `web` repo serves kubelab.live.
+
+## Out of scope
+
+- **kubelab.live rebuild** (ES, fresh) inside the `web` repo — follow-up after mlorente.dev is green (ADR-048 says one repo for both; this spec lands the first domain only).
+- **`api.mlorente.dev`** — the web calls the existing `api.kubelab.live` (confirmed canonical; `api.mlorente.dev` is migration residue). A dedicated brand API domain is a separate decision.
+- **Scaffold / golden-path template** — distilled later, after 2-3 products (ADR-053 §5).
+- **Per-PR ephemeral previews** (ApplicationSet) — deferred (ADR-053 §4).
+
+## Risks / open questions
+
+- **[OPEN — implementation]** `repository_dispatch` needs a PAT scoped to kubelab `contents:write` + `actions:write` stored as a secret in the `web` repo. Define rotation per secrets policy.
+- **[OPEN — implementation]** Cross-repo coupling: a frontend change that also needs a manifest change spans two repos (ADR-053 negative consequence). Document the two-repo flow in the `web` README.
+- **[RESOLVED]** Deploy target: VPS-K3s via the existing Argo CD staging→prod flow (manifests stay in kubelab). NOT Cloudflare Pages (ADR-045/049).
+- **[RESOLVED]** Image promotion mechanism: push `repository_dispatch` → `toolkit deployment promote`, NOT Image Updater/polling (ADR-046/ADR-053 §2).
+
+## Acceptance criteria
+
+- [ ] `mlorentedev/web` exists with mlorente.dev history preserved (`git log apps/web/site` lineage visible via `git blame` in the new repo).
+- [ ] A push to `web` master builds a `sha-<short>` image, pushes it, and fires a `repository_dispatch` to kubelab.
+- [ ] The kubelab receiver workflow promotes that tag to staging via `toolkit deployment promote` and Argo CD syncs it on the staging spoke.
+- [ ] `make dev` in `web` serves mlorente.dev locally against `api.kubelab.live` with no cluster running.
+- [ ] `apps/web/site` is removed from kubelab; the Go API and `infra/k8s` web manifests remain and still deploy.
+- [ ] The `kubelab.live → mlorente.dev` 301 redirect still resolves.
+
+## References
+
+- ADR: [[adr-053-platform-product-repos]] (the pattern), [[adr-048-platform-consumer-repo-boundary]] (the boundary), [[adr-046-gitops-delivery-promotion-strategy]] (promotion), [[adr-045-mlorente-dev-interactive-cv]] (Docker→nginx→K3s lock)
+- Epic: kubelab#697 (WEB-020)
+- Notifications of deploy events reuse NOTIFY-006 (#685), not a new mechanism

--- a/specs/WEB-020-web-repo-extraction/tasks.md
+++ b/specs/WEB-020-web-repo-extraction/tasks.md
@@ -1,0 +1,57 @@
+---
+tags: [spec, tasks]
+created: "2026-06-23"
+---
+
+# Tasks - WEB-020-web-repo-extraction
+
+> TDD/where-possible order. One task = one focused commit/PR. Spec frozen on entry to `implementing`.
+> Cross-repo work: some tasks land in the NEW `web` repo, marked [web]; the rest in kubelab [kubelab].
+
+## Setup
+
+- [ ] Confirm repo name `web` (ADR-048 open decision — owner: proposed `mlorentedev/web`)
+- [ ] `proposal.md` acceptance criteria reviewed
+- [ ] Mint a kubelab-scoped PAT (`contents:write` + `actions:write`) for cross-repo dispatch; store as `web` repo secret
+
+## Extraction (with history)
+
+- [ ] [web] `git filter-repo` (or subtree split) of `apps/web/site` → new `mlorentedev/web`, history preserved
+- [ ] [web] Verify `git blame` lineage survives on a sample file
+- [ ] [web] Add `LICENSE`, `README.md` (documents the two-repo flow + `make dev`), `.gitignore`
+
+## CI in the `web` repo
+
+- [ ] [web] Build immutable `sha-<short>` image on push: master, push to Docker Hub `mlorentedev/kubelab-web`
+- [ ] [web] On build success, fire `repository_dispatch` (event_type `web-image-published`, payload = tag) to `mlorentedev/kubelab`
+- [ ] [web] Dependabot + release automation (mirror kubelab conventions)
+
+## Receiver in kubelab
+
+- [ ] [kubelab] Workflow on `repository_dispatch: web-image-published` → `toolkit deployment promote --env staging --app web --version <tag>`
+- [ ] [kubelab] Verify Argo CD syncs the staging spoke with the new tag
+- [ ] [kubelab] Prod promotion unchanged (existing gated `promote-prod.yml`)
+
+## Inner loop
+
+- [ ] [web] `make dev` / `npm run dev` (`astro dev`) against `PUBLIC_API_URL` (default `https://api.kubelab.live`), no cluster required
+- [ ] [web] Document local/staging/prod API profiles in README
+
+## Disconnect
+
+- [ ] [kubelab] Remove `apps/web/site` (KEEP the Go API and `infra/k8s` web manifests/overlays)
+- [ ] [kubelab] Confirm `make deploy-k8s` + Argo CD still deploy web from the centralized manifests
+- [ ] [kubelab] Verify the `kubelab.live → mlorente.dev` 301 redirect still resolves
+
+## Closing
+
+- [ ] Every acceptance criterion covered by a test/smoke check
+- [ ] `features.json` emitted (one feature per acceptance criterion)
+- [ ] `verification.md` filled (cross-repo dispatch evidence + staging deploy)
+- [ ] PR(s) opened referencing this spec folder
+- [ ] On merge: `git mv specs/WEB-020-web-repo-extraction specs/archive/...`; tick #697
+
+## Machine-readable features
+
+Emit a sibling `features.json` once acceptance is frozen (id, behavior, verification, state, evidence).
+The agent CANNOT set `state: passing` — only the harness, after running `verification` with exit 0.

--- a/toolkit/features/orchestrator.py
+++ b/toolkit/features/orchestrator.py
@@ -225,7 +225,7 @@ class DeploymentOrchestrator:
 
     def _check_prod_status(self) -> None:
         production_services = {
-            "api": "https://api.mlorente.dev/health",
+            "api": "https://api.kubelab.live/health",
             "web": "https://mlorente.dev",
             "blog": "https://blog.mlorente.dev",
             "wiki": "https://wiki.mlorente.dev",


### PR DESCRIPTION
Closes #744.

## What
- **ADR-053**: platform-vs-product repository structure & deployment topology (extends ADR-048).
- **WEB-020 spec**: pilot extraction of `apps/web/site` to its own `web` repo, applying ADR-053.
- **Cleanup**: stale `api.mlorente.dev` healthcheck -> `api.kubelab.live` in `toolkit/orchestrator.py`.

## Decisions captured
- Product code per repo; K8s manifests centralized in kubelab; Argo CD app-of-apps.
- Image promotion = push (`repository_dispatch` -> `toolkit deployment promote`), not polling.
- Deploy notifications via the NOTIFY fabric (#685), separate from the trigger.
- Per-repo dev/local inner loop; cluster is the outer loop.
- Scaffold distilled after 2-3 products (Rule of Three).

Pilot implementation tracked under WEB-020 (#697).
