### PR TITLE
fix(errors): patch libexpat HIGH CVEs failing the release Trivy gate

### DIFF
--- a/edge/errors/Dockerfile
+++ b/edge/errors/Dockerfile
@@ -10,6 +10,11 @@ LABEL org.opencontainers.image.title="kubelab-errors" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.source="https://github.com/mlorentedev/kubelab"
 
+# SEC: pull patched packages from Alpine's live index at build time rather than
+# waiting for a new nginx:1.31-alpine base image build. Fixes 3 HIGH CVEs
+# (CVE-2026-56131/56407/56408) in libexpat 2.8.1-r0, patched in 2.8.2-r0.
+RUN apk update && apk upgrade --no-cache
+
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup && \
     chown -R appuser:appgroup /var/cache/nginx /var/log/nginx && \


### PR DESCRIPTION
## Summary
- The release-please release PR's CI failed at "Errors / Build and Push Docker Image for errors / Trivy vulnerability scan" (run 28945546946). Root cause: `nginx:1.31-alpine` bundles `libexpat 2.8.1-r0`, which has 3 HIGH CVEs (CVE-2026-56131, CVE-2026-56407, CVE-2026-56408) plus several MEDIUM ones, all fixed in `2.8.2-r0`. `ci-publish.yml`'s Trivy step gates on `severity: CRITICAL,HIGH` + `ignore-unfixed: true`, so the 3 HIGH/fixed CVEs failed the build.
- Fix: `edge/errors/Dockerfile` now runs `apk update && apk upgrade --no-cache` right after `FROM`, pulling the patched package from Alpine's live index at build time instead of waiting for a new `nginx:1.31-alpine` base image build.

## Test plan
- [x] Built the image locally (`docker build`): log confirms `Upgrading libexpat (2.8.1-r0 -> 2.8.2-r0)`
- [x] Ran Trivy locally against the built image with the same filters as CI (`--severity CRITICAL,HIGH --ignore-unfixed`): **0 vulnerabilities**
- [ ] CI: confirm the `errors` image build's Trivy scan step passes on this PR