### PR TITLE
chore(staging): deploy web sha-b36005f

### DIFF
--- a/infra/config/values/staging.yaml
+++ b/infra/config/values/staging.yaml
@@ -52,7 +52,7 @@ apps:
       enable_homelabs: false
       enable_contact: false
   # Third-party services
-      version: sha-d080f7d
+      version: sha-b36005f
   services:
     core:
       gitea:

--- a/infra/k8s/overlays/staging/generated/deployments.yaml
+++ b/infra/k8s/overlays/staging/generated/deployments.yaml
@@ -88,7 +88,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: docker.io/mlorentedev/kubelab-web:sha-d080f7d
+          image: docker.io/mlorentedev/kubelab-web:sha-b36005f
           imagePullPolicy: IfNotPresent
           ports:
             - name: http


### PR DESCRIPTION
Staging promotion of `web` to `sha-b36005f` (ADR-046, cross-repo dispatch from mlorentedev/web).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the staging environment to use a newer version of a third-party service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->