### PR TITLE
docs(lessons): verify master before closing a duplicate of a closed twin

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -29,6 +29,18 @@ owner: manu
 **Rule**: Pattern to follow going forward
 ```
 
+### [2026-06-23] A CLOSED twin issue in the `knowledge` repo is not evidence the work shipped — verify master
+
+**Context**: Reconciling the double-board (the kubelab bitácora vs. the mirror issues in the `knowledge` repo). `knowledge#100` (NOTIFY-007, kubelab #686) and `knowledge#102` (APP-CONFIG-003, kubelab #688) were both **CLOSED**. On a single-board project that reads as "done", so the first instinct was to close the kubelab duplicates #686/#688 as already-shipped.
+
+**Problem**: The two boards track the same work but transition independently. A CLOSED state on the `knowledge` twin records only that *someone marked the mirror issue closed* — it says nothing about whether the deliverable exists in `kubelab` master. Checking the code showed neither NOTIFY-007 nor APP-CONFIG-003 was actually implemented: the close was bookkeeping drift, not a shipped feature. Closing the kubelab issues on the strength of the twin would have buried two unimplemented features as "done" — no code, no test, and gone from the backlog where the remaining work was visible.
+
+**Solution**: Kept #686/#688 open, commented the discrepancy on the board as double-board debt (CONSOLE-003), and made "verify in master" a gate before closing any issue as a duplicate. The twin's status became a hint to investigate, never proof of completion.
+
+**Rule**: Before closing an issue as a duplicate of a CLOSED twin — or trusting any second board's "done" — verify the deliverable exists in `master`: grep the code, run the test, check the artifact. A CLOSED issue is a claim about a *tracker*, not about the *codebase*; on a multi-board setup the two drift, and "done" on the mirror can mask "never built". Trust the code, not the gemelo.
+
+**Tags**: `#governance` `#bitacora` `#double-board` `#duplicates` `#verification` `#console-003`
+
 ### [2026-06-20] From the non-admin workstation, "can't reach the node" has three independent causes — not "node down"
 
 **Context**: Validating the new K3s upgrade runbook (OPS-002 #429) against staging needed read-only pre-flight commands on ace1. ace1 was powered on, yet every SSH attempt from this Windows non-admin box (EGW-LEN029) failed — first read as "the on-demand node is off", which was wrong.


### PR DESCRIPTION
## What

Adds a governance lesson to `docs/lessons.md`: a CLOSED mirror issue in the `knowledge` repo is **not** evidence the work shipped.

## Why

Today, `knowledge#100` (NOTIFY-007 → #686) and `knowledge#102` (APP-CONFIG-003 → #688) were both CLOSED on the knowledge board, yet neither feature exists in `kubelab` master. Closing the kubelab duplicates on the strength of the twin would have buried two unimplemented features as "done".

## Rule recorded

Before closing an issue as a duplicate of a CLOSED twin, verify the deliverable exists in `master` (grep code / run test / check artifact). A CLOSED issue is a claim about a *tracker*, not the *codebase*; on a multi-board setup the two drift. Tracked as double-board debt under CONSOLE-003.

Doc-only change (SDD skip).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new governance lesson explaining the importance of verifying deliverables before closing related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->