### PR TITLE
feat(ansible): install tmux via base_system role

### DIFF
--- a/infra/ansible/roles/base_system/defaults/main.yml
+++ b/infra/ansible/roles/base_system/defaults/main.yml
@@ -5,6 +5,7 @@ base_packages:
   - git
   - htop
   - vim
+  - tmux
   - jq
   - unzip
   - ca-certificates

--- a/specs/ANSIBLE-021-tmux/proposal.md
+++ b/specs/ANSIBLE-021-tmux/proposal.md
@@ -47,6 +47,6 @@ No open questions.
 
 ## References
 
-- Backlog: `kubelab/11-tasks.md` ANSIBLE-021
+- Issue: [#814](https://github.com/mlorentedev/kubelab/issues/814) (bitácora; tasks live in GitHub per ADR-018)
 - Dotfiles: `~/Projects/dotfiles/.zsh/functions.zsh` — `sshmux` function
 - Role: `infra/ansible/roles/base_system/`

--- a/specs/ANSIBLE-021-tmux/proposal.md
+++ b/specs/ANSIBLE-021-tmux/proposal.md
@@ -17,12 +17,14 @@ Captured 2026-05-11 during dotfiles tmux integration.
 
 ## What
 
-Add `tmux` to the `base_system` Ansible role's package list. Re-run `base_system` against the inventory targets it already covers:
+Add `tmux` to the `base_system` Ansible role's package list. Under the per-node `make provision NODE=x` flow, `base_system` runs on **5 nodes**:
 
-- Homelab: ace1, ace2, rpi4, rpi3, beelink
-- Cloud: vps, aws1
+- Homelab: ace1, ace2, beelink, rpi4
+- Cloud: aws1
 
-Jetson is deliberately excluded — Ubuntu 18.04, raw-only via ANSIBLE-014, not an interactive-session target.
+**vps and rpi3 are NOT covered by this change**: their bespoke playbooks (`provision-vps.yml`, `provision-rpi3.yml`) deliberately omit `base_system`. They receive tmux as part of the minimal-baseline fix in **ANSIBLE-029 (#817)** — not bolted onto the prod K3s playbook here.
+
+Jetson is deliberately excluded — Ubuntu 18.04, raw-only via ANSIBLE-014, not an interactive-session target (its `provision-jetson.yml` also omits `base_system`).
 
 ## Out of scope
 
@@ -34,7 +36,7 @@ Jetson is deliberately excluded — Ubuntu 18.04, raw-only via ANSIBLE-014, not 
 
 - Idempotency: apt module handles "already installed" gracefully. No risk.
 - Side effects: `tmux` is ~1 MB, no service, no port. Zero blast radius.
-- Verification load: re-running `base_system` against 7 hosts via existing `make provision` flow.
+- Verification load: re-running `base_system` against 5 hosts via existing `make provision` flow.
 
 No open questions.
 
@@ -42,11 +44,13 @@ No open questions.
 
 - [ ] `base_system` role defaults list includes `tmux` (single line change).
 - [ ] Provisioning is idempotent (no failures; only "changed" on first run per host).
-- [ ] Smoke succeeds on every covered host: `for h in ace1 ace2 rpi4 rpi3 beelink vps aws1; do ssh "$h" tmux -V; done`.
+- [ ] Smoke succeeds on every covered host: `for h in ace1 ace2 aws1 beelink rpi4; do ssh "$h" tmux -V; done`.
 - [ ] Jetson NOT touched (verify smoke returns "command not found" for jetson or inventory inspection shows exclusion).
 
 ## References
 
-- Issue: [#814](https://github.com/mlorentedev/kubelab/issues/814) (bitácora; tasks live in GitHub per ADR-018)
+- Issue: [#420](https://github.com/mlorentedev/kubelab/issues/420) (canonical; bitácora per ADR-018)
+- Systemic baseline-coverage gap: [#817](https://github.com/mlorentedev/kubelab/issues/817) (ANSIBLE-029) — vps/rpi3 tmux lands there
+- Host context: ADR-058 (ace2 dev-node)
 - Dotfiles: `~/Projects/dotfiles/.zsh/functions.zsh` — `sshmux` function
 - Role: `infra/ansible/roles/base_system/`

--- a/specs/ANSIBLE-021-tmux/tasks.md
+++ b/specs/ANSIBLE-021-tmux/tasks.md
@@ -9,14 +9,14 @@ created: "2026-05-13"
 
 ## Setup
 
-- [ ] Branch created from main: `feat/ANSIBLE-021-tmux`
-- [ ] `proposal.md` reviewed; no open questions
+- [x] Branch created from main: `feat/ANSIBLE-021-tmux` ✓ 2026-06-29
+- [x] `proposal.md` reviewed; no open questions ✓ 2026-06-29
 
 ## Implementation
 
-- [ ] Add `tmux` to `base_system` role packages list (one-line YAML change)
-- [ ] Run `make provision NODE=ace1 ENV=homelab` (or equivalent) — verify idempotent, `tmux` installed
-- [ ] Run on remaining hosts: ace2, rpi4, rpi3, beelink, vps, aws1
+- [x] Add `tmux` to `base_system` role packages list (one-line YAML change) ✓ 2026-06-29
+- [ ] Run `make provision NODE=ace2 ENV=staging` (or equivalent) — verify idempotent, `tmux` installed (homelab-on + ts-bridge)
+- [ ] Run on remaining hosts: ace1, rpi4, rpi3, beelink, vps, aws1
 - [ ] Execute smoke loop: `for h in ace1 ace2 rpi4 rpi3 beelink vps aws1; do ssh "$h" tmux -V; done` — capture output
 
 ## Closing
@@ -25,4 +25,4 @@ created: "2026-05-13"
 - [ ] Jetson explicitly excluded — confirm
 - [ ] Diff is a single-line role change + zero changes elsewhere (no scope creep)
 - [ ] `verification.md` filled in (or marked deferred — low risk)
-- [ ] PR opened, ANSIBLE-021 ticked in `kubelab/11-tasks.md` with PR link
+- [ ] PR opened; close #814 on merge — built-in workflow sets bitácora Done (ADR-018, no more `11-tasks.md`)

--- a/specs/ANSIBLE-021-tmux/tasks.md
+++ b/specs/ANSIBLE-021-tmux/tasks.md
@@ -16,13 +16,13 @@ created: "2026-05-13"
 
 - [x] Add `tmux` to `base_system` role packages list (one-line YAML change) ✓ 2026-06-29
 - [ ] Run `make provision NODE=ace2 ENV=staging` (or equivalent) — verify idempotent, `tmux` installed (homelab-on + ts-bridge)
-- [ ] Run on remaining hosts: ace1, rpi4, rpi3, beelink, vps, aws1
-- [ ] Execute smoke loop: `for h in ace1 ace2 rpi4 rpi3 beelink vps aws1; do ssh "$h" tmux -V; done` — capture output
+- [ ] Run on remaining hosts: ace1, aws1, beelink, rpi4 (vps + rpi3 deferred to ANSIBLE-029 / #817)
+- [ ] Execute smoke loop: `for h in ace1 ace2 aws1 beelink rpi4; do ssh "$h" tmux -V; done` — capture output
 
 ## Closing
 
 - [ ] All hosts return `tmux 3.x` (or similar)
 - [ ] Jetson explicitly excluded — confirm
-- [ ] Diff is a single-line role change + zero changes elsewhere (no scope creep)
+- [ ] Role diff is a single line in `base_packages` (spec doc updates excluded; no role scope creep)
 - [ ] `verification.md` filled in (or marked deferred — low risk)
-- [ ] PR opened; close #814 on merge — built-in workflow sets bitácora Done (ADR-018, no more `11-tasks.md`)
+- [ ] PR opened; close #420 on merge — built-in workflow sets bitácora Done (ADR-018, no more `11-tasks.md`)


### PR DESCRIPTION
## Summary

Adds `tmux` to the `base_system` role `base_packages` list so it is installed on every node that runs `base_system` via the existing `make provision` flow. The dotfiles `sshmux` helper relies on `tmux` for SSH session persistence; without it the helper silently fell back to plain SSH.

This also gives ADR-058's ace2 dev-node its `tmux` foundation (the `dev_node` role will add `tmux-resurrect` on top).

## Coverage (audited — base_system is NOT universal)

Under `make provision NODE=x` (routes to `provision-<node>.yml`), `base_system` runs on **5 nodes**: ace1, ace2, aws1, beelink, rpi4.

- **vps** and **rpi3** use bespoke playbooks that omit `base_system` → not covered here. Their tmux (and the systemic non-uniform-baseline gap) is tracked in **#817 (ANSIBLE-029)** — deliberately not bolted onto the prod K3s playbook.
- **jetson** excluded by construction (`provision-jetson.yml` omits `base_system`).

## Scope

- One-line IaC change to `base_packages`.
- Spec `specs/ANSIBLE-021-tmux/` corrected (real coverage + smoke loop) and repointed at canonical issue #420 (duplicate #814 closed).

## Verification (deploy-gated: homelab powered + ts-bridge)

- [ ] `make provision NODE=<host> ENV=staging` idempotent; `tmux` installed
- [ ] Smoke: `for h in ace1 ace2 aws1 beelink rpi4; do ssh "$h" tmux -V; done`
- [ ] Jetson untouched

This is a desired-state IaC change: merging lands it on master; the actual install happens at the next `make provision`.

Refs #420 — intentionally NOT auto-closed on merge. #420 stays open until the homelab smoke above verifies tmux on the hosts, then it is closed manually (keeps the board honest per Standing Order #8).