### PR TITLE
ci(drift): gate base kustomization image sync against common.yaml

### DIFF
--- a/.github/workflows/check-config-drift.yml
+++ b/.github/workflows/check-config-drift.yml
@@ -89,6 +89,21 @@ jobs:
           echo "::error::  make config-generate ENV=$TARGET_ENV"
           echo "::error::Review the diff, then commit the regenerated files."
 
+      # Base kustomization image tags are synced from common.yaml (env-independent),
+      # so gate once. The generator drift check above covers overlays only — this
+      # catches a manual common.yaml image bump that skipped `make sync-k8s-images`
+      # (e.g. edge.errors.version or a third-party tag). #792.
+      - name: Check base kustomization image sync (#792)
+        if: matrix.env == 'prod'
+        run: poetry run toolkit sync images --check
+
+      - name: Hint on image-sync drift
+        if: failure() && matrix.env == 'prod'
+        run: |
+          echo "::error::Base kustomization image tags drifted from common.yaml. Locally run:"
+          echo "::error::  make sync-k8s-images"
+          echo "::error::Review the diff, then commit infra/k8s/base/kustomization.yaml."
+
       # Headscale ACL policy is prod-only (single control plane, ADR-015), so gate once.
       - name: Validate Headscale ACL policy (ADR-041 / VPN-ACL-002)
         if: matrix.env == 'prod'


### PR DESCRIPTION
Closes #792 (surfaced during DELIVERY-003 / #791).

## Problem

The config-drift gate runs `make config-check-drift` which regenerates the **overlays** only. The base `infra/k8s/base/kustomization.yaml` `images:` block is synced from common.yaml by `toolkit sync images` — and was **not** gated. A manual common.yaml image bump (`edge.errors.version`, or any third-party tag) that skipped `make sync-k8s-images` would silently drift, with no CI signal.

## Fix

Wire the **already-existing** `toolkit sync images --check` into `check-config-drift.yml`, gated to the `prod` matrix leg (the base kustomization is env-independent, so run once — same 'gate once' pattern as the Headscale ACL check). No new toolkit code.

## Verification

- `toolkit sync images --check` on a bumped `edge.errors.version` without a sync → **exit 1**; in-sync → **exit 0** (verified locally).
- yamllint green at local (100) and CI (120). Static commands only (no event input).