### PR TITLE
chore(staging): deploy web sha-ae17d2c

### DIFF
--- a/infra/config/values/staging.yaml
+++ b/infra/config/values/staging.yaml
@@ -52,7 +52,7 @@ apps:
       enable_homelabs: false
       enable_contact: false
   # Third-party services
-      version: sha-c8fa9a6
+      version: sha-ae17d2c
   services:
     core:
       gitea:

--- a/infra/k8s/overlays/staging/generated/deployments.yaml
+++ b/infra/k8s/overlays/staging/generated/deployments.yaml
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: docker.io/mlorentedev/kubelab-web:sha-c8fa9a6
+          image: docker.io/mlorentedev/kubelab-web:sha-ae17d2c
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Staging promotion of `web` to `sha-ae17d2c` (ADR-046, cross-repo dispatch from mlorentedev/web).