### PR TITLE
chore(deploy): pin errors to 1.1.5

### DIFF
--- a/infra/config/values/common.yaml
+++ b/infra/config/values/common.yaml
@@ -352,7 +352,7 @@ edge:
   errors:
     name: errors
     image_name: kubelab-errors
-    version: "1.1.4"
+    version: "1.1.5"
     port: 8080
     health_path: /health
     resources:

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -85,7 +85,7 @@ images:
   - name: postgres
     newTag: 16-alpine
   - name: docker.io/mlorentedev/kubelab-errors
-    newTag: 1.1.4
+    newTag: 1.1.5
   # Custom apps web/api: per-env tags via `toolkit deployment promote` (overlays).
   # errors is synced from edge.errors.version above (DELIVERY-003 single SSOT).
   - name: docker.io/mlorentedev/kubelab-web


### PR DESCRIPTION
Automated errors tag promotion to `1.1.5` (DELIVERY-003). Single SSOT `edge.errors.version` + synced kustomization; K3s and VPS follow on merge.