### PR TITLE
fix(toolkit): apply age_key_env() to every sops call + fail-loud deploy-argocd (TOOL-017)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,10 @@ _deploy-argocd-helm:
 	OIDC_SECRET=$$(ENV=dev $(POETRY) run toolkit secrets show apps.services.security.authelia.oidc_client_secret_argocd --env common 2>/dev/null | tail -1) && \
 	SLACK_WEBHOOK=$$(ENV=dev $(POETRY) run toolkit secrets show argocd.slack_webhook_url --env common 2>/dev/null | tail -1) && \
 	GH_WEBHOOK_SECRET=$$(ENV=dev $(POETRY) run toolkit secrets show argocd.github_webhook_secret --env common 2>/dev/null | tail -1) && \
+	test -n "$$ARGOCD_HASH"       || { echo "FATAL: argocd.admin_password_hash decrypted empty — refusing to install Argo CD with a blank admin password (check SOPS age key)" >&2; exit 1; } && \
+	test -n "$$OIDC_SECRET"       || { echo "FATAL: oidc_client_secret_argocd decrypted empty — refusing to install Argo CD with blank OIDC (check SOPS age key)" >&2; exit 1; } && \
+	test -n "$$SLACK_WEBHOOK"     || { echo "FATAL: argocd.slack_webhook_url decrypted empty — refusing to install (check SOPS age key)" >&2; exit 1; } && \
+	test -n "$$GH_WEBHOOK_SECRET" || { echo "FATAL: argocd.github_webhook_secret decrypted empty — refusing to install (check SOPS age key)" >&2; exit 1; } && \
 	helm upgrade --install argocd argo/argo-cd \
 		--namespace argocd --create-namespace \
 		--kubeconfig $(HUB_KUBECONFIG) \

--- a/tests/test_sops_age_key.py
+++ b/tests/test_sops_age_key.py
@@ -6,11 +6,56 @@ decrypt because the key lives at ~/.config/age/key.txt, not the sops default.
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import pytest
 
 from toolkit.core import sops
+
+TOOLKIT_ROOT = Path(__file__).resolve().parents[1] / "toolkit"
+_SUBPROCESS_FUNCS = {"run", "Popen", "call", "check_call", "check_output"}
+
+
+def _is_sops_command(call: ast.Call) -> bool:
+    """True when the first positional arg is a list literal whose head is ``"sops"``."""
+    if not call.args:
+        return False
+    first = call.args[0]
+    if not isinstance(first, ast.List) or not first.elts:
+        return False
+    head = first.elts[0]
+    return isinstance(head, ast.Constant) and head.value == "sops"
+
+
+def _is_subprocess_call(call: ast.Call) -> bool:
+    func = call.func
+    if isinstance(func, ast.Attribute):  # subprocess.run(...)
+        return func.attr in _SUBPROCESS_FUNCS
+    if isinstance(func, ast.Name):  # run(...) after ``from subprocess import run``
+        return func.id in _SUBPROCESS_FUNCS
+    return False
+
+
+def _subtree_has_name(node: ast.AST, name: str) -> bool:
+    return any(isinstance(n, ast.Name) and n.id == name for n in ast.walk(node))
+
+
+def _subtree_has_os_environ(node: ast.AST) -> bool:
+    for n in ast.walk(node):
+        if isinstance(n, ast.Attribute) and n.attr == "environ":
+            if isinstance(n.value, ast.Name) and n.value.id == "os":
+                return True
+    return False
+
+
+def _iter_sops_calls():
+    """Yield (relative_path, ast.Call) for every direct ``sops`` subprocess call under toolkit/."""
+    for py in sorted(TOOLKIT_ROOT.rglob("*.py")):
+        tree = ast.parse(py.read_text(encoding="utf-8"), filename=str(py))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and _is_subprocess_call(node) and _is_sops_command(node):
+                yield py.relative_to(TOOLKIT_ROOT.parent), node
 
 
 class TestResolveAgeKeyFile:
@@ -59,3 +104,31 @@ class TestAgeKeyEnv:
         out = sops.age_key_env({"PATH": "/x"})
         assert "SOPS_AGE_KEY_FILE" not in out
         assert out == {"PATH": "/x"}
+
+
+class TestSopsCallsUseAgeKeyEnv:
+    """Regression guard (TOOL-017/C1/C10): every ``sops`` subprocess must run with an
+    explicit ``env=`` derived from ``age_key_env()`` — never a bare/implicit ``os.environ``.
+
+    Otherwise decryption silently fails on a fresh shell where the age key sits only at
+    the repo-convention path, and callers (e.g. ``make deploy-argocd``) feed blank
+    secrets downstream.
+    """
+
+    def test_at_least_one_sops_call_is_scanned(self) -> None:
+        # Guards the guard: if the AST matcher stops finding sops calls, the test is
+        # silently vacuous. There are several real sops subprocess sites under toolkit/.
+        assert sum(1 for _ in _iter_sops_calls()) >= 5
+
+    def test_every_sops_subprocess_uses_age_key_env(self) -> None:
+        offenders: list[str] = []
+        for rel, call in _iter_sops_calls():
+            env_kw = next((kw for kw in call.keywords if kw.arg == "env"), None)
+            if env_kw is None:
+                offenders.append(f"{rel}:{call.lineno} — no env= (subprocess inherits os.environ)")
+                continue
+            if _subtree_has_name(env_kw.value, "age_key_env"):
+                continue
+            if _subtree_has_os_environ(env_kw.value):
+                offenders.append(f"{rel}:{call.lineno} — env=os.environ bypasses age_key_env()")
+        assert not offenders, "sops subprocess calls must use age_key_env():\n  " + "\n  ".join(offenders)

