### PR TITLE
chore(staging): deploy web sha-a78a6a4

### DIFF
--- a/infra/config/values/staging.yaml
+++ b/infra/config/values/staging.yaml
@@ -52,7 +52,7 @@ apps:
       enable_homelabs: false
       enable_contact: false
   # Third-party services
-      version: sha-08aa560
+      version: sha-a78a6a4
   services:
     core:
       gitea:

--- a/infra/k8s/overlays/staging/generated/deployments.yaml
+++ b/infra/k8s/overlays/staging/generated/deployments.yaml
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: docker.io/mlorentedev/kubelab-web:sha-08aa560
+          image: docker.io/mlorentedev/kubelab-web:sha-a78a6a4
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Staging promotion of `web` to `sha-a78a6a4` (ADR-046, cross-repo dispatch from mlorentedev/web).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the staging environment to use the latest application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->