### PR TITLE
fix(deps): bump cryptography to 50.0.0 and pytest to 9.0.3 (SEC-DEPS-001)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ pydantic-settings = "^2.14.2"
 jinja2 = "^3.1.6"
 argon2-cffi = "^25.1.0" # For Argon2 password hashing
 pyyaml = "^6.0.3" # For YAML configuration files
-cryptography = "^49.0.0" # For JWKS RSA key generation
+cryptography = "^50.0.0" # For JWKS RSA key generation
 mkdocs = "^1.6.1"
 mkdocs-material = "^9.7.7"
 pymdown-extensions = "^11.0"
@@ -31,7 +31,7 @@ httpx = "^0.28.1" # HTTP client for registry tag verification (deployment promot
 ruff = "^0.16.1"
 mypy = "^2.3.0"
 pre-commit = "^4.6.1"
-pytest = "^8.2.3"
+pytest = "^9.0.3"
 pytest-cov = "^7.1.0"
 pytest-mock = "^3.15.1"
 


### PR DESCRIPTION
## Summary

Closes the two open Dependabot advisories on `master`. Both are **major** bumps, so the existing carets could not pick them up — the constraints had to move by hand.

| Package | Severity | Advisory | Was | Now |
| --- | --- | --- | --- | --- |
| `cryptography` | **high** | PKCS#7 EnvelopedData decryption exposes a Bleichenbacher oracle | `^49.0.0` | `^50.0.0` (resolves 50.0.0) |
| `pytest` | moderate | vulnerable tmpdir handling | `^8.2.3` | `^9.0.3` (resolves 9.1.1) |

`pytest-cov` 7.1.0 and `pytest-mock` 3.15.1 resolve unchanged against pytest 9. The diff is two lines because `poetry.lock` is gitignored in this repo.

## Why the suite passing is not sufficient evidence

`cryptography` is not a leaf dependency here — it backs **JWKS RSA key generation** (`credentials.py`) and sits on the **SOPS/age** path. So I verified the paths that a green suite would not have covered:

- **The import guard still resolves.** `credentials.py` wraps its `cryptography` imports in `try/except ImportError` and sets `HAS_CRYPTOGRAPHY = False` on failure. That is the invisible failure mode: a moved module path in 50.x would have **silently disabled RSA generation** rather than raising. Asserted `HAS_CRYPTOGRAPHY is True` explicitly.
- **RSA generation actually produces a usable key.** `generate_jwks_rsa_key(4096)` returns a PEM that round-trips back through `load_pem_private_key` at 4096 bits — not merely a non-empty string.
- **SOPS decryption works end to end.** `make secrets-audit` reads **staging 37/37** and **prod 44/44**. (The 5 gaps it reports under `dev` are pre-existing and unrelated — a dependency bump cannot remove SOPS keys.)
- **No regression:** `make test` → **370 passed, 108 deselected**, identical to the pre-bump baseline.

Nothing was rotated: the JWKS key was generated in memory for the check and never written to SOPS.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Infrastructure (Ansible, Terraform, K8s)
- [ ] CI/CD
- [ ] Docs
- [x] Security / dependency maintenance

## Checklist

- [x] Tests pass (`make test`) — 370 passed, 108 deselected
- [x] CLAUDE.md updated — n/a, no gotcha/path/convention changed
- [x] No secrets or credentials committed — the RSA check was in-memory only
- [x] Vault updated — n/a, no durable lesson (a routine bump; the verification approach is already covered by the existing "verify the path the dependency actually backs" discipline)

Closes #883
