### PR TITLE
docs(WEB-020): enter implementing, record extraction milestone

### DIFF
--- a/specs/WEB-020-web-repo-extraction/proposal.md
+++ b/specs/WEB-020-web-repo-extraction/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "WEB-020-web-repo-extraction"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: implementing # draft | implementing | verifying | archived
 created: "2026-06-23"
 issue: "kubelab#697"   # repo#NNN — GitHub issue / Project item that tracks this spec
 tags: [spec, proposal, web, repo-structure, gitops]
@@ -40,6 +40,8 @@ template_version: "1.0"
 - **[OPEN — implementation]** Cross-repo coupling: a frontend change that also needs a manifest change spans two repos (ADR-053 negative consequence). Document the two-repo flow in the `web` README.
 - **[RESOLVED]** Deploy target: VPS-K3s via the existing Argo CD staging→prod flow (manifests stay in kubelab). NOT Cloudflare Pages (ADR-045/049).
 - **[RESOLVED]** Image promotion mechanism: push `repository_dispatch` → `toolkit deployment promote`, NOT Image Updater/polling (ADR-046/ADR-053 §2).
+- **[RESOLVED — 2026-06-23]** Extraction scope: extract **`apps/web/`** (the whole product dir), not just `apps/web/site/`. The `Dockerfile`/`LICENSE`/`README`/`CHANGELOG`/`version.txt` live at `apps/web/`; the Docker build context is `./apps/web` with `COPY site/…`. Extracting `apps/web/` → repo root keeps `site/` as a subdir, so the build maps 1:1 (zero Dockerfile edits) and those files arrive with history.
+- **[OPEN — inner-loop]** Code default of `PUBLIC_API_URL` is `https://api.staging.kubelab.live` (`site/src/data/site.ts`), but acceptance criterion #4 says default `https://api.kubelab.live`. Reconcile when wiring `make dev`.
 
 ## Acceptance criteria
 

--- a/specs/WEB-020-web-repo-extraction/tasks.md
+++ b/specs/WEB-020-web-repo-extraction/tasks.md
@@ -10,15 +10,17 @@ created: "2026-06-23"
 
 ## Setup
 
-- [ ] Confirm repo name `web` (ADR-048 open decision — owner: proposed `mlorentedev/web`)
-- [ ] `proposal.md` acceptance criteria reviewed
-- [ ] Mint a kubelab-scoped PAT (`contents:write` + `actions:write`) for cross-repo dispatch; store as `web` repo secret
+- [x] Confirm repo name `web` (ADR-048 open decision — owner: proposed `mlorentedev/web`) ✓ 2026-06-23
+- [x] `proposal.md` acceptance criteria reviewed ✓ 2026-06-23
+- [x] Mint a kubelab-scoped PAT (`contents:write` + `actions:write`) for cross-repo dispatch; store as `web` repo secret ✓ 2026-06-23 (fine-grained, scoped to `kubelab`)
 
 ## Extraction (with history)
 
-- [ ] [web] `git filter-repo` (or subtree split) of `apps/web/site` → new `mlorentedev/web`, history preserved
-- [ ] [web] Verify `git blame` lineage survives on a sample file
-- [ ] [web] Add `LICENSE`, `README.md` (documents the two-repo flow + `make dev`), `.gitignore`
+> **Scope (decided 2026-06-23):** extracted **`apps/web/`** (whole product dir), NOT just `apps/web/site/` — the `Dockerfile`/`LICENSE`/`README`/`CHANGELOG`/`version.txt` live at `apps/web/` and the build context is `./apps/web` with `COPY site/…`. Extracting `apps/web/` → repo root keeps `site/` as a subdir → Docker build maps 1:1, zero Dockerfile edits, files arrive with history. See `proposal.md` Risks.
+
+- [x] [web] `git filter-repo` of `apps/web/` → new `mlorentedev/web`, history preserved (239→12 commits; public; default branch `master`) ✓ 2026-06-23
+- [x] [web] Verify `git blame` lineage survives on a sample file (`site/package.json`, `Dockerfile` → `a93727f`; `--follow` on `site/src/data/site.ts`) ✓ 2026-06-23
+- [ ] [web] Update `README.md` for the two-repo flow + `make dev` (`LICENSE`/`.gitignore` already arrived with the extraction)
 
 ## CI in the `web` repo
 


### PR DESCRIPTION
## What

WEB-020 setup + extraction are complete. This updates the spec to reflect reality:
- `status: draft → implementing`
- Setup + Extraction tasks ticked (with dates)
- Records the **scope decision**: extracted `apps/web/` (whole product dir), not just `apps/web/site/` — keeps the Dockerfile build context 1:1 and brings LICENSE/README/CHANGELOG with history
- Flags the `PUBLIC_API_URL` default discrepancy (code: `api.staging.kubelab.live` vs acceptance #4: `api.kubelab.live`) for the inner-loop phase

## Evidence

`mlorentedev/web` created (public, default `master`), 12 commits, `git blame` + `--follow` lineage verified.

## Next (separate PRs)

- [web repo] CI: build `sha-<short>` image → Docker Hub → `repository_dispatch` to kubelab
- [kubelab] Receiver workflow → `toolkit deployment promote --env staging --app web`
- [kubelab] Disconnect: remove `apps/web` (manifests stay)

Refs #697