### PR TITLE
fix(toolkit): stop an empty mapping deleting the common subtree on merge

### DIFF
--- a/infra/config/secrets/staging.enc.yaml
+++ b/infra/config/secrets/staging.enc.yaml
@@ -51,7 +51,6 @@ apps:
                 webhook_secret: ENC[AES256_GCM,data:3BAS8orV0B2YcVob62AM1lTACaXOAEOZpqKzjh5psCj7upCk21p77dT1XmJBFuKGHMf3xaNBpK4poa2V3noASPWT/sFU31NEnY9XgjLqx4us6bbph2I=,iv:/i7T2fn6fmrUmFM9YZ6B+ASec+oJrbfl/E+EuG6RIZI=,tag:5IYhMiuhCzfYzK4B+gcjsA==,type:str]
             n8n:
                 encryption_key: ENC[AES256_GCM,data:AYjzpZrPnEtuQu28w/XvGJMcmdM1EQGmbZCziTMdvHTz/trgXVE0UJSzQxijeIy3TaI9vYSbqbt8rIDzXsJ8iA==,iv:o6jQLt2fCnkR4vLrL2wAlARDaUjTg658qG2auxuY/Cc=,tag:r2YxMBymsQu8jXbilJMmtg==,type:str]
-            dev_node: {}
 my:
     test:
         key: ""
@@ -79,7 +78,7 @@ sops:
             SSYsV8s0L39tqW7+Gy2wt1YcazknuDE7vdbpByM/xQGbuirRRlQ2fg==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1wpqxa7vqkr6watypd6zlw7kspz506kq2kvluxnluhz72mgtaga3qlg84cv
