### PR TITLE
chore(staging): deploy web sha-78a6044

### DIFF
--- a/infra/config/values/staging.yaml
+++ b/infra/config/values/staging.yaml
@@ -52,7 +52,7 @@ apps:
       enable_homelabs: false
       enable_contact: false
   # Third-party services
-      version: sha-0d97016
+      version: sha-78a6044
   services:
     core:
       gitea:

--- a/infra/k8s/overlays/staging/generated/deployments.yaml
+++ b/infra/k8s/overlays/staging/generated/deployments.yaml
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: docker.io/mlorentedev/kubelab-web:sha-0d97016
+          image: docker.io/mlorentedev/kubelab-web:sha-78a6044
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Staging promotion of `web` to `sha-78a6044` (ADR-046, cross-repo dispatch from mlorentedev/web).