### PR TITLE
ci: accept X.Y.Z-rc.N staging tags in web image receiver

### DIFF
--- a/.github/workflows/web-image-receiver.yml
+++ b/.github/workflows/web-image-receiver.yml
@@ -1,8 +1,10 @@
 ---
 name: Web Image Receiver
 
-# Cross-repo receiver (ADR-053 §2). mlorentedev/web CI publishes an immutable
-# `sha-<short>` image and fires a `repository_dispatch` (web-image-published).
+# Cross-repo receiver (ADR-053 §2). mlorentedev/web CI publishes a staging image —
+# `sha-<short>` (legacy) or a SemVer pre-release `X.Y.Z-rc.N` (web's
+# semver-everywhere delivery, extending ADR-046) — and fires a
+# `repository_dispatch` (web-image-published).
 # Here we promote that tag to staging via `toolkit deployment promote` and open a
 # staging-deploy PR (ADR-046 D3 — PR-per-update); merging it (human + required
 # checks) lets Argo CD sync staging to master HEAD. Same mechanism as
@@ -45,10 +47,14 @@ jobs:
           TAG: ${{ github.event.client_payload.tag }}
         run: |
           # Defensive: the dispatch is authenticated (KUBELAB_DISPATCH_TOKEN), but
-          # staging only ever tracks immutable sha-<short> tags (ADR-046).
+          # we still pin the accepted tag shapes. Staging tracks immutable
+          # sha-<short> (legacy) and SemVer pre-releases X.Y.Z-rc.N (web's
+          # semver-everywhere delivery, extending ADR-046). Clean X.Y.Z is
+          # prod-only (promote-prod.yml) and never promoted to staging here.
           case "$TAG" in
             sha-*) ;;
-            *) echo "::error::Unexpected tag '$TAG' (expected sha-<short>)"; exit 1 ;;
+            [0-9]*.[0-9]*.[0-9]*-rc.*) ;;
+            *) echo "::error::Unexpected tag '$TAG' (expected sha-<short> or X.Y.Z-rc.N)"; exit 1 ;;
           esac
           poetry run toolkit deployment promote --env staging --app web --version "$TAG"
 


### PR DESCRIPTION
## Why

`web` is moving to **semver-everywhere delivery** (web's ADR — extends ADR-046): staging images get SemVer pre-release tags `X.Y.Z-rc.N` (instead of `sha-<short>`), and prod gets clean `X.Y.Z` by promoting the same image digest.

This is the **tolerant-first** step of the cross-repo rollout: kubelab must accept the new tag shape **before** web starts sending it, or the `web-image-published` dispatch would error and staging delivery would break.

## Change

`web-image-receiver.yml` — widen the tag guard:

```diff
  case "$TAG" in
    sha-*) ;;
+   [0-9]*.[0-9]*.[0-9]*-rc.*) ;;
-   *) echo "::error::Unexpected tag '$TAG' (expected sha-<short>)"; exit 1 ;;
+   *) echo "::error::Unexpected tag '$TAG' (expected sha-<short> or X.Y.Z-rc.N)"; exit 1 ;;
  esac
```

## Safety

- **Backward-compatible:** `sha-<short>` is still accepted, so nothing breaks today. Safe to merge before the web change.
- **Staging/prod separation kept:** clean `X.Y.Z` is rejected here (prod-only via `promote-prod.yml`); only `-rc.*` pre-releases are accepted for staging.
- **No toolkit change needed:** `toolkit deployment promote` and `promote-prod.yml` already pass semver tags through (validated by `tag_exists`, no format guard) — only this receiver hard-coded `sha-*`.

## Rollout order

1. **This PR** (kubelab tolerant) ← we are here
2. web flips staging to `X.Y.Z-rc.N` + promote-by-digest on release
3. kubelab drops the legacy `sha-*` shape (follow-up)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded staging promotion to accept more image tag formats, including release-candidate tags and existing immutable tags.
  * Improved validation to reject unsupported tag formats, reducing failed promotions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->