### PR TITLE
fix(deps): add types-requests so the venv mypy matches pre-commit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pre-commit = "^4.6.1"
 pytest = "^9.0.3"
 pytest-cov = "^7.1.0"
 pytest-mock = "^3.15.1"
+types-requests = "^2.33.0.20260712"
 
 [tool.poetry.scripts]
 toolkit = "toolkit.main:app"


### PR DESCRIPTION
## Summary

`make type` fails on a clean `master`. One line fixes it.

```
toolkit/features/notify_smoke.py:170: error: Library stubs not installed for "requests"  [import-untyped]
Found 1 error in 1 file (checked 59 source files)
```

## Why it was invisible

Two mypy gates run against different environments, and only the lenient one is ever exercised in a way anyone sees:

| Gate | Environment | `types-requests` | Extra args |
| --- | --- | --- | --- |
| `make type` | the project venv (`pyproject.toml`) | **absent** | none |
| pre-commit `mirrors-mypy` | its own isolated env | present via `additional_dependencies` | `--ignore-missing-imports` |

`[tool.mypy]` overrides `ignore_missing_imports` for `sh`, `yaml`, `argon2`, `uptime_kuma_api` — not `requests`. So the venv had neither the stubs nor a suppression, while pre-commit had both. The import dates from #670 (NOTIFY-001).

## Why stubs rather than an override

Adding `requests` to the `ignore_missing_imports` list would also silence the failure, but it stops type-checking those calls. The stubs check them — and they already pass: mypy now reports **no issues across all 59 source files**, so the annotations were correct all along, just unverified.

## Verification

- `make type` → `Success: no issues found in 59 source files` (was: 1 error).
- `make check` → **all four legs green** (`lint`, `type`, `test` 389 passed, `validate-sync`). The chain previously aborted at `type` and never reached `test` or `validate-sync`.

## Note

`poetry.lock` is gitignored in this repo, so the diff is a single line.

The reason a red `make type` could survive on `master` at all is tracked separately as CI-GATE-006 (#904): no CI job runs pytest, ruff, or mypy over `toolkit/`.

Closes #902