--- a/toolkit/features/configuration.py
+++ b/toolkit/features/configuration.py
@@ -1,4 +1,3 @@
-import os
 import subprocess
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -338,7 +337,7 @@ class ConfigurationManager:
                 capture_output=True,
                 text=True,
                 check=True,
-                env=os.environ,
+                env=age_key_env(),  # auto-discover SOPS_AGE_KEY_FILE (toolkit/core/sops.py)
             )
             decrypted_data = yaml.safe_load(result.stdout) or {}
 

--- a/toolkit/features/credentials.py
+++ b/toolkit/features/credentials.py
@@ -16,6 +16,7 @@ from argon2 import PasswordHasher
 from toolkit.config.constants import AUTHELIA_CONFIG, PATH_STRUCTURES
 from toolkit.config.settings import settings
 from toolkit.core.logging import logger
+from toolkit.core.sops import age_key_env
 from toolkit.features.configuration import ConfigurationManager
 from toolkit.features.docker_service import DockerService
 
@@ -236,6 +237,7 @@ class CredentialsManager:
                 capture_output=True,
                 text=True,
                 check=True,
+                env=age_key_env(),  # auto-discover SOPS_AGE_KEY_FILE (toolkit/core/sops.py)
             )
             data = yaml.safe_load(result.stdout) or {}
             return self._flatten_dict(data)

--- a/toolkit/features/secrets_manager.py
+++ b/toolkit/features/secrets_manager.py
@@ -22,6 +22,7 @@ from typing import Any
 from toolkit.config.constants import AUTHELIA_CONFIG, PATH_STRUCTURES
 from toolkit.config.settings import PROJECT_ROOT
 from toolkit.core.logging import logger
+from toolkit.core.sops import age_key_env
 from toolkit.features.configuration import ConfigurationManager
 
 # =============================================================================
@@ -733,6 +734,7 @@ class SecretsManager:
             ["sops", "-d", str(sops_file)],
             capture_output=True,
             text=True,
+            env=age_key_env(),  # auto-discover SOPS_AGE_KEY_FILE (toolkit/core/sops.py)
         )
         if result.returncode != 0:
             return None
@@ -765,6 +767,7 @@ class SecretsManager:
             ["sops", "set", str(sops_file), sops_path, f'"{value}"'],
             capture_output=True,
             text=True,
+            env=age_key_env(),  # auto-discover SOPS_AGE_KEY_FILE (toolkit/core/sops.py)
         )
 
         if result.returncode != 0:
@@ -794,6 +797,7 @@ class SecretsManager:
             ["sops", "unset", str(sops_file), sops_path],
             capture_output=True,
             text=True,
+            env=age_key_env(),  # auto-discover SOPS_AGE_KEY_FILE (toolkit/core/sops.py)
         )
 
         if result.returncode != 0:


### PR DESCRIPTION
## Problem

`core/sops.py` exists so every `sops` subprocess is self-sufficient about the age
key regardless of shell setup — but `age_key_env()` was applied inconsistently.
Five `sops` call-sites ran with a bare/implicit `os.environ`:

- `secrets_manager.show_secret` / `set_secret` / `unset_secret` (no `env=`)
- `configuration.batch_update_secrets` decrypt step (`env=os.environ`) — its
  encrypt siblings already used `age_key_env()`
- `credentials._read_existing_secrets` (no `env=`)

On a fresh shell where the age key sits only at the repo-convention path
(`~/.config/age/key.txt`) and `SOPS_AGE_KEY_FILE` is not exported, decryption
silently returns empty. `make deploy-argocd` extracts four hub secrets via
`toolkit secrets show … | tail -1` and feeds them into `helm --set`; the pipe
swallowed the failure, so **Argo CD could be installed with a blank admin
password hash and blank OIDC client secret** — no error surfaced.

## Changes

- Pass `env=age_key_env()` to all five `sops` subprocess call-sites (dropped the
  now-unused `import os` in `configuration.py`).
- `deploy-argocd` now `test -n` guards each extracted secret and aborts loudly
  instead of `--set`-ing a blank. All four keys are populated in the vault, so
  this fails only on a genuine decrypt failure / misconfiguration.
- Regression guard in `tests/test_sops_age_key.py`: an AST scan asserting every
  `sops` subprocess under `toolkit/` runs with an explicit `age_key_env()`-derived
  `env=`, never a bare/implicit `os.environ`. Also asserts ≥5 sites are scanned so
  the guard can't go silently vacuous.

## Notes

- `credentials._read_existing_secrets` was not named in the audit's C1/C10 but is
  pulled in by the DoD's *"and any other caller"* clause and is required for the
  AST guard to pass — included deliberately, not scope creep.
- `deploy-argocd` guards all four secrets (not just the two auth-critical ones):
  verified empirically that admin-hash, OIDC, slack-webhook and gh-webhook are all
  present in the vault, so guarding all four matches the DoD literally without
  risking a working deploy.

## Verification

- New guard proven red (5 offenders listed) → green.
- `ruff` clean; full toolkit unit suite `347 passed` (e2e/infra excluded — need a
  live cluster). `deploy-argocd` not run (touches real infra).

Covers audit findings C1, C10 (`docs/audits/codebase-audit-2026-07-06.md`).

Closes #828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret-handling commands to use the correct encryption key environment automatically, making decrypt/edit operations more reliable.
  * Added a safety check during deployment so the process stops immediately if any required secret is empty, preventing incomplete releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->