### PR TITLE
chore(staging): deploy web sha-20c9f91

### DIFF
--- a/infra/config/values/staging.yaml
+++ b/infra/config/values/staging.yaml
@@ -52,6 +52,7 @@ apps:
       enable_homelabs: false
       enable_contact: false
   # Third-party services
+      version: sha-20c9f91
   services:
     core:
       gitea:

--- a/infra/k8s/overlays/staging/generated/deployments.yaml
+++ b/infra/k8s/overlays/staging/generated/deployments.yaml
@@ -88,8 +88,8 @@ spec:
     spec:
       containers:
         - name: web
-          image: docker.io/mlorentedev/kubelab-web:dev
-          imagePullPolicy: Always
+          image: docker.io/mlorentedev/kubelab-web:sha-20c9f91
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
Staging promotion of `web` to `sha-20c9f91` (ADR-046, cross-repo dispatch from mlorentedev/web).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the staging app configuration to use a newer version reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->