### PR TITLE
fix(k3s): recover staging ACME cert renewal + generic k8s restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -759,6 +759,15 @@ apply-secrets:
 	@test -n "$(ENV)" || (echo "Usage: make apply-secrets ENV=staging|prod" && exit 1)
 	@$(TOOLKIT) infra k8s apply-secrets --env $(ENV)
 
+# Restart any K8s deployment via the toolkit (rollout restart + wait). Generic over
+# service + namespace (NS defaults to kubelab). E.g. make a pod re-read a changed
+# env-var Secret: make restart-service SVC=traefik ENV=staging NS=kube-system
+.PHONY: restart-service
+restart-service:
+	@test -n "$(SVC)" || (echo "Usage: make restart-service SVC=<deployment> ENV=staging|prod [NS=namespace]" && exit 1)
+	@test -n "$(ENV)" || (echo "Usage: make restart-service SVC=<deployment> ENV=staging|prod [NS=namespace]" && exit 1)
+	@$(TOOLKIT) infra k8s restart $(SVC) --env $(ENV) $(if $(NS),--namespace $(NS),)
+
 # Renders Traefik Middlewares that wrap SOPS-sourced API keys (ADR-035 Stage 1).
 # Currently only api-key-ollama (prod). Adding a new auth-protected service:
 #   1. Append a SecretSpec to SECRET_CATALOG (toolkit/features/secrets_manager.py)

--- a/infra/ansible/playbooks/provision-ace1.yml
+++ b/infra/ansible/playbooks/provision-ace1.yml
@@ -84,6 +84,7 @@
       changed_when: false
       check_mode: false
       no_log: true
+      tags: [always]  # prerequisite: secrets needed by any tag-filtered role
 
     - name: Decrypt env secrets (controller-side)
       command: sops -d {{ playbook_dir }}/../../config/secrets/{{ deploy_env }}.enc.yaml
@@ -93,11 +94,13 @@
       changed_when: false
       check_mode: false
       no_log: true
+      tags: [always]  # prerequisite: secrets needed by any tag-filtered role
 
     - name: Merge secrets (env overrides common)
       set_fact:
         secrets: "{{ (sops_common.stdout | from_yaml) | combine(sops_env.stdout | from_yaml, recursive=True) }}"
       no_log: true
+      tags: [always]  # prerequisite: secrets needed by any tag-filtered role
 
     - name: Generate Headscale pre-auth key (via VPS)
       command: >
@@ -121,6 +124,7 @@
           {{ [ansible_host] +
              ([config.networking.nodes.ace1.lan_ip]
               if config.networking.nodes.ace1.lan_ip is defined else []) }}
+      tags: [always]  # prerequisite: k3s role needs k3s_tls_san under --tags k3s
 
   roles:
     - role: ../roles/base_system
@@ -155,7 +159,9 @@
         k3s_traefik_http_port: "{{ config.k3s.traefik.http_port }}"
         k3s_traefik_https_port: "{{ config.k3s.traefik.https_port }}"
         k3s_traefik_acme_enabled: true
-        k3s_traefik_acme_email: "{{ config.edge.traefik.acme_email }}"
+        # SSOT-014c: acme_email is derived from apps.contact.email by the Python
+        # config loader, which raw include_vars here does NOT run — mirror it.
+        k3s_traefik_acme_email: "{{ config.edge.traefik.acme_email | default(config.apps.contact.email, true) }}"
         k3s_traefik_acme_dns_provider: "{{ config.edge.traefik.dns_provider }}"
         k3s_traefik_acme_dns_resolvers: "{{ config.edge.traefik.dns_resolver_1 }},{{ config.edge.traefik.dns_resolver_2 }}"
         k3s_traefik_acme_cloudflare_token: "{{ secrets.cloudflare.api_token }}"

--- a/infra/ansible/roles/k3s_server/handlers/main.yml
+++ b/infra/ansible/roles/k3s_server/handlers/main.yml
@@ -4,3 +4,13 @@
     name: k3s
     state: restarted
     daemon_reload: true
+
+# Picks up a changed CF_DNS_API_TOKEN (read only at pod start) so ACME DNS-01
+# can renew. Notified by the Cloudflare Secret task; runs only when it changes.
+- name: Restart Traefik
+  command: k3s kubectl -n kube-system rollout restart deployment traefik
+  changed_when: true
+
+- name: Wait for Traefik rollout
+  command: k3s kubectl -n kube-system rollout status deployment traefik --timeout=120s
+  changed_when: false

--- a/infra/ansible/roles/k3s_server/tasks/main.yml
+++ b/infra/ansible/roles/k3s_server/tasks/main.yml
@@ -77,6 +77,10 @@
     dest: /var/lib/rancher/k3s/server/manifests/cloudflare-api-token.yaml
     mode: "0600"
   no_log: true
