### PR TITLE
chore(lint): unify yamllint to a single .yamllint SSOT + ignore Astro cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,15 +44,10 @@ jobs:
           python-version: '3.12'
 
       - name: Validate YAML syntax
+        # Uses the repo .yamllint (single SSOT) — no inline config to drift.
         run: |
           pip install --quiet yamllint
-          yamllint -d '{extends: default,
-            rules: {
-              line-length: {max: 120},
-              document-start: disable,
-              truthy: {check-keys: false},
-              comments-indentation: disable
-            }}' .github/workflows/
+          yamllint .github/workflows/
 
       - name: Validate Makefile
         run: make -n help >/dev/null

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ _site/
 dist/
 bin/
 output/
+# Astro generated cache (e.g. stale apps/web/site residue after ADR-048 retirement)
+.astro/
 
 # Build artifacts
 *.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,16 +87,7 @@ repos:
     hooks:
       - id: yamllint
         exclude: '(infra/helm/.*/templates/|infra/ansible/|apps/blog/|apps/wiki/|infra/config/secrets/|infra/k8s/cluster/)'
-        args:
-          - '-d'
-          - >-
-            {extends: default,
-            rules: {
-              line-length: {max: 130},
-              document-start: disable,
-              truthy: {check-keys: false},
-              comments-indentation: disable
-            }}
+        # Config lives in the repo .yamllint (single SSOT) — no inline override.
 
   # Dockerfile linting
   - repo: https://github.com/hadolint/hadolint

--- a/.yamllint
+++ b/.yamllint
@@ -1,15 +1,14 @@
 ---
-# Project-wide yamllint config.
-# Default line-length (80) is too tight for Ansible role tasks and K8s manifests.
-# 100 is the sweet spot — readable on side-by-side diffs and matches modern norms
-# (Prettier default, Go fmt style). Keep at 100 unless a real long-line case
-# (Argon2 hash, long URL) justifies a per-file override.
+# Project-wide yamllint config — the single SSOT consumed by pre-commit AND CI
+# (both reference this file; neither passes an inline `-d` config anymore, so the
+# threshold lives in one place). Default line-length (80) is too tight for K8s
+# manifests and generated Authelia configs; 130 accommodates those (and Argon2
+# hashes via allow-non-breakable-words) without breaking committed output.
 extends: default
 
 rules:
   line-length:
-    max: 100
-    level: warning
+    max: 130
   document-start: disable
   truthy:
     check-keys: false


### PR DESCRIPTION
Closes the yamllint config drift flagged in the session handoff (thread E).

## Problem

Three different line-length limits across three places:
- `.yamllint` — max **100**, level warning, **and effectively unused** (`make lint` runs only ruff; CI and pre-commit both passed inline `-d` configs that override file discovery).
- CI `ci.yml` — inline **120** (error), workflows only.
- pre-commit — inline **130** (error), everything else.

## Fix

One SSOT: `.yamllint` at **max 130**, and CI + pre-commit drop their inline `-d` so they read it.

- **Why 130, not 120:** ~15 committed files have lines 121–130 (incl. generator output `infra/config/authelia/generated/*` and Authelia configs). 120 would fail them and force generator changes — out of scope. 130 is the value the repo already passes; the change is pure de-duplication.
- **Behaviour preserved:** `pre-commit run yamllint --all-files` green; `yamllint .github/workflows/` (CI-equivalent) green. No workflow file exceeds 120, so relaxing that gate to 130 changes nothing observable.

## Also

Ignore `.astro/` (Astro generated cache) — stale `apps/web/site` residue left after the astro-site retirement (ADR-048, #698) kept showing in `git status`. The dead `apps/web/` tree itself is local-only residue; `git clean -fdx apps/web/` removes it when you want (not done here — it's your local checkout).