### PR TITLE
feat(toolkit): reject placeholder secret values in audit and K8s apply (TOOL-019)

### DIFF
--- a/tests/test_secrets_placeholder_reject.py
+++ b/tests/test_secrets_placeholder_reject.py
@@ -1,0 +1,67 @@
+"""Tests for TOOL-019: secrets audit + K8s apply must reject placeholder values.
+
+The K8s overlay `secrets.yaml` manifests ship `REPLACE_WITH_SOPS_VALUE` by design,
+and `audit()` previously marked any non-empty value `present`. So a half-configured
+vault (a SOPS key still holding a placeholder) reported clean, and a placeholder
+could reach a cluster. These tests pin (audit finding C6):
+
+1. `is_placeholder()` recognises the known sentinels.
+2. `audit()` classifies a placeholder-valued key as MISSING, not present.
+3. `apply_secrets()` refuses (fails, no kubectl) when a mapped source is a placeholder.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from toolkit.config.constants import VAULT_PLACEHOLDERS, is_placeholder
+from toolkit.config.settings import PROJECT_ROOT
+from toolkit.features.configuration import ConfigurationManager
+from toolkit.features.k8s_secrets import apply_secrets
+from toolkit.features.secrets_manager import SecretsManager
+
+
+class TestIsPlaceholder:
+    @pytest.mark.parametrize("value", sorted(VAULT_PLACEHOLDERS))
+    def test_known_sentinels_are_placeholders(self, value: str) -> None:
+        assert is_placeholder(value) is True
+
+    def test_surrounding_whitespace_is_stripped(self) -> None:
+        assert is_placeholder("  REPLACE_WITH_SOPS_VALUE  ") is True
+
+    def test_real_value_is_not_a_placeholder(self) -> None:
+        assert is_placeholder("$argon2id$v=19$m=65536,t=3,p=4$realhash") is False
+
+    def test_empty_and_none_are_not_placeholders(self) -> None:
+        assert is_placeholder("") is False
+        assert is_placeholder(None) is False
+
+
+class TestAuditRejectsPlaceholders:
+    def test_placeholder_value_is_missing_not_present(self) -> None:
+        # basic_auth.user is a catalog secret in every env; feed it a placeholder and
+        # basic_auth.password a real value via a mocked decrypt.
+        fake = {"basic_auth": {"user": "REPLACE_WITH_SOPS_VALUE", "password": "a-real-password"}}
+        with patch.object(ConfigurationManager, "_decrypt_sops", return_value=fake):
+            result = SecretsManager(PROJECT_ROOT).audit("staging")
+
+        assert "basic_auth.user" in result.missing, "a placeholder must be reported missing"
+        assert "basic_auth.user" not in result.present
+        assert "basic_auth.password" in result.present, "a real value must stay present"
+
+
+class TestApplySecretsRefusesPlaceholders:
+    def test_refuses_and_does_not_call_kubectl(self, mocker: "pytest.MonkeyPatch") -> None:
+        run = mocker.patch("toolkit.features.k8s_secrets.subprocess.run")
+        fake_cm = mocker.Mock()
+        # One mapped source (api-secrets BEEHIIV_API_KEY) still holds a placeholder.
+        fake_cm.get_env_vars.return_value = {"APPS_PLATFORM_API_BEEHIIV_API_KEY": "REPLACE_WITH_SOPS_VALUE"}
+        mocker.patch("toolkit.features.k8s_secrets.ConfigurationManager", return_value=fake_cm)
+
+        ok = apply_secrets("staging", Path("."), dry_run=False)
+
+        assert ok is False, "apply must refuse a vault holding a placeholder"
+        run.assert_not_called()

--- a/toolkit/config/constants.py
+++ b/toolkit/config/constants.py
@@ -214,6 +214,23 @@ class ValidationRules:
 
 
 # =============================================================================
+# VAULT PLACEHOLDERS
+# =============================================================================
+
+# A decrypted secret equal to one of these sentinels is NOT actually configured,
+# even though it is syntactically present. audit() and the K8s apply guard treat
+# these as "missing" so a half-configured vault can neither report clean nor reach
+# a cluster (TOOL-019 / audit C6). REPLACE_WITH_SOPS_VALUE is the literal the K8s
+# overlay secrets.yaml manifests ship by design.
+VAULT_PLACEHOLDERS: frozenset[str] = frozenset({"REPLACE_WITH_SOPS_VALUE", "CHANGE_ME"})
+
+
+def is_placeholder(value: object) -> bool:
+    """True if ``value`` is a known 'not configured yet' placeholder sentinel."""
+    return isinstance(value, str) and value.strip() in VAULT_PLACEHOLDERS
+
+
+# =============================================================================
 # MESSAGES - SIMPLIFIED
 # =============================================================================
 

--- a/toolkit/features/k8s_secrets.py
+++ b/toolkit/features/k8s_secrets.py
@@ -6,6 +6,7 @@ import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from toolkit.config.constants import is_placeholder
 from toolkit.core.logging import logger
 from toolkit.features.configuration import ConfigurationManager
 
@@ -155,10 +156,25 @@ def apply_secrets(env: str, project_root: Path, dry_run: bool = False) -> bool:
 
     logger.success(f"Loaded {len(env_vars)} env vars from config + SOPS")
 
-    # 2. Build dynamic secrets that need config + SOPS merging
+    # 2. Pre-deploy guard (TOOL-019 / C6): never push a placeholder value to a cluster.
+    placeholder_hits = sorted(
+        f"{mapping.name}.{k8s_key}"
+        for mapping in SECRET_DEFINITIONS
+        for k8s_key, env_var in mapping.keys.items()
+        if is_placeholder(env_vars.get(env_var))
+    )
+    if placeholder_hits:
+        logger.error(
+            "Refusing to apply — placeholder value(s) still in the vault: "
+            + ", ".join(placeholder_hits)
+            + ". Configure them (toolkit secrets set …) before deploying."
+        )
+        return False
+
+    # 3. Build dynamic secrets that need config + SOPS merging
     dynamic_literals = _build_dynamic_literals(cm)
 
-    # 3. Apply each secret
+    # 4. Apply each secret
     all_ok = True
     for mapping in SECRET_DEFINITIONS:
         extra = dynamic_literals.get(mapping.name, {})

--- a/toolkit/features/secrets_manager.py
+++ b/toolkit/features/secrets_manager.py
@@ -19,7 +19,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
-from toolkit.config.constants import AUTHELIA_CONFIG, PATH_STRUCTURES
+from toolkit.config.constants import AUTHELIA_CONFIG, PATH_STRUCTURES, is_placeholder
 from toolkit.config.settings import PROJECT_ROOT
 from toolkit.core.logging import logger
 from toolkit.features.configuration import ConfigurationManager
@@ -507,7 +507,9 @@ class SecretsManager:
             if env not in spec.envs:
                 continue
             value = self._resolve_key(decrypted, spec.key_path)
-            if value is not None and str(value).strip():
+            # A placeholder sentinel (REPLACE_WITH_SOPS_VALUE/CHANGE_ME) is syntactically
+            # present but not configured — treat as missing (TOOL-019 / C6).
+            if value is not None and str(value).strip() and not is_placeholder(value):
                 result.present.append(spec.key_path)
             else:
                 result.missing.append(spec.key_path)


### PR DESCRIPTION
## Problem

`SecretsManager.audit()` marked a key `present` iff its decrypted value was
non-empty (`str(value).strip()`). The K8s overlay `secrets.yaml` manifests ship
`REPLACE_WITH_SOPS_VALUE` placeholders by design, and nothing in audit/apply
rejected that literal — so a half-configured vault (a SOPS key still holding a
placeholder) reported clean via `make secrets-audit`, and a placeholder could reach
a cluster through `apply-secrets`. (audit finding **C6**)

## Change

- `VAULT_PLACEHOLDERS` + `is_placeholder()` in `constants.py` — the sentinel set
  (`REPLACE_WITH_SOPS_VALUE`, `CHANGE_ME`), in a neutral module both consumers import
  without an import cycle.
- `audit()`: a placeholder-valued key is now classified **missing**, not present.
- `apply_secrets()`: a pre-deploy guard scans the mapped source values and **refuses
  to apply** (returns False, before any `kubectl`) if any is a placeholder.
- Tests (`tests/test_secrets_placeholder_reject.py`): `is_placeholder` sentinels /
  whitespace / real-value / empty-None; audit classifies placeholder as missing;
  apply refuses without calling kubectl.

## Scope notes

- The apply guard lives in `apply_secrets` (orchestrator level), **not** in
  `_apply_single_secret` — deliberately, so it touches a disjoint block from
  TOOL-018 (#848) and the two merge cleanly in any order.
- The DoD's *optional* "suspiciously-short values" heuristic is **not** implemented:
  a min-length rule would false-positive on legitimately short secrets. Placeholder
  detection is deterministic literal matching only.
- Placeholders are folded into `missing` (DoD-literal) rather than a new
  `AuditResult.placeholders` field, to avoid touching the dataclass + CLI rendering.

## Verification

- New audit/apply tests proven red → green.
- `ruff` clean; full toolkit unit suite `352 passed` (e2e/infra excluded — need a
  live cluster). Real `secrets audit` unchanged: STAGING 37/37, PROD 38/38 (100%) —
  no real value misclassified as a placeholder.

Covers audit finding C6 (`docs/audits/codebase-audit-2026-07-06.md`).

Closes #832