### PR TITLE
chore(secrets): remove prod's orphaned admin password hash

### DIFF
--- a/infra/config/secrets/prod.enc.yaml
+++ b/infra/config/secrets/prod.enc.yaml
@@ -6,7 +6,6 @@ apps:
     services:
         security:
             authelia:
-                users_admin_password_hash: ENC[AES256_GCM,data:95Jqhqd1fBiAOtOfR+C32HghwcA+LI5uOW5TMAnymq5hN75VSO9Ec7pkjgOu6BGKFr6GcnnM7QhJy/GEcUC/L+0CKbDAygZUeczSu1md6umNdskmh2dVogr3hZ6xlq3yZg==,iv:Q5JcaQKjNwQihLTuMH+VPN+vJgQ8AAbslirJnLSuntQ=,tag:ncGJ95kPFGWtfBIRIHWDMg==,type:str]
                 oidc_hmac_secret: ENC[AES256_GCM,data:re8Fj2chuHmOMtmIoNEMcsRhghq6keVpA69NMQloReFtfEjtsMxKDrkCWrkFQlQqOEZX98gANbRSUIHHDlExgHMJfLrHK+/fOaNOK3xsp5igU2veQTU=,iv:BQ88GwF1adAVxlw8iW8u/HswhcNh42whgaz0k9XPSKQ=,tag:9zEp0IX0yTQxQ97nMfzu7A==,type:str]
                 session_secret: ENC[AES256_GCM,data:GZa632zaWr0s6+vpN9/J6IliWAIRFRm+FKYI/E+9qjkayzZO/STImlRLWtZqPH/CCHwBcMxCHNxK1jnI49jhGnUxMp5O/1IdMtBZNNdjfpWMCzwC8dA=,iv:7M9tGsVEAh7smAOkhzKpGHg7sgEsodyBnaLulWB/QXI=,tag:KqV/sF7boS1mfLNAR1kAJQ==,type:str]
                 storage_encryption_key: ENC[AES256_GCM,data:YRQBeMZm/PXoZEozBJlVOEu5oAHNCzB8ct5Ez3IGKDZdvFTmSKnCok6Nq0sfBs+SPjITYEkgz/NSpG9t35CRoi5SMRMjpBRgOZKaWL6DBJ0VupPGmuk=,iv:jKhCEKf8ubwT74G0MLc8yBztFcg0tOeB0+gzF/vVsgs=,tag:QF/GJqRU6EAI0JoBoIGFjQ==,type:str]
@@ -70,7 +69,7 @@ sops:
             bxzjfSRYRP7H3hZNVJUlKud8ERFunk0Ql1CWYsNT8LdUllnS3LZojQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1wpqxa7vqkr6watypd6zlw7kspz506kq2kvluxnluhz72mgtaga3qlg84cv
-    lastmodified: "2026-08-09T17:28:52Z"
-    mac: ENC[AES256_GCM,data:HuCXevuMjyHq1IwuleGCTGwB1g0sNC5BiKGCexHUsiZ0Qwjs+zxkgJtOk106nkWdDXRjs7aNkRA6FRH95S76Rxyo64MIhDGyIcqi9gAxJ4nRZaLY+AfBRpzHrNDnIx78BXO/YoPCPCvS2JK3aWZh3bUn2ISiwVyqFDrkThPF8r4=,iv:RRhvpkaKj+GPygt+ZO8psGu9IgeVZWgDTQnsytIHrwc=,tag:YBFcWCHyjjl0C8XkmHWJ+w==,type:str]
+    lastmodified: "2026-08-09T23:51:17Z"
+    mac: ENC[AES256_GCM,data:LG09z53ToOooXgbcl7qoMhCHXHu3utxsnOdV6l7u3BYWUzDsUYvWD9GUKucoIFbc8TYEax4DIJWfJFUXNuK2kHKBVp/RbO+0UTVDT7ULMXsTT8duuF9bJ5AAcJ1Y6mTHm9v3eWVnAnNmBX4m8fzO/jy4+pXNWQUQdmJEut1Xe1Y=,iv:aAOtBdkSWhVcsBWQBpsALbdrLl1xyDUz04M/ltmGi6E=,tag:nbzIsNtXFvwJOR4i1H5gqg==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.7.3

--- a/toolkit/cli/credentials.py
+++ b/toolkit/cli/credentials.py
@@ -85,7 +85,10 @@ def show_secrets(
 def hash_password(
     key_path: Annotated[
         str,
-        typer.Argument(help="Dot-separated path to the secret key (e.g., 'apps.authelia.users_admin_password_hash')"),
+        typer.Argument(
+            help="Dot-separated path to the secret key "
+            "(e.g., 'apps.services.security.authelia.users_operator_password_hash')"
+        ),
     ],
     env: Annotated[str, typer.Option("--env", "-e", help="Target environment")] = "dev",
 ) -> None:

--- a/toolkit/features/credentials.py
+++ b/toolkit/features/credentials.py
@@ -188,7 +188,7 @@ class CredentialsManager:
 
         Args:
             key_path: The dot-separated path to the key in the secrets file
-                      (e.g., "apps.authelia.users_admin_password_hash").
+                      (e.g., "apps.services.security.authelia.users_operator_password_hash").
             env: The target environment (e.g., "dev").
         """
         logger.section(f"Generate Hashed Secret for '{key_path}' - {env.upper()}")


### PR DESCRIPTION
Completes #910. #932 removed this key from dev and staging and gave dev
its missing operator hash, but deliberately left `prod.enc.yaml` alone: a
parallel session held that file for the AI-007 sweep, and two sessions
rewriting the same SOPS ciphertext cannot merge. That sweep landed in
#935, so prod is now free.

`apps.auth.admin_username` resolves to `operator` in every environment,
so `users_admin_password_hash` has had no consumer since the SSOT-014b
rename. Verified dead before deleting:

- `SECRET_CATALOG` registers only `users_operator_password_hash`
- no manifest, template or toolkit module reads the admin key
- prod's `users_operator_password_hash` is present and is what Authelia
  actually serves

## The audit cannot see this change, and that is the point

`make secrets-audit ENV=prod` reports 43/43 (100%) both before and after
this commit. `audit()` iterates `SECRET_CATALOG`, and this key was never
registered there — so an unregistered credential is invisible to it by
construction. The audit is evidence of no regression; it is not evidence
the key is gone.

The proof of deletion is the inverse check:

    $ make secrets-show KEY=apps.services.security.authelia.users_admin_password_hash SECRETS_ENV=prod
    [ERROR] Key '...users_admin_password_hash' not found in prod secrets

and the operator hash surviving the same read, which proves the deletion
hit the intended key rather than its neighbour. The diff is one data line
plus SOPS's mac/lastmodified rewrite.

## Help text that advertised the dead key

`credentials hash-password` named `apps.authelia.users_admin_password_hash`
in both its CLI argument help and its docstring — the dead key, under a
subtree that has not been the real path for months (the live one is
`apps.services.security.authelia.*`). That is the exact command someone
would run to recreate what this commit deletes, so both are corrected
here rather than left for the docs sweep.

The runbook prose in `docs/runbooks/{sops-and-secrets,secrets-reference}.md`
still documents the old key. That is audit finding D11, already tracked
as #826, and is left to that sweep to keep this diff atomic.

Closes #910