### PR TITLE
fix(secrets): remove the orphaned admin password hash from prod

### DIFF
--- a/infra/config/secrets/prod.enc.yaml
+++ b/infra/config/secrets/prod.enc.yaml
@@ -6,7 +6,6 @@ apps:
     services:
         security:
             authelia:
-                users_admin_password_hash: ENC[AES256_GCM,data:95Jqhqd1fBiAOtOfR+C32HghwcA+LI5uOW5TMAnymq5hN75VSO9Ec7pkjgOu6BGKFr6GcnnM7QhJy/GEcUC/L+0CKbDAygZUeczSu1md6umNdskmh2dVogr3hZ6xlq3yZg==,iv:Q5JcaQKjNwQihLTuMH+VPN+vJgQ8AAbslirJnLSuntQ=,tag:ncGJ95kPFGWtfBIRIHWDMg==,type:str]
                 oidc_hmac_secret: ENC[AES256_GCM,data:re8Fj2chuHmOMtmIoNEMcsRhghq6keVpA69NMQloReFtfEjtsMxKDrkCWrkFQlQqOEZX98gANbRSUIHHDlExgHMJfLrHK+/fOaNOK3xsp5igU2veQTU=,iv:BQ88GwF1adAVxlw8iW8u/HswhcNh42whgaz0k9XPSKQ=,tag:9zEp0IX0yTQxQ97nMfzu7A==,type:str]
                 session_secret: ENC[AES256_GCM,data:GZa632zaWr0s6+vpN9/J6IliWAIRFRm+FKYI/E+9qjkayzZO/STImlRLWtZqPH/CCHwBcMxCHNxK1jnI49jhGnUxMp5O/1IdMtBZNNdjfpWMCzwC8dA=,iv:7M9tGsVEAh7smAOkhzKpGHg7sgEsodyBnaLulWB/QXI=,tag:KqV/sF7boS1mfLNAR1kAJQ==,type:str]
                 storage_encryption_key: ENC[AES256_GCM,data:YRQBeMZm/PXoZEozBJlVOEu5oAHNCzB8ct5Ez3IGKDZdvFTmSKnCok6Nq0sfBs+SPjITYEkgz/NSpG9t35CRoi5SMRMjpBRgOZKaWL6DBJ0VupPGmuk=,iv:jKhCEKf8ubwT74G0MLc8yBztFcg0tOeB0+gzF/vVsgs=,tag:QF/GJqRU6EAI0JoBoIGFjQ==,type:str]
@@ -70,7 +69,7 @@ sops:
             bxzjfSRYRP7H3hZNVJUlKud8ERFunk0Ql1CWYsNT8LdUllnS3LZojQ==
             -----END AGE ENCRYPTED FILE-----
           recipient: age1wpqxa7vqkr6watypd6zlw7kspz506kq2kvluxnluhz72mgtaga3qlg84cv
-    lastmodified: "2026-08-09T17:28:52Z"
-    mac: ENC[AES256_GCM,data:HuCXevuMjyHq1IwuleGCTGwB1g0sNC5BiKGCexHUsiZ0Qwjs+zxkgJtOk106nkWdDXRjs7aNkRA6FRH95S76Rxyo64MIhDGyIcqi9gAxJ4nRZaLY+AfBRpzHrNDnIx78BXO/YoPCPCvS2JK3aWZh3bUn2ISiwVyqFDrkThPF8r4=,iv:RRhvpkaKj+GPygt+ZO8psGu9IgeVZWgDTQnsytIHrwc=,tag:YBFcWCHyjjl0C8XkmHWJ+w==,type:str]
+    lastmodified: "2026-08-09T23:59:03Z"
+    mac: ENC[AES256_GCM,data:muFlkWU6xF64V/yCCxNuaG26LFio7mtuuSjgL31a1LgZNVFEt6k+0i7vUbxaSVxtA+8bJtiBnH79CPZIKESfx8/VlZ52qy0hP+Hafn6bTVOlg5sl+tGEicumWrqEF2YwR7zUdMBLZDJC/90A0qu41VVEXQHdKbYUGTbM9Sk8wIc=,iv:/APFJ/ig/036JD1NOJx1GZaoauzZCRhXC/eZe4Jw6P8=,tag:QzVgeLX7OEXoJzDFR2I7BQ==,type:str]
     unencrypted_suffix: _unencrypted
     version: 3.7.3


### PR DESCRIPTION
Completes the third of #910 that #932 deliberately left behind.

## Why it was left

#932 removed `users_admin_password_hash` from dev and staging and stopped there on purpose: a parallel session held an unmerged commit rewriting `prod.enc.yaml` for the AI-007 sweep, and two sessions re-encrypting the same SOPS file in parallel produce a conflict with no useful three-way merge. That PR (#935) has since merged, so the constraint is gone.

**#910 was closed on 2026-08-09 at 23:54 — twelve minutes after #905 — while this half of the defect was still live.** Verified before touching anything: the hash read back from `prod.enc.yaml` this morning. Rather than reopen the ticket for bookkeeping, this PR makes the closure true.

## The defect

`apps.auth.admin_username` resolves to `operator` in every environment, so this key has had no consumer since the SSOT-014b rename. `SECRET_CATALOG` never registered it — which is exactly why **prod reported 100% while carrying an unrotated, unvalidated, unsurfaced credential hash**. The audit is not the check here; its silence is the bug.

## Verification

Deliberately not trusting the tool's own report — `[SUCCESS]` is the exact word `credentials hash-password` prints for a write it never performs (#934). Each claim has an independent probe, and the positive control was taken *first*, while the key was still there:

| Check | Before | After |
|---|---|---|
| `users_admin_password_hash` | present, and **distinct** from operator's — a dead second key, not an alias | `[ERROR] Key not found in prod secrets` |
| `users_operator_password_hash` | `$argon2id$...ChROLRUTz...` | byte-identical |
| `users_testuser_password_hash` | present | present |
| `secrets audit --env prod` | 43/43 (100%) | 43/43 (100%) |

The encrypted diff is itself the evidence. SOPS encrypts per-value in YAML mode, so the change reads as **exactly one content line removed** plus `lastmodified` and `mac` — the same 5-line shape as #932's staging change:

```
 infra/config/secrets/prod.enc.yaml | 5 ++---
-  users_admin_password_hash: ENC[AES256_GCM,data:...]
-  lastmodified / mac
+  lastmodified / mac
```

## Still open from #910

Its third bullet — *"consider whether the audit should flag **unknown** keys under a managed subtree, not just missing ones"* — is the design question, not the cleanup. An orphan that no catalog entry claims is precisely what went unnoticed here, in three environments, for months. Not in scope for this PR.

Closes #910