### PR TITLE
feat(delivery): build-once re-tag for the api image (DELIVERY-002)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,18 +34,71 @@ jobs:
           OUTPUTS: ${{ toJSON(steps.release.outputs) }}
         run: echo "$OUTPUTS"
 
+  # ADR-056 build-once: the prod semver is produced by RE-TAGGING the staging-
+  # validated `sha-<short>` digest, never a rebuild. `imagetools create` copies the
+  # multi-arch manifest list, so `api:X.Y.Z` and `api:sha-<short>` are byte-identical
+  # (incident #666 / kubelab#679). `publish-errors` stays a rebuild — errors is edge
+  # infra, out of the staging-sha lane (ADR-056 Out of scope).
   publish-api:
-    name: Publish API
+    name: Publish API (re-tag staging digest)
     needs: release-please
     if: needs.release-please.outputs.api_release_created == 'true'
-    uses: ./.github/workflows/ci-publish.yml
-    with:
-      app: api
-      tag: ${{ needs.release-please.outputs.api_version }}
-      sha: ${{ github.sha }}
-      context: ./apps/api
-      runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
-    secrets: inherit
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    permissions:
+      contents: read
+    env:
+      REGISTRY_PREFIX: ${{ vars.REGISTRY_PREFIX || 'kubelab' }}
+      VERSION: ${{ needs.release-please.outputs.api_version }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install toolkit
+        run: |
+          python -m pip install "poetry>=1.8,<2.0"
+          poetry install --only main
+      - name: Resolve staging-validated sha
+        id: sha
+        run: |
+          SHA="$(poetry run toolkit deployment image-tag --env staging --app api)"
+          echo "Staging-validated tag for api: $SHA"
+          echo "tag=$SHA" >> "$GITHUB_OUTPUT"
+      - name: Login registry
+        uses: docker/login-action@v4
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Re-tag digest as semver (build-once)
+        env:
+          SHA: ${{ steps.sha.outputs.tag }}
+        run: |
+          set -euo pipefail
+          REGISTRY="${{ secrets.DOCKERHUB_USERNAME }}/${REGISTRY_PREFIX}-api"
+          # Copy the full manifest list to the semver tag + :latest alias. No rebuild.
+          docker buildx imagetools create \
+            -t "${REGISTRY}:${VERSION}" \
+            -t "${REGISTRY}:latest" \
+            "${REGISTRY}:${SHA}"
+          # Verify digest equality: the semver and the staging sha MUST resolve to the
+          # same manifest-list digest, or build-once parity is broken (fail the release).
+          FMT='{{.Manifest.Digest}}'
+          SHA_DIGEST="$(docker buildx imagetools inspect "${REGISTRY}:${SHA}" --format "$FMT")"
+          VER_DIGEST="$(docker buildx imagetools inspect "${REGISTRY}:${VERSION}" --format "$FMT")"
+          echo "::notice::api:${SHA} -> ${SHA_DIGEST}"
+          echo "::notice::api:${VERSION} -> ${VER_DIGEST}"
+          if [ "$SHA_DIGEST" != "$VER_DIGEST" ]; then
+            echo "::error::Digest mismatch — re-tag did not preserve the staging artifact"
+            exit 1
+          fi
+          {
+            echo "## Build-once re-tag (ADR-056)"
+            echo "- App: api"
+            echo "- Staging digest: \`${SHA}\` -> \`${SHA_DIGEST}\`"
+            echo "- Promoted semver: \`${VERSION}\` -> \`${VER_DIGEST}\`"
+            echo "- Rebuild: none (manifest list copied)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publish-errors:
     name: Publish Errors

--- a/docs/runbooks/gitops-delivery-promotion.md
+++ b/docs/runbooks/gitops-delivery-promotion.md
@@ -14,6 +14,10 @@ How code reaches staging and prod. Implements [ADR-046](../adr/adr-046-gitops-de
 
 Image tags are **never reused as desired state**: a tag change is always a real git diff Argo reconciles. release-please is the sole authority for semver.
 
+### How the prod semver is produced (build-once — ADR-056, `api` only)
+
+When release-please cuts `api:X.Y.Z`, `release.yml` does **not** rebuild. It resolves the staging-validated `sha-<short>` from `values/staging.yaml` (`toolkit deployment image-tag --env staging --app api`) and re-tags that exact digest with `docker buildx imagetools create -t api:X.Y.Z api:sha-<short>` (manifest list copied → byte-identical amd64+arm64). So the bytes prod runs are the bytes a human validated on staging — closing the artifact-parity gap that CrashLooped the first gated promotion (#666 / #679). Parity is verified in-job by digest equality; a mismatch fails the release. **Precondition:** `api` must be pinned to a real `sha-*` in staging (deploy it there first), or the release fails fast rather than ship unvalidated bytes. `errors` is out of scope (edge infra) — it still rebuilds at release. The prune janitor (`ci-cleanup.yml`) never deletes a `sha-*` referenced by a committed overlay, so a pending re-tag can't lose its source.
+
 ## Deploy to staging (normal dev loop)
 
 1. Open a feature PR, get it green, merge to `master`.

--- a/specs/DELIVERY-002-build-once-apps/features.json
+++ b/specs/DELIVERY-002-build-once-apps/features.json
@@ -1,0 +1,47 @@
+{
+  "spec": "DELIVERY-002-build-once-apps",
+  "features": [
+    {
+      "id": "C1-no-rebuild-at-release",
+      "behavior": "On release_created for api, no docker build runs for the semver tag; the image is produced solely by re-tagging an existing sha-<short> digest.",
+      "verification": "release.yml publish-api uses 'docker buildx imagetools create'; no build-push-action, no ci-publish.yml call. Digest-equality asserted in-job at first api release.",
+      "state": "pending",
+      "evidence": ".github/workflows/release.yml"
+    },
+    {
+      "id": "C2-digest-parity",
+      "behavior": "kubelab-api:X.Y.Z resolves to the same manifest-list digest as the staging-validated kubelab-api:sha-<short> (identical amd64+arm64).",
+      "verification": "In-job 'imagetools inspect --format {{.Manifest.Digest}}' compares both tags; mismatch exits 1 and fails the release.",
+      "state": "pending",
+      "evidence": ".github/workflows/release.yml (Re-tag digest as semver step)"
+    },
+    {
+      "id": "C3-sha-from-ssot",
+      "behavior": "The sha to re-tag is resolved from the staging SSOT (values/staging.yaml), never hardcoded; a non-sha pin is rejected.",
+      "verification": "tests/test_image_tag.py::TestResolveImageSha (test_returns_pinned_sha, test_errors_on_dev_pin, test_errors_on_semver_pin, test_errors_on_missing_pin).",
+      "state": "pending",
+      "evidence": "tests/test_image_tag.py"
+    },
+    {
+      "id": "C4-promote-prod-unchanged",
+      "behavior": "promote-prod.yml behavior is unchanged (still refuses a non-existent registry tag; still opens a gated PR).",
+      "verification": "promote-prod.yml and promotion.promote untouched in behavior; tests/test_promotion.py green (5/5).",
+      "state": "pending",
+      "evidence": "tests/test_promotion.py"
+    },
+    {
+      "id": "C5-resolver-offline",
+      "behavior": "A toolkit command resolves the staging-pinned sha for an app and is unit-tested without network/registry access.",
+      "verification": "tests/test_image_tag.py::TestResolveImageSha::test_returns_pinned_sha runs with no registry mock; toolkit deployment image-tag prints the bare tag to stdout.",
+      "state": "pending",
+      "evidence": "toolkit/cli/deployment.py (image-tag), toolkit/features/promotion.py (resolve_image_sha)"
+    },
+    {
+      "id": "C6-prune-guard",
+      "behavior": "ci-cleanup never prunes a sha-* tag referenced by a committed overlay, so a pending re-tag cannot lose its source.",
+      "verification": "tests/test_registry_prune.py::TestSelectStaleTags::test_never_prunes_protected_sha; CLI gathers per-app pins from staging/prod values and threads them as protected.",
+      "state": "pending",
+      "evidence": "toolkit/features/registry.py, toolkit/cli/registry.py"
+    }
+  ]
+}

--- a/specs/DELIVERY-002-build-once-apps/tasks.md
+++ b/specs/DELIVERY-002-build-once-apps/tasks.md
@@ -18,21 +18,21 @@ created: "2026-06-26"
 
 > TDD where the surface allows. The toolkit resolver is unit-testable; the workflow re-tag is verified by digest equality.
 
-- [ ] Write failing unit test: a toolkit helper resolves the staging-pinned `sha-<short>` for `api` from `infra/config/values/staging.yaml` (`apps.platform.api.version`), no network. Asserts SSOT-sourced, errors on a non-sha pin.
-- [ ] Implement `toolkit deployment image-tag --env staging --app <app>` (prints the pinned tag) to make it pass.
-- [ ] Refactor: extract the values-loading shared with `deployment promote` (no dup).
-- [ ] `release.yml`: replace `publish-api` (which calls `ci-publish.yml` → rebuild) with a **re-tag job** — resolve the staging sha via the toolkit, `docker login`, `docker buildx imagetools create -t <img>:<version> <img>:<sha>`, then `imagetools inspect` to log the resolved digest. **`publish-errors` is left unchanged** (errors out of scope — edge infra, ADR-056 *Alternatives*).
-- [ ] Guard the prune race: `ci-cleanup.yml` must not prune a `sha-*` tag referenced by a committed overlay (or document that re-tag precedes the prune window). Add a test/assertion if code-guarded.
-- [ ] Update `docs/runbooks/gitops-delivery-promotion.md`: the promotion sequence is now build-once (no manual candidate-semver validation step — parity is structural).
+- [x] Write failing unit test: a toolkit helper resolves the staging-pinned `sha-<short>` for `api` from `infra/config/values/staging.yaml` (`apps.platform.api.version`), no network. Asserts SSOT-sourced, errors on a non-sha pin. ✓ 2026-06-27 (`tests/test_image_tag.py`)
+- [x] Implement `toolkit deployment image-tag --env staging --app <app>` (prints the pinned tag) to make it pass. ✓ 2026-06-27 (`promotion.resolve_image_sha` + `deployment.image_tag`)
+- [x] Refactor: extract the values-loading shared with `deployment promote` (no dup). ✓ 2026-06-27 (`promotion._load_values_doc`)
+- [x] `release.yml`: replace `publish-api` (which calls `ci-publish.yml` → rebuild) with a **re-tag job** — resolve the staging sha via the toolkit, `docker login`, `docker buildx imagetools create -t <img>:<version> <img>:<sha>`, then `imagetools inspect` to log the resolved digest. **`publish-errors` is left unchanged** (errors out of scope — edge infra, ADR-056 *Alternatives*). ✓ 2026-06-27
+- [x] Guard the prune race: `ci-cleanup.yml` must not prune a `sha-*` tag referenced by a committed overlay (or document that re-tag precedes the prune window). Add a test/assertion if code-guarded. ✓ 2026-06-27 (`select_stale_tags` `protected` set + CLI pin-gathering; `test_never_prunes_protected_sha`)
+- [x] Update `docs/runbooks/gitops-delivery-promotion.md`: the promotion sequence is now build-once (no manual candidate-semver validation step — parity is structural). ✓ 2026-06-27
 
 ## Closing
 
-- [ ] Every acceptance criterion covered by a test/smoke check (digest-equality assertion for the re-tag)
-- [ ] `features.json` emitted (one feature per acceptance criterion; `state: pending` until the harness runs them)
-- [ ] Type checks pass (`make type`)
-- [ ] Lint passes (`make lint`)
-- [ ] No unrelated changes (no CalVer `ci-release.yml` edits — that is a separate ticket)
-- [ ] `verification.md` filled (digest-equality evidence: `<app>:X.Y.Z` == `:sha-<short>`)
+- [x] Every acceptance criterion covered by a test/smoke check (digest-equality assertion for the re-tag) ✓ 2026-06-27 (C1/C2 = in-job digest-equality at first release; C3-C6 unit-tested)
+- [x] `features.json` emitted (one feature per acceptance criterion; `state: pending` until the harness runs them) ✓ 2026-06-27
+- [x] Type checks pass (`make type`) ✓ 2026-06-27 (changed modules mypy-clean; pre-existing `notify_smoke.py` stub gap unrelated)
+- [x] Lint passes (`make lint`) ✓ 2026-06-27 (All checks passed)
+- [x] No unrelated changes (no CalVer `ci-release.yml` edits — that is a separate ticket) ✓ 2026-06-27
+- [x] `verification.md` filled (digest-equality evidence: `<app>:X.Y.Z` == `:sha-<short>`) ✓ 2026-06-27
 - [ ] PR opened referencing this spec folder
 - [ ] On merge: `git mv specs/DELIVERY-002-build-once-apps specs/archive/...`; #679 closes (built-in workflow → Done)
 

--- a/specs/DELIVERY-002-build-once-apps/verification.md
+++ b/specs/DELIVERY-002-build-once-apps/verification.md
@@ -9,22 +9,26 @@ created: "2026-06-26"
 
 Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
 
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+- [~] C1 — no `docker build` for the semver tag -> `release.yml` `publish-api` is now a re-tag job (`docker buildx imagetools create`), no `build-push-action`, no call to `ci-publish.yml`. **Runtime digest-equality proof pending the first `api` release in CI.**
+- [~] C2 — `api:X.Y.Z` == `api:sha-<short>` manifest-list digest -> asserted in-job (`imagetools inspect --format '{{.Manifest.Digest}}'`, fail on mismatch). **Verified at first release.**
+- [x] C3 — sha resolved from staging SSOT, never hardcoded -> `tests/test_image_tag.py::TestResolveImageSha` (reads `values/staging.yaml`; `test_errors_on_dev_pin` / `test_errors_on_semver_pin` enforce the sha shape).
+- [x] C4 — `promote-prod.yml` unchanged -> not touched; `tests/test_promotion.py` still green (5/5).
+- [x] C5 — toolkit command resolves the pinned sha without network -> `tests/test_image_tag.py::TestResolveImageSha::test_returns_pinned_sha` (no registry mock; a network call would raise).
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- Test suite: `poetry run pytest tests/` -> **322 passed, 108 deselected** (live-env markers), 17s. New: `tests/test_image_tag.py` (6), prune guard `tests/test_registry_prune.py::TestSelectStaleTags::test_never_prunes_protected_sha`.
+- Type: `mypy` clean on all 4 changed modules (pre-existing `notify_smoke.py` stub gap unrelated).
+- Manual smoke: `toolkit deployment image-tag --env staging --app web` -> `sha-c8fa9a6` (rc=0, clean stdout); `--app api` -> rc=1 (no sha pin yet — guard fires correctly).
+- No regressions: yes (322 green, including the 5 prior promotion tests after the shared-loader refactor).
 
 ## Decisions made during implementation
 
 Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
 
--
--
+- Resolver reads the **raw** `staging.yaml` pin, not the merged config — merged would surface the inherited `dev` from `common.yaml` and mask "no validated staging artifact". The absent pin must be an error, not a silent `dev`.
+- Prune guard implemented as a `protected` set threaded through the pure `select_stale_tags` (not an ad-hoc filter in the I/O loop) so it stays unit-testable and protects a pinned sha even outside the retention window.
+- `:latest` alias preserved on the re-tag (the old stable build pushed it too) so nothing downstream that resolves `:latest` regresses.
 
 ## Promotion candidates
 

--- a/tests/test_image_tag.py
+++ b/tests/test_image_tag.py
@@ -1,0 +1,69 @@
+"""Tests for the build-once sha resolver (DELIVERY-002 / ADR-056).
+
+The resolver reads the staging-validated immutable ``sha-<short>`` pinned in
+``values/staging.yaml`` so release.yml can re-tag that exact digest as the prod
+semver — never a rebuild. Pure file read: no registry, no network.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from toolkit.features import promotion
+
+_VALUES_TEMPLATE = """\
+apps:
+  platform:
+    api:
+{api_version}
+    web:
+      version: sha-c8fa9a6
+"""
+
+
+def _write_values(root: Path, api_version: str) -> Path:
+    values_dir = root / "infra" / "config" / "values"
+    values_dir.mkdir(parents=True, exist_ok=True)
+    path = values_dir / "staging.yaml"
+    indented = f"      version: {api_version}" if api_version else "      domain: api.staging"
+    path.write_text(_VALUES_TEMPLATE.format(api_version=indented))
+    return path
+
+
+@pytest.fixture
+def root_patched(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    monkeypatch.setattr(promotion, "settings", type("S", (), {"project_root": tmp_path}))
+    return tmp_path
+
+
+class TestResolveImageSha:
+    def test_returns_pinned_sha(self, root_patched, monkeypatch) -> None:
+        _write_values(root_patched, "sha-abc1234")
+        # No registry mock: a network call here would raise — proving the resolver is offline.
+        assert promotion.resolve_image_sha("staging", "api") == "sha-abc1234"
+
+    def test_reads_per_app_pin(self, root_patched) -> None:
+        _write_values(root_patched, "sha-abc1234")
+        assert promotion.resolve_image_sha("staging", "web") == "sha-c8fa9a6"
+
+    def test_errors_on_missing_pin(self, root_patched) -> None:
+        _write_values(root_patched, "")  # api has no version key -> not validated
+        with pytest.raises(ValueError, match="No staging-pinned|sha-<short>"):
+            promotion.resolve_image_sha("staging", "api")
+
+    def test_errors_on_dev_pin(self, root_patched) -> None:
+        _write_values(root_patched, "dev")
+        with pytest.raises(ValueError, match="not an immutable sha"):
+            promotion.resolve_image_sha("staging", "api")
+
+    def test_errors_on_semver_pin(self, root_patched) -> None:
+        _write_values(root_patched, "1.2.0")
+        with pytest.raises(ValueError, match="not an immutable sha"):
+            promotion.resolve_image_sha("staging", "api")
+
+    def test_errors_on_non_platform_app(self, root_patched) -> None:
+        _write_values(root_patched, "sha-abc1234")
+        with pytest.raises(ValueError, match="not a platform app"):
+            promotion.resolve_image_sha("staging", "errors")

--- a/tests/test_registry_prune.py
+++ b/tests/test_registry_prune.py
@@ -49,6 +49,14 @@ class TestSelectStaleTags:
         with pytest.raises(ValueError, match="retention"):
             select_stale_tags([], retention=-1)
 
+    def test_never_prunes_protected_sha(self) -> None:
+        # A sha pinned by a committed overlay must survive even outside the
+        # retention window — pruning it would break a pending prod re-tag (ADR-056).
+        tags = [_tag("sha-old0000", "2026-06-01T00:00:00Z"), _tag("sha-new1111", "2026-06-09T00:00:00Z")]
+        stale = select_stale_tags(tags, retention=0, protected={"sha-old0000"})
+        assert "sha-old0000" not in stale
+        assert "sha-new1111" in stale
+
 
 class TestDockerHubClient:
     def test_list_tags_paginates(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/toolkit/cli/deployment.py
+++ b/toolkit/cli/deployment.py
@@ -128,6 +128,31 @@ def promote(
         raise typer.Exit(1) from None
 
 
+@app.command(name="image-tag")
+def image_tag(
+    env: Annotated[
+        str,
+        typer.Option("--env", "-e", help="Source environment whose SSOT pin to read (staging)"),
+    ],
+    app_name: Annotated[
+        str,
+        typer.Option("--app", "-a", help="Platform app (api|web)"),
+    ],
+) -> None:
+    """
+    Print the immutable ``sha-<short>`` tag pinned for a platform app (ADR-056 build-once).
+
+    Resolves ``apps.platform.<app>.version`` from ``values/<env>.yaml`` — the staging-
+    validated digest release.yml re-tags as the prod semver (never a rebuild). Prints the
+    bare tag to stdout for CI capture; errors (exit 1) if the pin is absent or not a sha.
+    """
+    try:
+        typer.echo(promotion.resolve_image_sha(env, app_name))
+    except Exception as e:
+        logger.error(MESSAGES.ERROR_FAILED_WITH_REASON.format("Resolve image tag", str(e)))
+        raise typer.Exit(1) from None
+
+
 @app.command()
 def status(
     env: Annotated[

--- a/toolkit/cli/registry.py
+++ b/toolkit/cli/registry.py
@@ -5,7 +5,8 @@ from typing import Annotated
 import typer
 
 from toolkit.core.logging import logger
-from toolkit.features import registry
+from toolkit.features import promotion, registry
+from toolkit.features.registry import SHA_TAG_PREFIX
 
 app = typer.Typer(
     name="registry",
@@ -42,8 +43,20 @@ def prune(
     """
     logger.section(f"Registry Prune{' (dry-run)' if dry_run else ''}")
     app_list = [a.strip() for a in apps.split(",") if a.strip()]
+    # Never prune a sha referenced by a committed overlay (ADR-056 prune guard):
+    # gather the per-app sha pins from every env's values and protect them.
+    protected: dict[str, set[str]] = {}
+    for app_name in app_list:
+        pins = {
+            pin
+            for env in ("staging", "prod")
+            if (pin := promotion.read_pinned_version(env, app_name)) and pin.startswith(SHA_TAG_PREFIX)
+        }
+        if pins:
+            protected[app_name] = pins
+            logger.info(f"{app_name}: protecting overlay-pinned {sorted(pins)}")
     try:
-        registry.prune(app_list, registry_prefix, retention, dry_run)
+        registry.prune(app_list, registry_prefix, retention, dry_run, protected=protected)
     except Exception as e:
         logger.error(f"Registry prune failed: {e}")
         raise typer.Exit(1) from None

--- a/toolkit/features/promotion.py
+++ b/toolkit/features/promotion.py
@@ -14,6 +14,10 @@ ruamel round-trip (comment- and order-preserving) rather than a PyYAML rewrite.
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
+from typing import Any
+
 from ruamel.yaml import YAML
 
 from toolkit.config.constants import COMPONENTS
@@ -22,6 +26,70 @@ from toolkit.core.logging import logger
 from toolkit.features.configuration import ConfigurationManager
 from toolkit.features.generator_k8s import K8sGenerator
 from toolkit.features.registry import tag_exists
+
+# Immutable CI build tag: ``sha-${GITHUB_SHA::7}`` (see staging-deploy.yml). The
+# web-image-receiver rejects anything else, so staging only ever pins this shape.
+_SHA_TAG = re.compile(r"^sha-[0-9a-f]{7,}$")
+
+
+def _load_values_doc(env: str) -> tuple[YAML, Path, Any]:
+    """Load ``values/<env>.yaml`` comment-preservingly. Returns ``(yaml, path, data)``.
+
+    Shared by ``promote`` (round-trip write) and ``resolve_image_sha`` (read-only)
+    so the values path and ruamel round-trip config live in one place.
+    """
+    path = settings.project_root / "infra" / "config" / "values" / f"{env}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(f"Values file not found: {path}")
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    return yaml, path, yaml.load(path.read_text())
+
+
+def resolve_image_sha(env: str, app: str) -> str:
+    """Return the immutable ``sha-<short>`` pinned for a platform app in ``values/<env>.yaml``.
+
+    Reads ``apps.platform.<app>.version`` straight from the env SSOT — the exact
+    artifact a human last validated on that environment (ADR-056 B1). release.yml
+    re-tags this digest as the prod semver (build-once); it is never rebuilt.
+
+    Raises ``ValueError`` if the app is not a platform app, or its pin is absent /
+    not an immutable ``sha-<short>`` tag (still ``dev``, a semver, etc.) — refusing
+    to promote bytes the environment never ran (incident #666 / kubelab#679).
+    """
+    if app not in COMPONENTS.PLATFORM_APPS:
+        raise ValueError(
+            f"App '{app}' is not a platform app {COMPONENTS.PLATFORM_APPS}; "
+            "edge services (e.g. errors) are not on the build-once sha lane"
+        )
+    _, path, data = _load_values_doc(env)
+    version = (data.get("apps") or {}).get("platform", {}).get(app, {}).get("version")
+    if not version:
+        raise ValueError(
+            f"No staging-pinned version for platform app '{app}' in {path.name}; "
+            "staging must deploy an immutable sha-<short> build before a prod re-tag"
+        )
+    if not _SHA_TAG.match(str(version)):
+        raise ValueError(
+            f"Staging pin for '{app}' is '{version}', not an immutable sha-<short> tag; "
+            "refusing to re-tag bytes staging never validated (ADR-056 build-once)"
+        )
+    return str(version)
+
+
+def read_pinned_version(env: str, app: str) -> str | None:
+    """Return the raw ``apps.platform.<app>.version`` pin in ``values/<env>.yaml``, or ``None``.
+
+    Tolerant sibling of ``resolve_image_sha``: no validation, never raises on a
+    non-sha (prod pins a semver). Used by the prune janitor to learn which tags a
+    committed overlay references so it never deletes one (ADR-056 prune guard).
+    """
+    try:
+        _, _, data = _load_values_doc(env)
+    except FileNotFoundError:
+        return None
+    version = (data.get("apps") or {}).get("platform", {}).get(app, {}).get("version")
+    return str(version) if version else None
 
 
 def _resolve_image(env: str, app: str) -> tuple[str, str]:
@@ -59,13 +127,7 @@ def promote(env: str, app: str, version: str) -> None:
     if exists is None:
         logger.warning(f"Could not verify {registry}/{image_name}:{version} exists; proceeding")
 
-    values_path = settings.project_root / "infra" / "config" / "values" / f"{env}.yaml"
-    if not values_path.exists():
-        raise FileNotFoundError(f"Values file not found: {values_path}")
-
-    yaml = YAML()
-    yaml.preserve_quotes = True
-    data = yaml.load(values_path.read_text())
+    yaml, values_path, data = _load_values_doc(env)
 
     platform = data.setdefault("apps", {}).setdefault("platform", {})
     app_cfg = platform.setdefault(app, {})

--- a/toolkit/features/registry.py
+++ b/toolkit/features/registry.py
@@ -36,12 +36,20 @@ class TagInfo:
     last_updated: str
 
 
-def select_stale_tags(tags: list[TagInfo], retention: int) -> list[str]:
+def select_stale_tags(
+    tags: list[TagInfo],
+    retention: int,
+    protected: frozenset[str] | set[str] = frozenset(),
+) -> list[str]:
     """Pure policy: which tag names to delete.
 
     Keep the ``retention`` most recent ``sha-*`` tags (newest first by
     ``last_updated``); the rest are stale. Every ``-rc.*`` tag is stale. Returns
     stale sha (oldest first) followed by rc tags.
+
+    ``protected`` names are never returned — a sha pinned by a committed overlay
+    (``values/<env>.yaml``) must survive even if it falls outside the retention
+    window, or a pending build-once prod re-tag would lose its source (ADR-056).
     """
     if retention < 0:
         raise ValueError(f"retention must be >= 0, got {retention}")
@@ -52,7 +60,7 @@ def select_stale_tags(tags: list[TagInfo], retention: int) -> list[str]:
     )
     stale_sha = [t.name for t in sha[retention:]]
     rc = [t.name for t in tags if _RC_MARKER in t.name]
-    return stale_sha + rc
+    return [name for name in stale_sha + rc if name not in protected]
 
 
 def tag_exists(registry: str, image_name: str, tag: str) -> bool | None:
@@ -138,17 +146,22 @@ def prune(
     retention: int,
     dry_run: bool,
     client: DockerHubClient | None = None,
+    protected: dict[str, set[str]] | None = None,
 ) -> int:
     """Prune stale tags for each ``<registry_prefix>-<app>`` repo.
 
-    Returns the count deleted (or, in ``dry_run``, that would be deleted).
+    ``protected`` maps app -> sha tags pinned by a committed overlay; those are
+    never deleted (ADR-056 prune guard). Returns the count deleted (or, in
+    ``dry_run``, that would be deleted).
     """
     client = client or DockerHubClient.from_env()
+    protected = protected or {}
     total = 0
     for app in apps:
         repo = f"{registry_prefix}-{app}"
         tags = client.list_tags(repo)
-        stale = select_stale_tags(tags, retention)
+        keep = protected.get(app, set())
+        stale = select_stale_tags(tags, retention, protected=keep)
         sha_count = sum(1 for t in tags if t.name.startswith(SHA_TAG_PREFIX))
         kept = min(sha_count, retention)
         if not stale:


### PR DESCRIPTION
## What

Extends ADR-055 (shipped for the extracted `web` repo) to kubelab's `api` image: the prod semver is now produced by **re-tagging the staging-validated `sha-<short>` digest**, never a rebuild. Implements DELIVERY-002 / ADR-056 (decision: B1, re-tag the staging-pinned sha). Closes #679.

## Why

The first gated prod promotion (`api` → `1.1.0`, #664) CrashLooped on an init-guard staging never exercised, because `1.1.0` was a *rebuild* from the release commit, not the artifact validated in staging (incident #666 / #679). `release.yml` still rebuilt the semver via `ci-publish.yml`. Build-once makes prod run the exact bytes a human validated on staging — parity is structural, not a manual checklist step.

## Changes

- **`promotion.resolve_image_sha(env, app)`** — reads the raw `apps.platform.<app>.version` pin from `values/<env>.yaml`, requires an immutable `sha-<short>` (rejects `dev`/semver/absent). Reads the *raw* pin (not merged config) so an absent pin is an error, not a silent inherited `dev`. Shared values loader (`_load_values_doc`) deduped with `promote()`.
- **`toolkit deployment image-tag --env staging --app <app>`** — prints the pinned sha to stdout for CI capture.
- **`release.yml` `publish-api`** — `docker buildx imagetools create -t :X.Y.Z -t :latest :sha-<short>` (manifest list copied → byte-identical amd64+arm64, no rebuild) + in-job digest-equality assertion that fails the release on mismatch. **`publish-errors` left unchanged** (edge infra, ADR-056 *Out of scope*).
- **Prune guard** — `select_stale_tags(..., protected=...)` never deletes a `sha-*` referenced by a committed overlay; the CLI gathers per-app pins from staging+prod values so a pending re-tag can't lose its source.
- Runbook `gitops-delivery-promotion.md`, spec `verification.md` + `features.json`.

## Verification

- `poetry run pytest tests/` → **322 passed**, 108 deselected. New: `tests/test_image_tag.py` (6) + prune-guard test.
- `make lint` All passed; mypy clean on changed modules.
- Smoke: `image-tag --app web` → `sha-c8fa9a6` (rc=0); `--app api` → rc=1 (no staging sha pinned yet — guard fires; documented precondition).

**Precondition / known follow-up:** `api` is not yet pinned to a `sha-*` in `values/staging.yaml` (inherits `dev`). The first `api` release after this merge requires an `api` staging deploy first, or the release fails fast (by design — refuses to ship unvalidated bytes). C1/C2 (runtime digest equality) are CI-verified at that first release.

Spec: `specs/DELIVERY-002-build-once-apps/`.
