### PR TITLE
fix(toolkit): harden K8s secret delivery — no secrets in argv, safe_dump YAML (SEC-SECRETS-001)

### DIFF
--- a/tests/test_k8s_secrets_apply.py
+++ b/tests/test_k8s_secrets_apply.py
@@ -1,9 +1,10 @@
 """Tests for k8s_secrets._apply_single_secret — fail-closed on partial mappings (TOOL-018).
 
-A K8s Secret is applied via `kubectl create secret … --dry-run=client -o yaml | kubectl
-apply -f -`, which REPLACES the entire Secret. If only a subset of a mapping's source
-values resolve (e.g. an env-specific SOPS key not yet synced), applying that subset would
-shrink the live Secret and silently drop the missing keys on the next pod restart.
+A K8s Secret manifest is rendered in-process and applied via `kubectl apply -f -`
+(stdin) — one subprocess call, no secret in argv (SEC-SECRETS-001). `apply` REPLACES
+the entire Secret. If only a subset of a mapping's source values resolve (e.g. an
+env-specific SOPS key not yet synced), applying that subset would shrink the live
+Secret and silently drop the missing keys on the next pod restart.
 
 The contract these tests pin (audit finding C2): a partial mapping must fail closed —
 return False WITHOUT ever calling kubectl — so the live Secret is never shrunk and
@@ -47,7 +48,7 @@ class TestApplySingleSecretFailsClosed:
         ok = _apply_single_secret(mapping, env_vars, {}, dry_run=False, env="staging")
 
         assert ok is True
-        assert run.call_count == 2  # create (render) + apply
+        assert run.call_count == 1  # single `apply -f -` via stdin (no `create` subprocess)
 
     def test_dynamic_only_secret_with_extra_literals_applies(self, mocker: "pytest.MonkeyPatch") -> None:
         # authelia-users / apprise-secrets style: keys={} and the value comes from a builder.
@@ -58,4 +59,4 @@ class TestApplySingleSecretFailsClosed:
         ok = _apply_single_secret(mapping, {}, {"users_database.yml": "users: {}"}, dry_run=False, env="staging")
 
         assert ok is True
-        assert run.call_count == 2
+        assert run.call_count == 1

--- a/tests/test_k8s_secrets_delivery.py
+++ b/tests/test_k8s_secrets_delivery.py
@@ -1,0 +1,123 @@
+"""Tests for SEC-SECRETS-001 (#831): harden K8s secret delivery.
+
+Two structural weaknesses from the 2026-07-06 audit:
+
+- **C5** — every secret value (incl. the RSA-4096 JWKS key) was passed as
+  `kubectl create secret … --from-literal=KEY=VALUE` **argv**, readable via
+  `/proc/<pid>/cmdline` for the duration of the call. The manifest is now
+  rendered in-process and applied via `kubectl apply -f -` (stdin) — no value
+  ever reaches argv.
+- **C13** — `users_database.yml` / apprise `kubelab.yml` were hand-rendered with
+  f-strings, so a value containing `"`, `:` or a newline produced invalid YAML
+  (and Authelia then failed to parse its user DB, locking everyone out). Both are
+  now built as dicts and `yaml.safe_dump`-ed.
+"""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import yaml
+
+from toolkit.features import k8s_secrets as ks
+from toolkit.features.k8s_secrets import (
+    SecretMapping,
+    _apply_single_secret,
+    _build_apprise_config,
+    _build_users_database,
+    _render_secret_manifest,
+)
+
+
+def _cm(merged: dict) -> MagicMock:
+    cm = MagicMock()
+    cm.get_merged_config.return_value = merged
+    return cm
+
+
+class TestNoSecretsInArgv:
+    def test_secret_value_never_reaches_subprocess_argv(self, mocker) -> None:
+        run = mocker.patch.object(
+            ks.subprocess,
+            "run",
+            return_value=SimpleNamespace(returncode=0, stdout="secret/x configured", stderr=""),
+        )
+        secret = "s3cr3t-RSA-VALUE-do-not-leak"
+        mapping = SecretMapping(name="x", keys={"token": "TOKEN_ENV"})
+
+        ok = _apply_single_secret(mapping, {"TOKEN_ENV": secret}, {}, dry_run=False)
+
+        assert ok is True
+        assert run.call_count == 1, "only `kubectl apply -f -` should run (no `create` subprocess)"
+        cmd = run.call_args.args[0]
+        assert cmd[-3:] == ["apply", "-f", "-"]
+        assert not any(secret in str(part) for part in cmd), "secret must not appear in argv"
+        # It rides in stdin, base64-encoded inside the Secret manifest.
+        stdin = run.call_args.kwargs["input"]
+        assert secret not in stdin, "raw secret must not appear even in stdin (base64-encoded)"
+        assert base64.b64encode(secret.encode()).decode() in stdin
+
+    def test_partial_render_still_fails_closed_without_subprocess(self, mocker) -> None:
+        run = mocker.patch.object(ks.subprocess, "run")
+        mapping = SecretMapping(name="x", keys={"a": "A_ENV", "b": "B_ENV"})
+
+        ok = _apply_single_secret(mapping, {"A_ENV": "present"}, {}, dry_run=False)  # B missing
+
+        assert ok is False, "TOOL-018 fail-closed must survive the refactor"
+        run.assert_not_called()
+
+
+class TestRenderSecretManifest:
+    def test_base64_roundtrip_and_shape(self) -> None:
+        out = _render_secret_manifest("x", "kube-system", {"a": "hello", "b": 'mul\nti:line"'})
+        doc = yaml.safe_load(out)  # must be valid YAML
+
+        assert doc["kind"] == "Secret"
+        assert doc["type"] == "Opaque"
+        assert doc["metadata"] == {"name": "x", "namespace": "kube-system"}
+        assert base64.b64decode(doc["data"]["a"]).decode() == "hello"
+        assert base64.b64decode(doc["data"]["b"]).decode() == 'mul\nti:line"'
+
+
+class TestYamlBuildersEscape:
+    def test_users_db_survives_hostile_displayname(self) -> None:
+        merged = {
+            "apps": {
+                "services": {
+                    "security": {
+                        "authelia": {
+                            "users": [
+                                {"username": "bob", "displayname": 'B"ob: the\nbuilder', "groups": ["admins"]}
+                            ],
+                            "users_bob_password_hash": "$argon2id$v=19$m=65536,t=3,p=4$abc:def",
+                        }
+                    }
+                },
+                "auth": {"admin_username": ""},
+            }
+        }
+        out = _build_users_database(_cm(merged))
+        parsed = yaml.safe_load(out)  # f-string version would raise here
+
+        assert parsed["users"]["bob"]["displayname"] == 'B"ob: the\nbuilder'
+        assert parsed["users"]["bob"]["password"] == "$argon2id$v=19$m=65536,t=3,p=4$abc:def"
+        assert parsed["users"]["bob"]["groups"] == ["admins"]
+
+    def test_apprise_config_is_valid_yaml_with_tags(self) -> None:
+        merged = {
+            "apps": {
+                "services": {
+                    "automation": {
+                        "apprise": {"telegram": {"bot_token": "123:ABC-def", "chat_page": "-1001", "chat_log": "-1002"}}
+                    }
+                }
+            }
+        }
+        out = _build_apprise_config(_cm(merged))
+        parsed = yaml.safe_load(out)
+
+        assert parsed["version"] == 1
+        tags = [next(iter(u.values()))["tag"] for u in parsed["urls"]]
+        assert tags == ["page", "log"]

--- a/toolkit/features/k8s_secrets.py
+++ b/toolkit/features/k8s_secrets.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import base64
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+
+import yaml
 
 from toolkit.config.constants import is_placeholder
 from toolkit.core.logging import logger
@@ -229,16 +232,16 @@ def _build_apprise_config(cm: ConfigurationManager) -> str:
         logger.warning("Apprise telegram bot_token/chat_page missing — skipping routing config")
         return ""
 
-    lines = ["version: 1", "urls:"]
-    lines.append(f'  - "tgram://{bot_token}/{chat_page}":')
-    lines.append("      tag: page")
+    # Build as a dict and yaml.safe_dump it (audit C13): a bot-token/chat id with a
+    # YAML-special char must not break the routing table. Each url is a single-key
+    # map {url: {tag: ...}} — the shape Apprise's `simple` mode expects.
+    urls: list[dict[str, dict[str, str]]] = [{f"tgram://{bot_token}/{chat_page}": {"tag": "page"}}]
     if chat_log:
-        lines.append(f'  - "tgram://{bot_token}/{chat_log}":')
-        lines.append("      tag: log")
+        urls.append({f"tgram://{bot_token}/{chat_log}": {"tag": "log"}})
     else:
         logger.warning("apprise chat_log not set — the 'log' tier will not deliver until it is")
 
-    return "\n".join(lines) + "\n"
+    return yaml.safe_dump({"version": 1, "urls": urls}, sort_keys=False, default_flow_style=False)
 
 
 def _build_users_database(cm: ConfigurationManager) -> str:
@@ -253,7 +256,10 @@ def _build_users_database(cm: ConfigurationManager) -> str:
         logger.warning("No Authelia users found in config")
         return ""
 
-    lines = ["users:"]
+    # Build as a dict and yaml.safe_dump it (audit C13): a displayname/email/hash
+    # containing a quote, colon or newline must NOT be able to break the user DB —
+    # an invalid users_database.yml locks everyone out of Authelia.
+    db: dict[str, dict[str, object]] = {}
     for user in users:
         username = admin_username if user.get("is_admin") else user.get("username", "")
         hash_key = f"users_{username}_password_hash"
@@ -263,21 +269,37 @@ def _build_users_database(cm: ConfigurationManager) -> str:
             logger.warning(f"  No password hash for user '{username}' (key: {hash_key})")
             continue
 
-        disabled = str(user.get("disabled", False)).lower()
-        displayname = user.get("displayname", username)
-        email = user.get("email", "")
-        groups = user.get("groups", [])
+        db[username] = {
+            "disabled": bool(user.get("disabled", False)),
+            "displayname": user.get("displayname", username),
+            "password": password_hash,
+            "email": user.get("email", ""),
+            "groups": list(user.get("groups", []) or []),
+        }
 
-        lines.append(f"  {username}:")
-        lines.append(f"    disabled: {disabled}")
-        lines.append(f'    displayname: "{displayname}"')
-        lines.append(f"    email: {email}")
-        lines.append(f'    password: "{password_hash}"')
-        lines.append("    groups:")
-        for group in groups:
-            lines.append(f"      - {group}")
+    if not db:
+        return ""
 
-    return "\n".join(lines)
+    return yaml.safe_dump({"users": db}, sort_keys=False, default_flow_style=False, allow_unicode=True)
+
+
+def _render_secret_manifest(name: str, namespace: str, data: dict[str, str]) -> str:
+    """Render an Opaque Secret as YAML with base64-encoded `data` — in-process.
+
+    The single delivery primitive (audit C5 / Design Tension #2): building the
+    manifest here and applying it via `kubectl apply -f -` (stdin) means no secret
+    value is ever passed as a subprocess argument (readable in /proc/<pid>/cmdline).
+    `data` + base64 is byte-equivalent to what `kubectl create secret -o yaml`
+    emitted, so the applied object is unchanged. `yaml.safe_dump` owns escaping.
+    """
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": name, "namespace": namespace},
+        "type": "Opaque",
+        "data": {k: base64.b64encode(v.encode("utf-8")).decode("ascii") for k, v in data.items()},
+    }
+    return yaml.safe_dump(manifest, sort_keys=False, default_flow_style=False)
 
 
 def _apply_single_secret(
@@ -292,8 +314,8 @@ def _apply_single_secret(
     ns_label = f" ({namespace})" if namespace != "kubelab" else ""
     logger.info(f"Processing secret: {mapping.name}{ns_label}")
 
-    # Build --from-literal args from env var keys
-    from_literals: list[str] = []
+    # Collect the desired key set from env vars + pre-rendered literals.
+    data: dict[str, str] = {}
     missing: list[str] = []
 
     for k8s_key, env_var in mapping.keys.items():
@@ -301,16 +323,15 @@ def _apply_single_secret(
         if not value:
             missing.append(f"{k8s_key} (from {env_var})")
             continue
-        from_literals.append(f"--from-literal={k8s_key}={value}")
+        data[k8s_key] = value
 
-    # Add pre-rendered literals (from dynamic builders)
     for k8s_key, value in extra_literals.items():
-        from_literals.append(f"--from-literal={k8s_key}={value}")
+        data[k8s_key] = value
 
-    # Fail closed (TOOL-018 / audit C2): a Secret is applied via `kubectl create …
-    # | kubectl apply -f -`, which REPLACES the whole Secret. Applying a subset would
-    # shrink the live Secret and silently drop the missing keys on the next pod
-    # restart. Never apply a partial render — refuse and let apply_secrets report it.
+    # Fail closed (TOOL-018 / audit C2): a Secret is applied via `kubectl apply -f -`,
+    # which REPLACES the whole Secret. Applying a subset would shrink the live Secret
+    # and silently drop the missing keys on the next pod restart. Never apply a
+    # partial render — refuse and let apply_secrets report it.
     if missing:
         logger.error(
             f"  Refusing to apply {mapping.name}: {len(missing)} of {len(mapping.keys)} "
@@ -319,37 +340,16 @@ def _apply_single_secret(
         )
         return False
 
-    # kubectl create secret ... --dry-run=client -o yaml | kubectl apply -f -
-    create_cmd = [
-        *_kubectl_base(env, namespace),
-        "create",
-        "secret",
-        "generic",
-        mapping.name,
-        *from_literals,
-        "--dry-run=client",
-        "-o",
-        "yaml",
-    ]
-
     if dry_run:
-        all_keys = list(mapping.keys.keys()) + list(extra_literals.keys())
-        logger.info(f"  [DRY-RUN] Would create secret '{mapping.name}' with keys: {all_keys}")
+        logger.info(f"  [DRY-RUN] Would apply secret '{mapping.name}' with keys: {list(data)}")
         return True
 
+    # Render in-process (no secret in argv) and apply via stdin.
+    manifest = _render_secret_manifest(mapping.name, namespace, data)
     try:
-        # Generate YAML
-        create_result = subprocess.run(
-            create_cmd,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        # Pipe to kubectl apply
-        apply_cmd = [*_kubectl_base(env, namespace), "apply", "-f", "-"]
         apply_result = subprocess.run(
-            apply_cmd,
-            input=create_result.stdout,
+            [*_kubectl_base(env, namespace), "apply", "-f", "-"],
+            input=manifest,
             capture_output=True,
             text=True,
             check=True,


### PR DESCRIPTION
## Problem (audit 2026-07-06)

`k8s_secrets.py` mixed a careful delivery path with two structural weaknesses:

- **C5** — every secret value (incl. the RSA-4096 JWKS key) was passed as `kubectl create secret … --from-literal=KEY=VALUE` **argv**, readable via `/proc/<pid>/cmdline` (`ps auxww`) for the duration of the call.
- **C13** — `_build_users_database` / `_build_apprise_config` hand-rendered YAML with f-strings; a `displayname`/`email`/hash/bot-token containing `"`, `:` or a newline produced invalid YAML → Authelia fails to parse its user DB and **locks everyone out**.

## Change

- **One delivery primitive** `_render_secret_manifest`: builds the Opaque Secret in-process (`data` + base64, byte-equivalent to the old `create -o yaml`) and `_apply_single_secret` applies it via `kubectl apply -f -` (**stdin**). No value ever reaches argv; the `create` subprocess is gone.
- **Both builders** now assemble a dict and `yaml.safe_dump` it — escaping is the serializer's job.
- TOOL-018 fail-closed on partial mappings is preserved.

## Verification

**Unit (368 passed, ruff+mypy clean):** no value in argv (rides base64 in stdin), base64 round-trip, hostile-input escaping (`"`/`:`/newline in displayname + `:` in hash), fail-closed intact.

**Staging smoke (real cluster, ADR-037 flow):**
- `make apply-secrets ENV=staging` → all 12 Secrets `configured` via the stdin primitive.
- `rollout restart authelia + apprise` → **both rolled out, 0 restarts** — they parsed the `safe_dump`d `users_database.yml` / `kubelab.yml`.
- Delivered-Secret check: `authelia-users` = valid YAML, 2 users w/ password+groups+displayname; `apprise` `kubelab.yml` = valid YAML, version 1, tags `[page, log]`.
- Side effect: creating the (missing) `postgres-secrets` recovered a postgres pod stuck 18d in `CreateContainerConfigError`.
- `make notify-smoke` is N/A from a non-VPN workstation (`n8n.staging.kubelab.live` is VPN-only DNS) — the apprise routing table itself is proven valid+correctly-shaped above.

Closes #831