+  register: cf_token_secret
+  notify:
+    - Restart Traefik
+    - Wait for Traefik rollout
   when: k3s_traefik_acme_enabled and k3s_traefik_acme_cloudflare_token | length > 0
 
 # --- Traefik HelmChartConfig (ports + plugins, ADR-015) ---

--- a/toolkit/cli/infra.py
+++ b/toolkit/cli/infra.py
@@ -752,6 +752,46 @@ def k8s_status(
     logger.console.print(result.stdout)
 
 
+@k8s_app.command("restart")
+def k8s_restart(
+    deployment: Annotated[str, typer.Argument(help="Deployment name to restart")],
+    env: Annotated[str, typer.Option("--env", "-e", help="Target environment")],
+    namespace: Annotated[str, typer.Option("--namespace", "-n", help="Namespace")] = "kubelab",
+    timeout: Annotated[int, typer.Option("--timeout", help="Seconds to wait for rollout")] = 120,
+) -> None:
+    """Restart any K8s deployment (rollout restart + wait) on the env's cluster.
+
+    Codified replacement for ad-hoc `kubectl rollout restart`. Generic over
+    deployment + namespace (default: kubelab). Typical use: make a pod re-read a
+    changed env-var Secret, e.g. Traefik's CF_DNS_API_TOKEN after a token resync:
+      toolkit infra k8s restart traefik --env staging --namespace kube-system
+    """
+    if env == "dev":
+        logger.info("Dev environment uses Docker Compose, not K8s (use `services restart`)")
+        raise typer.Exit(0)
+
+    logger.section(f"Restart {namespace}/{deployment} - {env.upper()}")
+    validate_environment_config(env)
+
+    kctl = _kubectl_cmd(_get_kubeconfig(env))
+
+    restart = command.run(f"{kctl} -n {namespace} rollout restart deployment/{deployment}", check=False)
+    if restart.returncode != 0:
+        logger.error(f"rollout restart failed:\n{restart.stderr}")
+        raise typer.Exit(1)
+    logger.console.print(restart.stdout.strip())
+
+    rollout = command.run(
+        f"{kctl} -n {namespace} rollout status deployment/{deployment} --timeout={timeout}s",
+        check=False,
+    )
+    if rollout.returncode != 0:
+        logger.error(f"rollout did not complete within {timeout}s:\n{rollout.stderr or rollout.stdout}")
+        raise typer.Exit(1)
+    logger.console.print(rollout.stdout.strip())
+    logger.success(f"{namespace}/{deployment} restarted")
+
+
 @k8s_app.command("fetch-kubeconfig")
 def k8s_fetch_kubeconfig(
     env: Annotated[str, typer.Option("--env", "-e", help="Cluster to fetch (staging|prod|hub)")],


### PR DESCRIPTION
## Why
All staging apps served browser SSL errors: their Let's Encrypt certs expired
2026-06-20 and Traefik could not renew them. Root cause: the kube-system
`cloudflare-api-token` Secret on ace1 held a stale token (Cloudflare 9109
"Invalid access token"), so the ACME DNS-01 challenge failed for every domain.
The valid token was already in SOPS — no rotation needed; ace1's Secret was
simply out of sync.

## What
- **Auto-recovery**: a new `Restart Traefik` handler in the k3s_server role,
  notified when the Cloudflare token Secret changes, so Traefik re-reads
  `CF_DNS_API_TOKEN` (env var, read only at pod start). Future token changes
  self-heal via `make provision NODE=ace1 ENV=staging TAGS=k3s`.
- **Provision repairs (two latent bugs)**:
  - SOPS decrypt/merge + TLS-SAN prerequisites tagged `always`, so a tag-scoped
    k3s provision is self-contained (previously failed on undefined `_k3s_tls_san`).
  - `acme_email` falls back to `apps.contact.email`, mirroring the config-loader
    derivation that raw `include_vars` does not apply (broke every ace1
    re-provision since 2026-05-25).
- **Generic restart tooling**: `toolkit infra k8s restart <deployment> --env
  --namespace` + `make restart-service SVC= ENV= [NS=]`, replacing ad-hoc kubectl
  for restarting any workload.

## Verification
- Resynced the Secret + restarted Traefik via the new tooling; the entire staging
  fleet + the `*.staging.kubelab.live` wildcard now serve fresh Let's Encrypt
  certs (notAfter 2026-09-26, ~90d). Traefik logs show clean renewals, no more
  `Invalid access token`.
- `make provision NODE=ace1 ENV=staging TAGS=k3s` now completes green.
- `make test` 330 passed; ruff + mypy + yamllint clean.

## Follow-ups
- OBS-007 (#799): alert on cert expiry / ACME renewal failure (this went
  unnoticed for ~5 weeks).
- SSOT-023 (#800): have Ansible consume the toolkit-derived config instead of raw
  YAML (removes the duplicated acme_email derivation).