### PR TITLE
fix(toolkit): fail closed when a K8s secret mapping only partially resolves (TOOL-018)

### DIFF
--- a/tests/test_k8s_secrets_apply.py
+++ b/tests/test_k8s_secrets_apply.py
@@ -1,0 +1,61 @@
+"""Tests for k8s_secrets._apply_single_secret — fail-closed on partial mappings (TOOL-018).
+
+A K8s Secret is applied via `kubectl create secret … --dry-run=client -o yaml | kubectl
+apply -f -`, which REPLACES the entire Secret. If only a subset of a mapping's source
+values resolve (e.g. an env-specific SOPS key not yet synced), applying that subset would
+shrink the live Secret and silently drop the missing keys on the next pod restart.
+
+The contract these tests pin (audit finding C2): a partial mapping must fail closed —
+return False WITHOUT ever calling kubectl — so the live Secret is never shrunk and
+`apply_secrets` reports the failure.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from toolkit.features.k8s_secrets import SecretMapping, _apply_single_secret
+
+
+class TestApplySingleSecretFailsClosed:
+    def test_partial_mapping_fails_closed_without_calling_kubectl(self, mocker: "pytest.MonkeyPatch") -> None:
+        run = mocker.patch("toolkit.features.k8s_secrets.subprocess.run")
+        mapping = SecretMapping(name="api-secrets", keys={"A": "ENV_A", "B": "ENV_B"})
+        # ENV_B is missing → only 1 of 2 keys resolves.
+        env_vars = {"ENV_A": "value-a"}
+
+        ok = _apply_single_secret(mapping, env_vars, {}, dry_run=False, env="staging")
+
+        assert ok is False, "a partial mapping must fail, not apply a shrunken Secret"
+        run.assert_not_called()  # must never reach kubectl create/apply
+
+    def test_all_missing_fails_closed_without_calling_kubectl(self, mocker: "pytest.MonkeyPatch") -> None:
+        run = mocker.patch("toolkit.features.k8s_secrets.subprocess.run")
+        mapping = SecretMapping(name="api-secrets", keys={"A": "ENV_A", "B": "ENV_B"})
+
+        ok = _apply_single_secret(mapping, {}, {}, dry_run=False, env="staging")
+
+        assert ok is False
+        run.assert_not_called()
+
+    def test_fully_resolved_mapping_applies(self, mocker: "pytest.MonkeyPatch") -> None:
+        run = mocker.patch("toolkit.features.k8s_secrets.subprocess.run")
+        run.return_value = mocker.Mock(stdout="secret/api-secrets configured", returncode=0)
+        mapping = SecretMapping(name="api-secrets", keys={"A": "ENV_A", "B": "ENV_B"})
+        env_vars = {"ENV_A": "value-a", "ENV_B": "value-b"}
+
+        ok = _apply_single_secret(mapping, env_vars, {}, dry_run=False, env="staging")
+
+        assert ok is True
+        assert run.call_count == 2  # create (render) + apply
+
+    def test_dynamic_only_secret_with_extra_literals_applies(self, mocker: "pytest.MonkeyPatch") -> None:
+        # authelia-users / apprise-secrets style: keys={} and the value comes from a builder.
+        run = mocker.patch("toolkit.features.k8s_secrets.subprocess.run")
+        run.return_value = mocker.Mock(stdout="secret/authelia-users configured", returncode=0)
+        mapping = SecretMapping(name="authelia-users", keys={})
+
+        ok = _apply_single_secret(mapping, {}, {"users_database.yml": "users: {}"}, dry_run=False, env="staging")
+
+        assert ok is True
+        assert run.call_count == 2

--- a/toolkit/features/k8s_secrets.py
+++ b/toolkit/features/k8s_secrets.py
@@ -291,11 +291,17 @@ def _apply_single_secret(
     for k8s_key, value in extra_literals.items():
         from_literals.append(f"--from-literal={k8s_key}={value}")
 
+    # Fail closed (TOOL-018 / audit C2): a Secret is applied via `kubectl create …
+    # | kubectl apply -f -`, which REPLACES the whole Secret. Applying a subset would
+    # shrink the live Secret and silently drop the missing keys on the next pod
+    # restart. Never apply a partial render — refuse and let apply_secrets report it.
     if missing:
-        logger.warning(f"  Missing values: {', '.join(missing)}")
-        if not from_literals:
-            logger.error(f"  No values resolved for {mapping.name} — skipping")
-            return False
+        logger.error(
+            f"  Refusing to apply {mapping.name}: {len(missing)} of {len(mapping.keys)} "
+            f"source value(s) missing — {', '.join(missing)}. Applying a partial Secret "
+            f"would drop those keys from the live Secret."
+        )
+        return False
 
     # kubectl create secret ... --dry-run=client -o yaml | kubectl apply -f -
     create_cmd = [


### PR DESCRIPTION
## Problem

`_apply_single_secret` (`k8s_secrets.py`) built `--from-literal` args only for the
source values it could resolve. If *some* were missing but at least one resolved, it
logged a warning and applied anyway. A Secret is applied via:

```
kubectl create secret … --dry-run=client -o yaml | kubectl apply -f -
```

which **replaces the entire Secret**. So a transient missing source value (e.g. an
env-specific SOPS key not yet synced across staging/prod — which CLAUDE.md admits is
manual) shrank the live Secret and silently dropped the previously-present keys on
the next pod restart. `all_ok` stayed `True` because the `apply` itself succeeded, so
the run reported success. (audit finding **C2**)

**Failure scenario:** `INFRA_SMTP_PASS` present but `ZOHO_CLIENT_SECRET` missing in
prod → `apply-secrets ENV=prod` overwrites `api-secrets` down to 3 keys; the API pod
loses `ZOHO_CLIENT_SECRET` on its next restart, run reports success.

## Change

- Fail closed: any unresolved source key in a mapping is now an error — refuse to
  apply and return `False`, so `apply_secrets` reports the failure instead of
  applying a shrunken Secret. The live Secret is never partially replaced.
- Tests (`tests/test_k8s_secrets_apply.py`): partial mapping fails **without calling
  kubectl**, all-missing fails closed, fully-resolved applies, dynamic-only
  (`keys={}` + builder literal) applies.

## Scope / follow-ups

- **Merge semantics** (audit DoD item 2 — patch/server-side apply so a partial
  render can never drop keys) is deliberately deferred to the unified Secret
  primitive in **SEC-SECRETS-001 (#831)**; the audit's Design Tension #2 ties C2, C5
  and C13 into one primitive, so implementing merge here would be redone there.
- **Dynamic-only empty render** (out of scope, noted not fixed): `apprise-secrets` /
  `authelia-users` have `keys={}` and rely entirely on a builder; if the builder
  returns `""`, `from_literals` is empty and an *empty* Secret would be applied. A
  dry-run in this session showed both resolving empty in staging and prod, so the
  root cause (why the builders render empty) needs investigation before adding an
  empty-render guard — left as a follow-up rather than fixed blind.

## Verification

- New partial-mapping test proven red → green.
- `ruff` clean; `apply-secrets --env staging --dry-run` still exits 0 (staging/prod
  resolve every key — no regression); full toolkit unit suite `349 passed`
  (e2e/infra excluded — need a live cluster). Real `apply-secrets` not run (touches a
  live cluster).

Covers audit finding C2 (`docs/audits/codebase-audit-2026-07-06.md`).

Closes #829