### PR TITLE
ci(dependabot): track apps/api base image (version-updates)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -82,12 +82,37 @@ updates:
           - "patch"
           - "major"
 
+  # ---- Container image: apps/api (in this repo) ----
+  # Base images reach EOL and must be tracked regardless of where the code
+  # eventually lives — a missed version bump is exactly how alpine:3.18 rotted
+  # into a Trivy HIGH/CRITICAL failure. version-updates ON while api is in
+  # kubelab. (Go module bumps are churnier and security updates suffice, so the
+  # gomod entry below stays security-only.)
+  - package-ecosystem: "docker"
+    directory: "/apps/api"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "fix"
+      include: "scope"
+    groups:
+      api-docker-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
   # ============================================================
-  # Security-only -- apps departing to their own repos
+  # Security-only -- Go module deps (security suffices; avoid churn)
   # (open-pull-requests-limit: 0 -> no version PRs; security still flows)
   # ============================================================
 
-  # ---- Go API (-> own repo) ----
+  # ---- Go API modules ----
   - package-ecosystem: "gomod"
     directory: "/apps/api/src"
     schedule:
@@ -97,15 +122,3 @@ updates:
     labels:
       - "dependencies"
       - "api"
-
-  # ---- App container images (-> own repos) ----
-  - package-ecosystem: "docker"
-    directories:
-      - "/apps/api"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 0
-    labels:
-      - "dependencies"
-      - "docker"


### PR DESCRIPTION
## Why

The `/apps/api` **docker** Dependabot entry was `open-pull-requests-limit: 0` (security-only), on the documented premise that `api` would depart to its own repo (like `web`). That disabled **version-update** PRs — the exact channel that proposes a base-image bump (`3.18 → 3.24`). So the `alpine:3.18` EOL drift was never surfaced by Dependabot; it only blew up at release time as a Trivy HIGH/CRITICAL failure (see #769).

## Change

- `/apps/api` docker → **version-updates ON** (weekly, minor+patch grouped, `fix` prefix so release-please rebuilds the image). `3.18→3.24`-class bumps are minor → caught by the group.
- `/apps/api` **gomod** stays **security-only** — Go module bumps are churnier and security updates suffice. Base images are the EOL-risk surface; Go deps are not.
- `edge/errors` was already version-tracked — unchanged.

## Scope note

`api` staying in kubelab is the current assumption (it's in-repo, no extraction spec). The comment is neutral on its eventual placement — base images must be tracked regardless of where the code lives. Reversible if `api` later departs (its new repo would carry its own config).

Pairs with #769 (fixes the current EOL base); this prevents the recurrence.