### PR TITLE
feat(delivery): single-SSOT errors image tag + auto-pin on release (DELIVERY-003)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,3 +112,51 @@ jobs:
       context: ./edge/errors
       runner: ${{ vars.RUNNER_DOCKER || '"ubuntu-latest"' }}
     secrets: inherit
+
+  # DELIVERY-003: auto-pin the deployed errors tag after a release. errors is a
+  # single semver shared across envs (edge.errors.version), so the bump lands as
+  # one PR (a human merges) — no per-env gate, no manual kustomization edit. Runs
+  # after publish-errors so the image exists when the toolkit verifies the tag.
+  promote-errors:
+    name: Promote errors tag
+    needs: [release-please, publish-errors]
+    if: needs.release-please.outputs.errors_release_created == 'true'
+    runs-on: ${{ fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      ERRORS_VERSION: ${{ needs.release-please.outputs.errors_version }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install toolkit
+        run: |
+          python -m pip install "poetry>=1.8,<2.0"
+          poetry install --only main
+      - name: Pin errors to the released semver (writes SSOT + syncs kustomization)
+        run: poetry run toolkit deployment promote --app errors --version "$ERRORS_VERSION"
+      - name: Open errors promotion PR
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          git config user.name "kubelab-bot"
+          git config user.email "bot@kubelab.live"
+          git add infra/config/values/common.yaml infra/k8s/base/kustomization.yaml
+          if git diff --staged --quiet; then
+            echo "errors already pinned to ${ERRORS_VERSION}; nothing to open"; exit 0
+          fi
+          BRANCH="deploy/errors-${ERRORS_VERSION}"
+          git checkout -b "$BRANCH"
+          git commit -m "chore(deploy): pin errors to ${ERRORS_VERSION}"
+          git push -u origin "$BRANCH" --force-with-lease
+          BODY="Automated errors tag promotion to \`${ERRORS_VERSION}\` (DELIVERY-003)."
+          BODY="$BODY Single SSOT \`edge.errors.version\` + synced kustomization;"
+          BODY="$BODY K3s and VPS follow on merge."
+          gh pr create --base master --head "$BRANCH" \
+            --title "chore(deploy): pin errors to ${ERRORS_VERSION}" \
+            --body "$BODY"

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -84,10 +84,11 @@ images:
     newTag: RELEASE.2025-09-07T16-13-09Z
   - name: postgres
     newTag: 16-alpine
-  # Custom apps (managed by release-please, not sync_k8s_images.py)
+  - name: docker.io/mlorentedev/kubelab-errors
+    newTag: 1.1.1
+  # Custom apps web/api: per-env tags via `toolkit deployment promote` (overlays).
+  # errors is synced from edge.errors.version above (DELIVERY-003 single SSOT).
   - name: docker.io/mlorentedev/kubelab-web
     newTag: "1.0.1"
   - name: docker.io/mlorentedev/kubelab-api
     newTag: "1.0.0"
-  - name: docker.io/mlorentedev/kubelab-errors
-    newTag: "1.1.1"

--- a/specs/DELIVERY-003-errors-tag-automation/features.json
+++ b/specs/DELIVERY-003-errors-tag-automation/features.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "DELIVERY-003-errors-tag-automation-f1",
+    "behavior": "edge.errors.version is the single SSOT for the errors image tag; no hardcoded kubelab-errors newTag remains in base/kustomization.yaml.",
+    "verification": "poetry run pytest tests/test_sync_k8s_images.py -q && ! grep -A1 'kubelab-errors' infra/k8s/base/kustomization.yaml | grep -q '\"1.1.1\"'",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DELIVERY-003-errors-tag-automation-f2",
+    "behavior": "A release-please errors:X.Y.Z bump updates the deployed K3s tag without a manual kustomization edit (toolkit writes the SSOT + re-syncs; release.yml opens the PR).",
+    "verification": "poetry run pytest 'tests/test_promotion.py::TestPromoteErrors::test_writes_edge_version_and_syncs' -q",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DELIVERY-003-errors-tag-automation-f3",
+    "behavior": "VPS Ansible (errors_image) and K3s resolve the same edge.errors.{image_name,version} SSOT — no divergence possible.",
+    "verification": "grep -q 'edge.errors.version' infra/ansible/playbooks/deploy-vps.yml && grep -q 'resolve_errors_image' toolkit/scripts/sync_k8s_images.py",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DELIVERY-003-errors-tag-automation-f4",
+    "behavior": "The config-drift gate stays green after an errors promotion (kustomization == sync output, committed together).",
+    "verification": "make sync-k8s-images && git diff --quiet infra/k8s/base/kustomization.yaml",
+    "state": "pending",
+    "evidence": ""
+  },
+  {
+    "id": "DELIVERY-003-errors-tag-automation-f5",
+    "behavior": "The toolkit refuses an errors tag that does not exist in the registry (same safety as api).",
+    "verification": "poetry run pytest 'tests/test_promotion.py::TestPromoteErrors::test_rejects_missing_tag' -q",
+    "state": "pending",
+    "evidence": ""
+  }
+]

--- a/specs/DELIVERY-003-errors-tag-automation/proposal.md
+++ b/specs/DELIVERY-003-errors-tag-automation/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "DELIVERY-003-errors-tag-automation"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: implementing # draft | implementing | verifying | archived
 created: "2026-06-26"
 issue: "mlorentedev/kubelab#776"   # repo#NNN — GitHub issue / Project item that tracks this spec
 tags: [spec, proposal, delivery, ci-cd, versioning, edge]
@@ -34,9 +34,9 @@ Right-sized automation (**not** full api-parity):
 
 ## Risks / open questions
 
-- **[OPEN — implementation] How K3s reads the SSOT tag.** errors' K3s manifest is *static* (`base/edge/errors.yaml` + a base `images:` newTag), unlike api/web's *generated* deployments. Decide: extend the generator to emit errors' image from `edge.errors.version`, or have the toolkit write a Kustomize `images:` override. Prefer the path that keeps the drift gate (ADR-027) authoritative.
-- **[OPEN — design] Prod gate vs auto-pin-everywhere.** Simplest = auto-pin to all envs on release (errors is low-risk; a bad error page is cosmetic, not a CrashLoop). Slightly more rigorous = auto-pin staging on release + add `errors` to the gated `promote-prod.yml` choices for prod. **Recommend the gated form** (keeps ADR-046's "prod is a deliberate gate" invariant) unless the simplicity win is judged decisive. Resolve when implementing.
-- **[DEP] Sequenced after DELIVERY-002** — reuses the `deployment promote` plumbing that build-once touches; avoid a merge race by landing build-once first.
+- **[RESOLVED — implementation] How K3s reads the SSOT tag → extend `sync_k8s_images.py`.** `errors` is structurally a *semver-in-`common.yaml`* image (one `edge.errors.version`, shared across envs), exactly like the third-party images `sync_k8s_images.py` already syncs into `base/kustomization.yaml` — unlike api/web, whose tags live per-env in the overlays and ride `deployment promote`. So `errors` belongs on the **sync** lane, not the per-env promote lane: add it as a structured source (`{registry}/{edge.errors.image_name}:{edge.errors.version}`), emit it in the synced `images:` block, and delete the hand-edited `kubelab-errors` `newTag` from the custom-apps group. The drift gate (ADR-027) stays authoritative because the kustomization tag is now a pure function of `common.yaml`. (Rejected: extending the generator — it does not emit `kustomization.yaml` at all, NET-002.)
+- **[RESOLVED — design] Prod gate vs auto-pin-everywhere → auto-pin everywhere via the single `common.yaml` SSOT, PR-mediated.** A *single* `edge.errors.version` cannot be gated per-env without splitting it into per-env overrides — which directly contradicts this spec's "single SSOT" goal (point 1). The gated form is therefore self-defeating here. Auto-pin is still **deliberate**: the bump lands as a PR a human merges (mirrors `staging-deploy.yml`), preserving ADR-046's "no unreviewed prod change" invariant without per-env divergence. `errors` is cosmetic-risk (a bad error page is not a CrashLoop), so the single shared version is the right granularity. (`errors` is NOT added to `promote-prod.yml` choices — those stay api/web per-env.)
+- **[DONE — DEP] Sequenced after DELIVERY-002** — build-once landed first (#789); this reuses the `deployment promote` plumbing without a merge race.
 
 ## Acceptance criteria
 

--- a/specs/DELIVERY-003-errors-tag-automation/tasks.md
+++ b/specs/DELIVERY-003-errors-tag-automation/tasks.md
@@ -9,30 +9,37 @@ created: "2026-06-26"
 
 ## Setup
 
-- [ ] Branch created from main: `feat/DELIVERY-003-errors-tag-automation`
-- [ ] `proposal.md` is complete and acceptance criteria are testable
-- [ ] No open questions left in `proposal.md` "Risks / open questions"
+- [x] Branch created from master: `feat/DELIVERY-003-errors-tag-automation`
+- [x] `proposal.md` is complete and acceptance criteria are testable
+- [x] No open questions left in `proposal.md` "Risks / open questions" (both RESOLVED)
 
 ## Implementation
 
-> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+> TDD order, one focused commit each. Part A = single SSOT for K3s (AC1/AC3/AC4). Part B = auto-pin on release (AC2/AC5).
 
-- [ ] Write failing test for <behavior 1>
-- [ ] Implement <module/function> to make it pass
-- [ ] Refactor for clarity (extract, rename, dedupe)
-- [ ] Write failing test for <behavior 2>
-- [ ] Implement to make it pass
-- [ ] ...
+### Part A — `errors` on the sync lane (single SSOT)
+
+- [x] Write failing test (`tests/test_sync_k8s_images.py`): the synced `images:` block contains `docker.io/mlorentedev/kubelab-errors` with `newTag` == `edge.errors.version` from common.yaml, sourced from the structured `edge.errors` keys (registry + image_name + version), no network.
+- [x] Implement: add a structured-source path in `sync_k8s_images.py` that emits `errors` from `{registry}/{edge.errors.image_name}:{edge.errors.version}`; refactor `build_images_block` if needed (no dup with the third-party path).
+- [x] Remove the hand-edited `kubelab-errors` `newTag` from the custom-apps group in `infra/k8s/base/kustomization.yaml`; run `make sync-k8s-images` so it re-appears in the synced block.
+- [x] Verify the drift gate is green (`generated == committed`) after the sync.
+
+### Part B — auto-pin `errors` on release (no manual edit)
+
+- [x] Write failing test (`tests/test_promotion.py`): `promote(env, "errors", X.Y.Z)` verifies the registry tag exists, writes `edge.errors.version` in `common.yaml`, and triggers the image sync (mock the sync + registry). Rejects a non-existent tag (AC5).
+- [x] Implement: route `errors` in `promotion.promote` to an edge path (write `edge.errors.version` in common.yaml + run the image sync) instead of the per-env overlay path; keep platform apps unchanged. CLI `deployment promote --app errors` accepts it (env optional/ignored for edge — single SSOT).
+- [x] `release.yml`: add a job on `errors_release_created` that runs `toolkit deployment promote --app errors --version <errors_version>`, then opens a PR with the bumped `common.yaml` + synced `kustomization.yaml` (mirrors `staging-deploy.yml` open-pr). `publish-errors` (rebuild) stays.
 
 ## Closing
 
-- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
-- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
-- [ ] Type checks pass
-- [ ] Lint passes
-- [ ] No unrelated changes in the diff (no scope creep)
-- [ ] `verification.md` filled in
+- [x] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [x] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [x] Type checks pass (`make type`)
+- [x] Lint passes (`make lint`)
+- [x] No unrelated changes in the diff (no scope creep)
+- [x] `verification.md` filled in
 - [ ] PR opened referencing this spec folder
+- [ ] On merge: `git mv specs/DELIVERY-003-errors-tag-automation specs/archive/...`; #776 closes
 
 ## Machine-readable features
 

--- a/specs/DELIVERY-003-errors-tag-automation/verification.md
+++ b/specs/DELIVERY-003-errors-tag-automation/verification.md
@@ -9,22 +9,27 @@ created: "2026-06-26"
 
 Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
 
-- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
-- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+- [x] AC1 — `edge.errors.version` is the single SSOT; no hardcoded `kubelab-errors` `newTag` -> `sync_k8s_images.resolve_errors_image`/`collect_images` emit errors from `edge.errors`; the custom-apps group in `base/kustomization.yaml` no longer lists errors. Tests `tests/test_sync_k8s_images.py`.
+- [x] AC2 — release-please `errors:X.Y.Z` updates the K3s tag with no manual edit -> `release.yml` `promote-errors` job runs `toolkit deployment promote --app errors` then opens a PR; `promotion._promote_errors` writes the version + re-syncs. Test `tests/test_promotion.py::TestPromoteErrors::test_writes_edge_version_and_syncs`.
+- [x] AC3 — VPS Ansible and K3s resolve the same SSOT -> both read `edge.errors.{image_name,version}` (`deploy-vps.yml` `errors_image` unchanged; K3s `newTag` now derived from the same key). No divergence possible.
+- [~] AC4 — config-drift gate stays green after a promotion -> the gate (`make config-check-drift`) regenerates overlays only; the base kustomization is `make sync-k8s-images` territory, which the promote command always runs, so committed == sync output. Gate stays green. _Gap: nothing in CI asserts kustomization==common.yaml independently (follow-up below)._
+- [x] AC5 — toolkit refuses an errors tag absent from the registry -> `_promote_errors` calls `tag_exists` and raises. Test `test_rejects_missing_tag`; smoke: `promote --app errors --version 0.0.0-nonexistent` -> "not found" (real Docker Hub 404).
 
 ## Test status
 
-- Test suite: `<command> -> <output / coverage %>`
-- Manual smoke test: what was exercised, what was observed
-- No regressions in existing test suite: yes / no (if no, document)
+- Test suite: `poetry run pytest tests/` -> **330 passed, 108 deselected** (live-env markers), 18s. New: `tests/test_sync_k8s_images.py` (5), `tests/test_promotion.py::TestPromoteErrors` (3).
+- Type: `mypy` clean on changed modules (pre-existing `notify_smoke.py` stub gap unrelated). Lint: `make lint` All passed. `yamllint` green at both local (100) and CI (120) thresholds.
+- Manual smoke: `make sync-k8s-images` -> errors emitted in the synced block as `kubelab-errors:1.1.1` from `edge.errors.version`; `toolkit deployment promote --app errors --version 0.0.0-nonexistent` (no `--env`) -> registry 404 refusal.
+- No regressions: yes (updated one pre-existing test that used `errors` as the rejected example — now a valid target; switched it to `traefik`).
 
 ## Decisions made during implementation
 
 Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
 
--
--
+- `errors` joins the **sync** lane, not the promote-overlay lane — it is semver-in-`common.yaml` (shared), structurally a third-party image, unlike api/web's per-env tags. The sync regex naturally stops at the `# Custom apps` comment, so web/api stay hand-pinned below while errors moves into the synced block above.
+- `promote --app errors` is **env-agnostic** (single SSOT): `--env` made optional, ignored for errors, still required for api/web. `_promote_errors` writes `common.yaml` + re-syncs instead of regenerating an overlay.
+- `sync_k8s_images.main()` refactored to `sync(common, kustomization)` with injectable paths so the promote command can sync a working tree under `settings.project_root` (and so the policy is unit-testable).
+- Follow-up (not in scope): add a `sync-k8s-images --check` to the drift gate so a manual `edge.errors.version` bump without a sync is caught in CI (the automated release path already syncs).
 
 ## Promotion candidates
 

--- a/tests/test_promotion.py
+++ b/tests/test_promotion.py
@@ -81,9 +81,69 @@ class TestPromote:
         generator.return_value.generate.assert_not_called()
 
     def test_rejects_non_platform_app(self, env_patched) -> None:
+        # errors is now a valid target (DELIVERY-003); other edge services are not.
         with pytest.raises(ValueError, match="not a platform app"):
-            promotion.promote("staging", "errors", "1.1.1")
+            promotion.promote("staging", "traefik", "1.1.1")
 
     def test_rejects_dev_env(self, env_patched) -> None:
         with pytest.raises(ValueError, match="staging|prod"):
             promotion.promote("dev", "web", "1.2.0")
+
+
+_COMMON = """\
+# common values
+registry: docker.io/mlorentedev
+edge:
+  errors:
+    image_name: kubelab-errors
+    version: "1.1.1"  # SSOT for the errors image tag
+"""
+
+
+class TestPromoteErrors:
+    """errors rides the single-SSOT sync lane, not the per-env overlay (DELIVERY-003)."""
+
+    def _write_common(self, root: Path) -> Path:
+        d = root / "infra" / "config" / "values"
+        d.mkdir(parents=True, exist_ok=True)
+        path = d / "common.yaml"
+        path.write_text(_COMMON)
+        return path
+
+    def test_writes_edge_version_and_syncs(self, env_patched, monkeypatch) -> None:
+        root, generator = env_patched
+        common = self._write_common(root)
+        monkeypatch.setattr(promotion, "tag_exists", MagicMock(return_value=True))
+        sync_mock = MagicMock(return_value=0)
+        monkeypatch.setattr(promotion.sync_k8s_images, "sync", sync_mock)
+
+        promotion.promote("prod", "errors", "1.2.0")
+
+        text = common.read_text()
+        assert 'version: "1.2.0"' in text
+        assert "# SSOT for the errors image tag" in text  # comment survives round-trip
+        sync_mock.assert_called_once()
+        # errors must NOT touch the per-env overlay generator (that is api/web's lane).
+        generator.return_value.generate.assert_not_called()
+
+    def test_rejects_missing_tag(self, env_patched, monkeypatch) -> None:
+        root, _ = env_patched
+        self._write_common(root)
+        monkeypatch.setattr(promotion, "tag_exists", MagicMock(return_value=False))
+        sync_mock = MagicMock()
+        monkeypatch.setattr(promotion.sync_k8s_images, "sync", sync_mock)
+
+        with pytest.raises(ValueError, match="not found"):
+            promotion.promote("prod", "errors", "9.9.9")
+        sync_mock.assert_not_called()
+
+    def test_errors_ignores_env(self, env_patched, monkeypatch) -> None:
+        # Single SSOT in common.yaml: errors promotion is env-agnostic, so even
+        # env="dev" (no K8s overlay) is valid — unlike platform apps.
+        root, _ = env_patched
+        common = self._write_common(root)
+        monkeypatch.setattr(promotion, "tag_exists", MagicMock(return_value=True))
+        monkeypatch.setattr(promotion.sync_k8s_images, "sync", MagicMock(return_value=0))
+
+        promotion.promote("dev", "errors", "2.0.0")
+        assert 'version: "2.0.0"' in common.read_text()

--- a/tests/test_sync_k8s_images.py
+++ b/tests/test_sync_k8s_images.py
@@ -1,0 +1,51 @@
+"""Tests for sync_k8s_images — errors on the single-SSOT sync lane (DELIVERY-003).
+
+`errors` is a semver-in-common.yaml image (one edge.errors.version, shared across
+envs), so its K3s tag is derived by the same sync that handles third-party images
+— not hand-edited and not the per-env promote lane. Pure config -> image-list
+policy; no disk, no network.
+"""
+
+from __future__ import annotations
+
+from toolkit.scripts import sync_k8s_images
+
+
+def _config() -> dict:
+    return {
+        "registry": "docker.io/mlorentedev",
+        "edge": {"errors": {"image_name": "kubelab-errors", "version": "1.2.3"}},
+        "apps": {
+            "services": {
+                "core": {"gitea": {"image": "gitea/gitea:1.25.5"}},
+            }
+        },
+    }
+
+
+class TestResolveErrorsImage:
+    def test_builds_image_from_structured_keys(self) -> None:
+        # Same string Ansible renders for the VPS: {registry}/{image_name}:{version}.
+        assert sync_k8s_images.resolve_errors_image(_config()) == (
+            "docker.io/mlorentedev/kubelab-errors",
+            "1.2.3",
+        )
+
+    def test_returns_none_when_edge_errors_absent(self) -> None:
+        assert sync_k8s_images.resolve_errors_image({"registry": "docker.io/mlorentedev"}) is None
+
+    def test_returns_none_without_version(self) -> None:
+        cfg = {"registry": "docker.io/mlorentedev", "edge": {"errors": {"image_name": "kubelab-errors"}}}
+        assert sync_k8s_images.resolve_errors_image(cfg) is None
+
+
+class TestCollectImages:
+    def test_includes_errors_alongside_third_party(self) -> None:
+        images = sync_k8s_images.collect_images(_config())
+        assert ("docker.io/mlorentedev/kubelab-errors", "1.2.3") in images
+        assert ("gitea/gitea", "1.25.5") in images
+
+    def test_errors_emitted_in_block(self) -> None:
+        block = sync_k8s_images.build_images_block(sync_k8s_images.collect_images(_config()))
+        assert "docker.io/mlorentedev/kubelab-errors" in block
+        assert "newTag: 1.2.3" in block

--- a/toolkit/cli/deployment.py
+++ b/toolkit/cli/deployment.py
@@ -98,31 +98,39 @@ def deploy(
 
 @app.command()
 def promote(
-    env: Annotated[
-        str,
-        typer.Option("--env", "-e", help="Target environment (staging|prod)"),
-    ],
     app_name: Annotated[
         str,
-        typer.Option("--app", "-a", help="Platform app to promote (api|web)"),
+        typer.Option("--app", "-a", help="App to promote (api|web|errors)"),
     ],
     version: Annotated[
         str,
         typer.Option("--version", "-v", help="Immutable image tag (e.g. 1.2.0 or sha-abc1234)"),
     ],
+    env: Annotated[
+        str | None,
+        typer.Option("--env", "-e", help="Environment (staging|prod); required for api/web, ignored for errors"),
+    ] = None,
 ) -> None:
     """
-    Promote an app to an immutable image tag in an environment (ADR-046 D6).
+    Promote an app to an immutable image tag (ADR-046 D6).
 
-    Verifies the tag exists in the registry, sets apps.platform.<app>.version in
-    values/<env>.yaml, and regenerates the overlay atomically. Staging tracks SHA
-    tags (continuous deployment); prod tracks semver (gated by PR).
+    Verifies the tag exists in the registry, then: api/web set apps.platform.<app>.version
+    in values/<env>.yaml and regenerate the overlay (staging tracks SHA, prod tracks semver);
+    errors sets the single edge.errors.version in common.yaml and re-syncs the kustomization
+    (env-agnostic single SSOT, DELIVERY-003).
     """
-    logger.section(f"Promote {app_name} -> {version} ({env.upper()})")
-    validate_environment_config(env)
+    if app_name == "errors":
+        logger.section(f"Promote errors -> {version}")
+    else:
+        if not env:
+            logger.error("--env is required for platform apps (api|web)")
+            raise typer.Exit(1)
+        logger.section(f"Promote {app_name} -> {version} ({env.upper()})")
+        validate_environment_config(env)
     try:
-        promotion.promote(env, app_name, version)
-        logger.success(MESSAGES.SUCCESS_COMPLETED.format(f"Promote {app_name} to {version} in {env}"))
+        promotion.promote(env or "prod", app_name, version)
+        target = "errors" if app_name == "errors" else f"{app_name} in {env}"
+        logger.success(MESSAGES.SUCCESS_COMPLETED.format(f"Promote {target} to {version}"))
     except Exception as e:
         logger.error(MESSAGES.ERROR_FAILED_WITH_REASON.format("Promote", str(e)))
         raise typer.Exit(1) from None

--- a/toolkit/features/promotion.py
+++ b/toolkit/features/promotion.py
@@ -26,6 +26,7 @@ from toolkit.core.logging import logger
 from toolkit.features.configuration import ConfigurationManager
 from toolkit.features.generator_k8s import K8sGenerator
 from toolkit.features.registry import tag_exists
+from toolkit.scripts import sync_k8s_images
 
 # Immutable CI build tag: ``sha-${GITHUB_SHA::7}`` (see staging-deploy.yml). The
 # web-image-receiver rejects anything else, so staging only ever pins this shape.
@@ -102,12 +103,58 @@ def _resolve_image(env: str, app: str) -> tuple[str, str]:
     return registry, image_name
 
 
+def _promote_errors(version: str) -> None:
+    """Set ``edge.errors.version`` in ``common.yaml`` and re-sync the kustomization.
+
+    The errors image is a single semver shared across envs (DELIVERY-003), so its
+    promotion is env-agnostic: it writes the one SSOT and derives the K3s tag via
+    the image sync — no per-env overlay regeneration. Refuses a tag that does not
+    exist in the registry, same safety as platform apps.
+    """
+    yaml, common_path, data = _load_values_doc("common")
+    registry = data.get("registry", "docker.io/mlorentedev")
+    errors_cfg = (data.get("edge") or {}).get("errors")
+    if not errors_cfg or "image_name" not in errors_cfg:
+        raise ValueError("edge.errors.image_name missing from common.yaml")
+    image_name = errors_cfg["image_name"]
+
+    exists = tag_exists(registry, image_name, version)
+    if exists is False:
+        raise ValueError(
+            f"Tag '{version}' not found for {registry}/{image_name} — refusing to promote a "
+            "non-existent image (it would ImagePullBackOff)"
+        )
+    if exists is None:
+        logger.warning(f"Could not verify {registry}/{image_name}:{version} exists; proceeding")
+
+    previous = errors_cfg.get("version", "(unset)")
+    if previous == version:
+        logger.info(f"errors already at {version}; nothing to do")
+        return
+    errors_cfg["version"] = version
+    with common_path.open("w") as fh:
+        yaml.dump(data, fh)
+    logger.info(f"errors version {previous} -> {version} (edge.errors.version)")
+
+    # Derive the K3s tag from the SSOT so the drift gate stays authoritative.
+    sync_k8s_images.sync(common_path, settings.project_root / "infra" / "k8s" / "base" / "kustomization.yaml")
+    logger.success(f"Promoted errors to {version}; kustomization re-synced")
+
+
 def promote(env: str, app: str, version: str) -> None:
-    """Set ``apps.platform.<app>.version`` in ``values/<env>.yaml`` and regenerate the overlay.
+    """Set an app's deployed image tag in its SSOT and regenerate derived artifacts.
+
+    Platform apps (api/web) write ``apps.platform.<app>.version`` in
+    ``values/<env>.yaml`` and regenerate the overlay. The ``errors`` edge service
+    writes the single ``edge.errors.version`` in ``common.yaml`` and re-syncs the
+    kustomization (env-agnostic — see ``_promote_errors``).
 
     Raises ``ValueError`` for an unknown app, a non-existent registry tag, or a
-    ``dev`` target (dev runs on Docker Compose, not the K8s overlays).
+    ``dev`` target for a platform app (dev runs on Docker Compose, not the overlays).
     """
+    if app == "errors":
+        _promote_errors(version)
+        return
     if env == "dev":
         raise ValueError("Promotion targets K8s environments (staging|prod), not dev")
     if app not in COMPONENTS.PLATFORM_APPS:

--- a/toolkit/scripts/sync_k8s_images.py
+++ b/toolkit/scripts/sync_k8s_images.py
@@ -57,6 +57,45 @@ def parse_image(image_str: str) -> tuple[str, str]:
     return image_str[:last_colon], image_str[last_colon + 1 :]
 
 
+def resolve_errors_image(config: dict[str, object]) -> tuple[str, str] | None:
+    """Build the `errors` image (name, tag) from the structured `edge.errors` SSOT.
+
+    Unlike third-party images (single `name:tag` strings), `errors` is pinned by
+    separate keys — `registry` + `edge.errors.image_name` + `edge.errors.version`
+    — the same string Ansible renders for the VPS. This is the one custom app on
+    the sync lane: a semver shared across envs (DELIVERY-003), not a per-env tag.
+    Returns ``None`` if any key is missing.
+    """
+    edge = config.get("edge")
+    registry = config.get("registry")
+    if not isinstance(edge, dict) or not isinstance(registry, str):
+        return None
+    errors = edge.get("errors")
+    if not isinstance(errors, dict):
+        return None
+    image_name = errors.get("image_name")
+    version = errors.get("version")
+    if not isinstance(image_name, str) or not version:
+        return None
+    return f"{registry}/{image_name}", str(version)
+
+
+def collect_images(config: dict[str, object]) -> list[tuple[str, str]]:
+    """Resolve every synced image (third-party + the `errors` custom app)."""
+    images: list[tuple[str, str]] = []
+    for path in IMAGE_SOURCES:
+        image_str = resolve_path(config, path)
+        if not image_str or ":" not in image_str:
+            continue
+        name, tag = parse_image(image_str)
+        if tag and tag != "latest":
+            images.append((name, tag))
+    errors_image = resolve_errors_image(config)
+    if errors_image:
+        images.append(errors_image)
+    return images
+
+
 def build_images_block(images: list[tuple[str, str]]) -> str:
     """Build the YAML text for the images: section."""
     lines = [IMAGES_HEADER, "images:\n"]
@@ -66,20 +105,18 @@ def build_images_block(images: list[tuple[str, str]]) -> str:
     return "".join(lines)
 
 
-def main() -> int:
-    with open(COMMON_YAML) as f:
+def sync(common_yaml: Path = COMMON_YAML, kustomization: Path = KUSTOMIZATION) -> int:
+    """Rewrite the ``images:`` block in ``kustomization`` from ``common_yaml``.
+
+    Paths are injectable so callers (e.g. ``deployment promote --app errors``) can
+    re-sync a working tree other than the module default. Returns 0 on success.
+    """
+    with open(common_yaml) as f:
         config = yaml.safe_load(f)
 
-    content = KUSTOMIZATION.read_text()
+    content = kustomization.read_text()
 
-    images: list[tuple[str, str]] = []
-    for path in IMAGE_SOURCES:
-        image_str = resolve_path(config, path)
-        if not image_str or ":" not in image_str:
-            continue
-        name, tag = parse_image(image_str)
-        if tag and tag != "latest":
-            images.append((name, tag))
+    images = collect_images(config)
 
     if not images:
         print("WARNING: No images resolved from common.yaml", file=sys.stderr)
@@ -100,9 +137,14 @@ def main() -> int:
         # No images section yet -- append
         content = content.rstrip("\n") + "\n\n" + new_block
 
-    KUSTOMIZATION.write_text(content)
+    kustomization.write_text(content)
     print(f"Synced {len(images)} image tags from common.yaml -> kustomization.yaml")
     return 0
+
+
+def main() -> int:
+    """CLI entrypoint — sync the repo's default common.yaml -> kustomization.yaml."""
+    return sync()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Make `edge.errors.version` the **single SSOT** for the errors image tag and auto-pin it on release. Implements DELIVERY-003 / amends ADR-056 (reverses its errors *automation* carve-out while keeping errors off build-once). Closes #776.

## Why

`errors` was the one custom app left off the automated promotion lane (ADR-046). Its deployed tag lived in **two places** — `edge.errors.version` (common.yaml, consumed by VPS Ansible) **and** a hardcoded `newTag` in `base/kustomization.yaml` (K3s) — and a release-please `errors:X.Y.Z` bump needed a **manual** K3s pin (the CLAUDE.md "custom app images need manual pin" gotcha). A forgotten pin silently leaves prod on a stale errors image.

## Design (the two open questions, resolved)

- **How K3s reads the SSOT → extend `sync_k8s_images.py`.** `errors` is semver-in-`common.yaml` (one version, shared across envs), structurally like the third-party images the sync already manages — unlike api/web's per-env overlay tags. So it rides the **sync** lane, not the promote-overlay lane. The hardcoded `kubelab-errors` `newTag` is removed; the tag is now a pure function of `edge.errors.version`.
- **Prod gate vs auto-pin → auto-pin everywhere, PR-mediated.** A single shared version can't be gated per-env without splitting the SSOT (self-defeating vs the "single SSOT" goal). The bump still lands as a PR a human merges (mirrors `staging-deploy.yml`), preserving ADR-046's "no unreviewed prod change". errors is NOT added to `promote-prod.yml`.

## Changes

- **`sync_k8s_images.py`** — `resolve_errors_image` / `collect_images` emit errors from `{registry}/{edge.errors.image_name}:{edge.errors.version}`; `main()` refactored to `sync(common, kustomization)` with injectable paths. `base/kustomization.yaml` errors `newTag` removed (now synced).
- **`promotion.py`** — `promote()` routes `errors` to `_promote_errors`: writes `edge.errors.version` in common.yaml + re-syncs the kustomization (env-agnostic), with the same registry tag-existence refusal as api/web. CLI `--env` now optional (required for api/web, ignored for errors).
- **`release.yml`** — `promote-errors` job (after `publish-errors`) auto-pins the released semver and opens a PR. `publish-errors` rebuild unchanged.

## Verification

- `poetry run pytest tests/` → **330 passed**, 108 deselected. New: `tests/test_sync_k8s_images.py` (5) + `TestPromoteErrors` (3).
- `make lint` All passed; mypy clean on changed modules; yamllint green at local (100) and CI (120).
- Smoke: `make sync-k8s-images` emits `kubelab-errors:1.1.1` from the SSOT; `promote --app errors --version 0.0.0-nonexistent` (no `--env`) → registry 404 refusal (AC5).

**Known follow-up (not in scope):** the config-drift gate regenerates overlays only, not the base kustomization, so a *manual* `edge.errors.version` bump without a sync isn't caught in CI (the automated release path always syncs). A `sync-k8s-images --check` in the drift gate would close that — flagged for a separate ticket.

Spec: `specs/DELIVERY-003-errors-tag-automation/`.
