### PR TITLE
ci: default to GitHub-hosted runners + cancel superseded PR runs

### DIFF
--- a/.github/workflows/check-config-drift.yml
+++ b/.github/workflows/check-config-drift.yml
@@ -30,6 +30,12 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+# Cancel a superseded run on the same ref — the drift check is idempotent and
+# read-only, so a newer commit's run supersedes the older (ADR-030 amendment).
+concurrency:
+  group: drift-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
     branches: [master]
   workflow_dispatch:
 
+# Cancel a superseded run when a new commit is pushed to the same PR — frees
+# runners instead of letting stale builds occupy the fleet (ADR-030 amendment).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/docs/adr/adr-030-self-hosted-ci-runner.md
+++ b/docs/adr/adr-030-self-hosted-ci-runner.md
@@ -11,6 +11,21 @@ created: "2026-03-29"
 
 **Accepted** — 2026-03-30
 
+## Amendment — 2026-06-26 (hosted-primary for the public repo)
+
+Two assumptions behind the original decision no longer hold:
+
+1. **Cost / "zero Actions minutes."** The repo is now **public**, so GitHub-hosted runners are **free and effectively unlimited in parallelism**. The cost driver that motivated self-hosted is gone.
+2. **"No pushes happen when the homelab is off, so no workflow triggers without a runner."** The ADR-053 cross-repo flow broke this: `web` pushes fire a `repository_dispatch` → the **Web Image Receiver** and downstream workflows run on `master` independently of any local dev session. Combined with the single runner (the documented "jobs serialize" negative), this produced exactly the predicted failure — a backlog of ~9 runs serialized behind one ~12-min Docker build, with even cheap `validate`/drift jobs queued behind it.
+
+**Resolution — flip the default to GitHub-hosted; self-hosted becomes opt-in.**
+
+- `RUNNER_DOCKER` set to `["ubuntu-latest"]` (unset → identical fallback). Every workflow already reads `fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"')`, so this one change routes the whole fleet to hosted runners — many concurrent jobs, free, no homelab dependency. An audit confirmed **no CI job needs homelab access**: all are portable (buildx → Docker Hub with `cache-from: type=gha`, Python toolkit, `gh`/`git` PR-opening, release ZIP). The two greps that matched homelab patterns were a comment and Release-body text, not steps.
+- **Concurrency cancellation** added to the PR-triggered workflows (`ci.yml`, `check-config-drift.yml`): a new commit cancels the superseded run instead of piling onto the fleet.
+- The self-hosted runner (`kubelab-bee`) **stays available**: re-enable it for any future job that genuinely needs homelab resources (a step that must reach the cluster or a LAN-only service) by setting `RUNNER_DOCKER` back to the self-hosted labels, or per-job. The fork-PR guard and the toggle mechanics below are unchanged.
+
+The original self-hosted rationale remains valid for a **private** repo or a homelab-bound job; this amendment changes only the *default* for the current public, GitOps-delivered repo.
+
 ## Context
 
 All CI/CD workflows ran on GitHub-hosted runners (`ubuntu-latest`), consuming GitHub Actions minutes and depending on shared infrastructure. With Beelink provisioned as the on-demand Platform Node (ADR-028), we have dedicated compute (8GB RAM, 4 cores) already running a GitHub Actions runner container (ANSIBLE-013).


### PR DESCRIPTION
## Problem

CI is "always slow" because of a single self-hosted runner (`kubelab-bee`) that **serializes every job**. With the ADR-053 cross-repo flow, `web` pushes fire `repository_dispatch` → master workflows run independently of dev sessions, so a backlog builds up: ~9 runs queued behind **one ~12-min Docker build**, and even cheap `validate`/`Config Drift` jobs (plain Python/YAML, no homelab need) queue behind it. ADR-030 literally predicted this ("Single runner = jobs serialize").

## Fix (amends ADR-030)

The repo is **public** → GitHub-hosted runners are **free and massively parallel**. An audit confirms **no CI job needs the homelab** (builds push to Docker Hub with `cache-from: type=gha`; toolkit is Python; PRs via `gh`/`git`; deploys are GitOps via Argo CD, never from CI). The two homelab-pattern greps were a comment and Release-body text.

1. **`RUNNER_DOCKER` → `["ubuntu-latest"]`** (repo variable, already applied). Every workflow reads `fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"')`, so this single knob routes the whole fleet to hosted — concurrent, free, no homelab dependency.
2. **Concurrency cancellation** on `ci.yml` + `check-config-drift.yml`: a new commit cancels the superseded run instead of piling onto the fleet.
3. Self-hosted runner **stays available** — re-enable via `RUNNER_DOCKER` for any future job that genuinely needs homelab resources. Fork-PR guard unchanged.

## Effect

Multi-PR / multi-app work now runs in parallel on hosted runners; the serialization bottleneck and the indefinite-queue-when-busy failure are gone. The self-hosted rationale still holds for a private repo or a homelab-bound job (documented in the ADR amendment).

Amends ADR-030.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI and drift-check runs now automatically cancel older in-progress runs when a newer one starts, reducing queueing and stale results.
  * Default CI execution is now routed to hosted runners, with specialized runner usage remaining available when needed.

* **Documentation**
  * Updated the architecture decision record to reflect the current runner strategy and workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->