-    lastmodified: "2026-08-08T02:45:07Z"
-    mac: ENC[AES256_GCM,data:Zfu42wTaNuCZP1iuQ8CbfkqgnZwTA+lVnX+RCiBjnzOCSGpkJyXxr8VvIi4ijFjMa1aUwOR8cE/fYxuWLKwitobtwW5g9RUPgR1XASN6iSXiml/d7ErqSEGyRoYxayqGilBxn0ngtAImigcAAzqjD8F8Xs9pBil4uc5tR61LcX4=,iv:z742oYCabRrPVgc4xMjzfhFZfdqeaApjBM9Do4MyXB8=,tag:iRJPi5AT2BbLRj4BAafmdA==,type:str]
+    lastmodified: "2026-08-08T03:10:51Z"
+    mac: ENC[AES256_GCM,data:MVfBNHuFzt4ha3594PH0MBC9CxV7mKO2X7VLuxqqAjTHqrs6r5+sHIjIQWBMVI4aZoiLMUFBpAIWUwKvJNbtRcgQJ670ei4G7jhwXg6qMudcHFmEyEOOIuJ4dsAH+uiFDkH6LeEqVpm9BwMqy2DGORSX+y7i3x6k3Eb8of9/YIQ=,iv:qgTyweIYmT1d1uOpxgfs8LPYiwSk870vsTsLXu1Mt1c=,tag:gFzzo3x4gP52kztT121HGg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/tests/test_config_merge_semantics.py
+++ b/tests/test_config_merge_semantics.py
@@ -90,3 +90,48 @@ class TestMergeOrderContract:
         _merge(merged, {"argocd": {"admin_password": "hub"}})
         _merge(merged, {"argocd": {}})
         assert merged["argocd"]["admin_password"] == "hub"
+
+
+class TestWritePathCannotDestroySecrets:
+    """The same merge runs on a path that ENCRYPTS ITS RESULT BACK TO DISK.
+
+    `credentials.py` (`_promote_shared_secrets`) lifts shared subtrees out of an
+    env file via `_partition_secrets`, deep-merges them into the decrypted
+    `common.enc.yaml`, and re-encrypts the result. `_partition_secrets` copies
+    subtrees verbatim, and `apps.services.automation` is one of its SHARED_NESTED
+    paths — so an empty mapping in an env file was carried straight into the
+    write.
+
+    Under the old semantics that silently DELETED the corresponding subtree from
+    `common.enc.yaml` and persisted the deletion. This was not hypothetical:
+    `staging.enc.yaml` carried `apps.services.automation.dev_node: {}` while
+    `common.enc.yaml` held the dev-node PAT at exactly that path, so a
+    `credentials generate` run would have destroyed the credential.
+
+    Read-path breakage is recoverable — you re-run the tool. This is not.
+    """
+
+    SHARED_PATH = ("apps", "services", "automation")
+
+    def test_empty_mapping_in_promoted_payload_preserves_the_secret(self) -> None:
+        common = {"apps": {"services": {"automation": {"dev_node": {"github_token": "PAT"}}}}}
+        promoted = {"apps": {"services": {"automation": {"dev_node": {}}}}}
+        _merge(common, promoted)
+        automation = common["apps"]["services"]["automation"]
+        assert automation["dev_node"] == {"github_token": "PAT"}
+
+    def test_sibling_secrets_survive_an_empty_mapping_promotion(self) -> None:
+        common = {
+            "apps": {
+                "services": {
+                    "automation": {
+                        "dev_node": {"github_token": "PAT"},
+                        "github_runner": {"token": "RUNNER"},
+                    }
+                }
+            }
+        }
+        _merge(common, {"apps": {"services": {"automation": {"dev_node": {}}}}})
+        automation = common["apps"]["services"]["automation"]
+        assert automation["github_runner"] == {"token": "RUNNER"}
+        assert automation["dev_node"] == {"github_token": "PAT"}

--- a/tests/test_config_merge_semantics.py
+++ b/tests/test_config_merge_semantics.py
@@ -1,0 +1,92 @@
+"""Tests for the config/secrets deep-merge: an empty mapping must not delete data.
+
+`ConfigurationManager._deep_update` guarded its recursive branch with
+``isinstance(value, dict) and value``. An empty mapping is falsy, so it fell
+through to the assignment branch and *replaced* the base subtree instead of
+recursing into it — an empty dict in an env file silently deleted whatever
+`common` declared at that path.
+
+That diverged from the other merge path over the same files. The Ansible
+playbooks merge with ``combine(recursive=True)`` (``merge_hash``), which treats
+an empty mapping as a Mapping and recurses, preserving the base. So the two
+consumers of `common.enc.yaml` + `<env>.enc.yaml` disagreed about what the same
+two files meant:
+
+    common:  {dev_node: {github_token: "..."}}
+    staging: {dev_node: {}}
+
+    ansible combine(recursive=True) -> {dev_node: {github_token: "..."}}   token kept
+    toolkit _deep_update            -> {dev_node: {}}                      token GONE
+
+Found via ANSIBLE-033: the dev-node PAT lived in `common.enc.yaml` and
+provisioned correctly through Ansible, while `toolkit secrets audit` reported it
+missing — because a leftover `dev_node: {}` in `staging.enc.yaml` erased it on
+the toolkit side only. A credential that is present for one tool and absent for
+another is the drift the SSOT discipline exists to prevent.
+
+These tests pin the merge contract: an empty mapping is a no-op, every other
+override still wins.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from toolkit.features.configuration import ConfigurationManager
+
+
+def _merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Run _deep_update without constructing a ConfigurationManager (no env/IO)."""
+    cm = ConfigurationManager.__new__(ConfigurationManager)
+    return cm._deep_update(base, override)
+
+
+class TestEmptyMappingIsANoOp:
+    """An empty mapping declares no override, so it must not delete anything."""
+
+    def test_empty_mapping_preserves_base_subtree(self) -> None:
+        merged = _merge({"dev_node": {"github_token": "SENTINEL"}}, {"dev_node": {}})
+        assert merged["dev_node"] == {"github_token": "SENTINEL"}
+
+    def test_empty_mapping_preserves_deeply_nested_leaf(self) -> None:
+        base = {"apps": {"services": {"automation": {"dev_node": {"github_token": "S"}}}}}
+        override = {"apps": {"services": {"automation": {"dev_node": {}}}}}
+        merged = _merge(base, override)
+        token = merged["apps"]["services"]["automation"]["dev_node"]["github_token"]
+        assert token == "S"
+
+    def test_empty_mapping_for_absent_key_still_creates_it(self) -> None:
+        """Structure-only declarations stay structure — no crash, no invention."""
+        assert _merge({"other": 1}, {"argocd": {}}) == {"other": 1, "argocd": {}}
+
+
+class TestOverridesStillWin:
+    """Regression guard: the fix must only affect the empty-mapping case."""
+
+    def test_non_empty_mapping_merges_key_by_key(self) -> None:
+        merged = _merge({"a": {"keep": 1, "beat": 1}}, {"a": {"beat": 2, "add": 3}})
+        assert merged["a"] == {"keep": 1, "beat": 2, "add": 3}
+
+    def test_scalar_override_replaces(self) -> None:
+        assert _merge({"a": "old"}, {"a": "new"})["a"] == "new"
+
+    def test_explicit_none_still_clears_the_value(self) -> None:
+        """`key:` (null) remains the way to blank a value; only `{}` changed."""
+        assert _merge({"a": "old"}, {"a": None})["a"] is None
+
+    def test_mapping_replaces_scalar(self) -> None:
+        assert _merge({"a": "scalar"}, {"a": {"now": "mapping"}})["a"] == {"now": "mapping"}
+
+    def test_list_override_replaces_wholesale(self) -> None:
+        """Lists are not merged element-wise — unchanged, pinned to prevent drift."""
+        assert _merge({"a": [1, 2, 3]}, {"a": [9]})["a"] == [9]
+
+
+class TestMergeOrderContract:
+    """The documented order is common -> env, with env winning on real values."""
+
+    def test_env_empty_mapping_does_not_beat_common_value(self) -> None:
+        merged: dict[str, Any] = {}
+        _merge(merged, {"argocd": {"admin_password": "hub"}})
+        _merge(merged, {"argocd": {}})
+        assert merged["argocd"]["admin_password"] == "hub"

--- a/toolkit/features/configuration.py
+++ b/toolkit/features/configuration.py
@@ -87,13 +87,27 @@ class ConfigurationManager:
         return dict(items)
 
     def _deep_update(self, source: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[str, Any]:
-        """Recursive dict update."""
+        """Recursive dict update, matching Ansible's ``combine(recursive=True)``.
+
+        Recurse only when the override is a mapping; an empty mapping therefore
+        overrides nothing and leaves ``source`` intact. The previous guard was
+        ``isinstance(value, dict) and value`` — an empty dict is falsy, so it fell
+        through to assignment and *deleted* the base subtree. The playbooks merge
+        the very same files with ``combine(recursive=True)``, which preserves it,
+        so `common.enc.yaml` + `<env>.enc.yaml` meant two different things
+        depending on which tool read them (ANSIBLE-033: a PAT that provisioned
+        fine but audited as missing). Use `key:` (null) to blank a value.
+
+        Recursing into a non-mapping base is what raised `TypeError` when a
+        mapping override met a scalar base; the mapping now replaces it, as
+        `merge_hash` does.
+        """
         for key, value in overrides.items():
-            if isinstance(value, dict) and value:
-                returned = self._deep_update(source.get(key, {}), value)
-                source[key] = returned
+            if isinstance(value, dict):
+                base = source.get(key)
+                source[key] = self._deep_update(base if isinstance(base, dict) else {}, value)
             else:
-                source[key] = overrides[key]
+                source[key] = value
         return source
 
     def get_merged_config(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

`ConfigurationManager._deep_update` guarded its recursive branch with
`isinstance(value, dict) and value`. An empty mapping is **falsy**, so it fell
through to the assignment branch and *replaced* the base subtree instead of
recursing into it — an empty dict in an env file silently deleted whatever
`common` declared at that path.

The playbooks merge the very same files with `combine(recursive=True)`, which
treats an empty mapping as a Mapping and recurses. So `common.enc.yaml` +
`<env>.enc.yaml` meant two different things depending on which tool read them:

| Path | `common: {dev_node: {github_token: X}}` + `staging: {dev_node: {}}` |
|---|---|
| Ansible `combine(recursive=True)` | token **preserved** |
| toolkit `_deep_update` | token **gone** |

## The part that matters most: this also ran on a write path

`credentials.py` `_promote_shared_secrets` merges promoted subtrees into the
decrypted `common.enc.yaml` and **re-encrypts the result to disk**.
`_partition_secrets` copies subtrees verbatim, and `apps.services.automation` is
one of its `SHARED_NESTED` paths — so an empty mapping in an env file was carried
straight into that write and **persisted the deletion**.

This was not hypothetical. `staging.enc.yaml` carried
`apps.services.automation.dev_node: {}` while `common.enc.yaml` held the dev-node
PAT at exactly that path:

```
common after the credentials-generate write path:
  {'dev_node': {}, 'github_runner': {'token': 'RUNNER'}}
```

A `credentials generate` run would have silently and permanently destroyed the
credential. A broken read is recoverable by re-running the tool; this was not.

## How it surfaced

Found while reviewing #890. The ANSIBLE-033 dev-node PAT lives in
`common.enc.yaml` and provisions correctly through Ansible, while the toolkit
resolved it to nothing, because moving the token to `common` left a `dev_node: {}`
behind in `staging.enc.yaml`. Confirmed against the real encrypted files:

```
present in common.enc.yaml alone : True
present after common+staging merge: False
```

A credential that is present for one tool and absent for another is exactly the
drift the SSOT discipline exists to prevent — and it would have made
`make secrets-audit` report the token missing once ANSIBLE-033 registers it.

## The fix

Recurse whenever the override is a mapping, and into the base only when that is
a mapping too. Verified against Ansible's `merge_hash` on all four edge cases:

| Case | `merge_hash` | before | after |
|---|---|---|---|
| empty mapping override | base kept | base **deleted** | base kept |
| mapping over scalar | replaces | **TypeError** | replaces |
| scalar over mapping | replaces | replaces | replaces |
| explicit `None` | `None` | `None` | `None` |

The `TypeError` is a second, latent defect the same guard fixes: a mapping
override onto a scalar base used to recurse *into the scalar* and fail on item
assignment. `key:` (null) remains the way to blank a value.

## Blast radius — enumerated, not assumed

Every empty mapping in the config tree, by dotted path:

- `common.enc.yaml`: `apps.platform.api.email`, `apps.testing` — **inert**, absent from every values file, so they override nothing.
- `staging.enc.yaml`: `apps.services.automation.dev_node` (removed here), `argocd` (pre-existing, ARGO-010).

So the only behavioural change is staging inheriting `argocd.*` from common
instead of erasing it. Diffing a redacted image (path → hash of value) of the
merged config for **dev/staging/prod** shows exactly two deltas, both in staging,
and none in dev or prod:

```
- [staging] apps.services.automation.dev_node = <EMPTY_MAPPING>
+ [staging] apps.services.automation.dev_node.github_token = <hash>
- [staging] argocd = <EMPTY_MAPPING>
+ [staging] argocd.{admin_password,admin_password_hash,github_webhook_secret,slack_webhook_url,spokes.*}
```

Those hub keys are registered `envs=("prod",)`, so the staging audit is
unaffected, and the ConfigMap generator only emits `APPS_PLATFORM_*` / `INFRA_*`
keys — `argocd.*` flattens to `ARGOCD_*` and matches neither. Confirmed rather
than argued: generating the staging manifests with and without this patch gives
**byte-identical** output (`diff -r` clean), so no deployed artifact changes.

## Tests

New `tests/test_config_merge_semantics.py` — 11 cases pinning the merge contract:
empty mapping is a no-op, every other override still wins, and the write path
cannot destroy a sibling secret. 4 read-path cases failed before the fix; both
write-path cases fail on `master` and pass here. Full suite: **379 passed**.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Infrastructure (Ansible, Terraform, K8s)
- [ ] CI/CD
- [ ] Docs

## Checklist

- [x] Tests pass (`make test`) — 379 passed
- [x] CLAUDE.md updated — n/a
- [x] No secrets or credentials committed — the SOPS edit only removes an empty mapping; values were hashed, never printed
- [x] Vault updated — n/a
