### PR TITLE
docs(spec): add AC8 to AI-007 — the documentation surface the code sweep leaves lying

### DIFF
--- a/specs/AI-007-ollama-retirement/features.json
+++ b/specs/AI-007-ollama-retirement/features.json
@@ -47,5 +47,12 @@
     "verification": "grep -q 'AI-007' docs/adr/adr-028-operational-topology.md && grep -q 'AI-007' docs/adr/adr-029-intelligence-layer.md",
     "state": "pending",
     "evidence": ""
+  },
+  {
+    "id": "AI-007-ollama-retirement-f8",
+    "behavior": "No operational doc still describes Ollama as running; the dedicated rotation runbook is gone. ADRs, dated audits/snapshots and unbuilt-product component specs are deliberate survivors and are NOT checked - rewriting a historical record to erase Ollama would falsify it",
+    "verification": "! test -f docs/runbooks/ollama-api-key-rotation.md && ! git grep -il ollama -- docs/runbooks docs/troubleshooting docs/architecture/service-catalog.md docs/architecture/architecture-overview.md",
+    "state": "pending",
+    "evidence": ""
   }
 ]

--- a/specs/AI-007-ollama-retirement/proposal.md
+++ b/specs/AI-007-ollama-retirement/proposal.md
@@ -89,6 +89,12 @@ The order is enforced by **merge order, not by a runbook step someone has to rem
 - [ ] **AC5** — In prod, no `Middleware/api-key-ollama` and no backing Secret remain — the out-of-band objects Argo never tracked are gone, verified against the live cluster rather than against git.
 - [ ] **AC6** — `make test` and the prod e2e suite pass with no Ollama module, no skipped Ollama expectation, and no new failures.
 - [ ] **AC7** — ADR-028 and ADR-029 each carry an amendment note referencing AI-007 and #905.
+- [ ] **AC8** — No operational document still describes Ollama as a running service: `docs/runbooks/` and `docs/troubleshooting/` are clean, `docs/architecture/service-catalog.md` and `architecture-overview.md` are clean, and `docs/runbooks/ollama-api-key-rotation.md` (118 lines, a runbook for a service that will not exist) is deleted.
+
+  **Deliberate survivors, untouched by AC8** — the same allowlist discipline AC1 needs, for the same reason:
+  - **The 17 ADRs.** An ADR records a decision taken at a time; rewriting it to remove Ollama falsifies the record. ADR-035 *did* use Ollama as its first consumer. Only ADR-028 and ADR-029 change, and only by the amendment notes in AC7 — "amended, not superseded", per ADR-058 itself.
+  - **`docs/audits/*` and `docs/architecture/current-state-2026-03-22.md`** — dated snapshots. Same argument as ADRs.
+  - **`docs/architecture/components/kubelab-*.md`** — design positions for unbuilt L1 products, not claims about running infrastructure.
 
 ## References
 

--- a/specs/AI-007-ollama-retirement/tasks.md
+++ b/specs/AI-007-ollama-retirement/tasks.md
@@ -44,6 +44,9 @@ created: "2026-08-09"
 - [ ] [AC6] Delete `tests/e2e/test_ollama_public.py`; clean the entries in `expectations.py`, `conftest.py` and `tests/test_k8s_middlewares.py`
 - [ ] [AC1] Correct the rationale comments that outlive the service: `dev_node/tasks/main.yml` (coexistence header), `beelink_services` + `provision-bee.yml` ("moved to ace2"), `headscale/policy.hujson.j2` (the `tag:hermes → vps:443` justification — the **rule stays**, it also covers Gitea)
 - [ ] [AC7] Amend ADR-028 and ADR-029; fold in the two `CLAUDE.md` doc-drift fixes named in ADR-058 D4
+- [ ] [AC8] Delete `docs/runbooks/ollama-api-key-rotation.md` — a 118-line runbook for a service that will not exist
+- [ ] [AC8] Clear the present-tense claims from `docs/architecture/{service-catalog,architecture-overview}.md`, `docs/runbooks/{monitoring,operations,dns-homelab,hardware-setup,energy-consumption,non-admin-workstation-access}.md` and `docs/troubleshooting/docker-containers.md`
+- [ ] [AC8] **Do NOT touch** the other 15 ADRs, `docs/audits/*`, `current-state-2026-03-22.md`, or `components/kubelab-*.md`. They are historical records or unbuilt-product design positions; erasing Ollama from them would falsify the record. Verify by re-reading, not by grepping them clean
 - [ ] [AC1] Run the survivor check and confirm only the deliberate matches remain
 
 ## Closing


### PR DESCRIPTION
Follow-up to #915, which merged before this commit was pushed. The content is unchanged from what was reviewed on the AI-007 branch; it lands on its own branch because that branch had fallen behind master and a PR from it would have reverted #903, #911 and #913.

## Why AC8 exists

Mapping actual propagation rather than string occurrences found the inverse of the expected shape: **zero runtime consumers** — nothing in `apps/` or `edge/` references Ollama, which confirms ADR-029's "decided but unbuilt" with evidence — against **~36 documents** describing it as a running service.

AC1 deliberately excludes `docs/`; that exclusion is what makes AC1 satisfiable at all. AC7 covered only ADR-028 and ADR-029. So the criteria as merged in #915 can all pass while shipping an immaculate code sweep and documentation that lies.

## What changed

- `proposal.md` — AC8, plus an explicit survivor allowlist
- `tasks.md` — three `[AC8]` tasks in the PR-B block, one of them a "do NOT touch" instruction
- `features.json` — probe `f8`

## Deliberate survivors

AC8 carries the same allowlist discipline AC1 needed, for the same reason:

- **The 17 ADRs.** An ADR records a decision taken at a time. ADR-035 *did* use Ollama as its first middleware consumer; rewriting it to erase that falsifies the record. Only ADR-028 and ADR-029 change, and only via the amendment notes already in AC7 — "amended, not superseded", per ADR-058.
- **`docs/audits/*` and `docs/architecture/current-state-2026-03-22.md`** — dated snapshots, same argument.
- **`docs/architecture/components/kubelab-*.md`** — design positions for unbuilt L1 products, not claims about running infrastructure.

`f8` is scoped accordingly: it checks `docs/runbooks`, `docs/troubleshooting`, `service-catalog.md` and `architecture-overview.md`, and asserts `docs/runbooks/ollama-api-key-rotation.md` is gone. It does not grep the survivors clean.

## Scope

Spec-only, +16 lines across three files. No code, no infrastructure, no live change. The retirement itself still waits on `make tf-dns-apply` and the manual window with ace2 powered on.

Refs #905.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added acceptance criteria to remove outdated operational references to Ollama.
  * Added tasks to delete the obsolete Ollama API-key rotation runbook.
  * Clarified that historical records, audit snapshots, and unbuilt architecture documentation should remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->