### PR TITLE
feat(observability): provision the Grafana alert delivery path from git

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -29,6 +29,20 @@ owner: manu
 **Rule**: Pattern to follow going forward
 ```
 
+### [2026-08-10] A config that provisions cleanly can still fail at delivery
+
+**Context**: OBS-007 phase 1 — building the Grafana -> Apprise -> Telegram path before writing any alert query. The spec ordered it that way deliberately: "the substrate is the work; the rule is the easy part."
+
+**Problem**: The contact point provisioned without a single warning. `GET /api/v1/provisioning/contact-points` returned it, Grafana logged `finished to provision alerting`, and the test asserting a non-empty contact-point list went green. Everything that could be checked *before sending anything* said the configuration was correct.
+
+It was not. The first alert produced `notify retry canceled due to unrecoverable error: template: :1: unexpected ":=" in command`. Grafana's custom webhook **payload** parser rejects variable assignment (`{{ $type := "success" }}`), which ordinary Go templates accept and which is accepted inside a `templates.yaml` `define`. The restriction applies only to the payload template, and only at send time.
+
+Two further traps sat behind it. Grafana applies a newly provisioned alerting config roughly **60 seconds after the pod starts**, not at startup — so for the first minute after a rollout the *old* config is still notifying, and a fix looks like it did not work. And Grafana's stock webhook body (`title`/`message`/`alerts[]`) has neither the `body` nor the `tag` field Apprise requires, so the default payload would have been rejected regardless.
+
+**Solution**: Move any conditional logic out of the payload template into a named `define` in the provisioned templates file, and call it with `tmpl.Exec`. Build the JSON with `coll.Dict | data.ToJSON` rather than by hand, so quotes inside an alert annotation are escaped instead of producing a malformed body — Traefik's ACME errors do contain quotes. Then read the *Apprise* access log for `POST /notify/kubelab 200` and `Delivered Notification(s) - Tags: <tier>`, and compare timestamps against the `Applying new configuration to Alertmanager` line to be sure you are looking at the config you just deployed.
+
+**Rule**: For anything that *sends*, provisioning success is not delivery success — the only check that counts is an artifact observed at the far end. Order the work so the transport is proven by a trivial always-firing rule before any query exists; otherwise a silent alert has two candidate causes and no way to separate them. This one paid immediately: written in the other order, a payload-template parse error would have presented as "my LogQL matches nothing."
+
 ### [2026-06-26] A Trivy image failure has two independent sources — base-OS *and* the Go binary
 
 **Context**: The `api` image build (Trivy step in `ci-publish.yml`, gate = `CRITICAL,HIGH`, `ignore-unfixed: true`) started failing on the release PR. First read: the base was `alpine:3.18`, which had reached EOL — its apk packages no longer get security backports, so ~18 fixed-elsewhere HIGH/CRITICAL CVEs tripped the scanner. Bumped the runtime base to the current stable `alpine:3.24`.

--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -80,6 +80,24 @@ configMapGenerator:
     options:
       disableNameSuffixHash: true
 
+  # Grafana alerting provisioning (OBS-007). NOTE the deliberate difference from
+  # its grafana-dashboards sibling directly above: that one disables the name
+  # hash, this one keeps it. Dashboards are re-read on a timer
+  # (`updateIntervalSeconds: 60` in grafana-dashboard-provider), so a stable name
+  # is fine there. Alerting provisioning is read ONCE at Grafana startup, so
+  # without the hash suffix a rule change would land on disk and never take
+  # effect. The hash makes every change a new object name, which rolls the pod.
+  # Same rationale as authelia-config. Do not "align" this with the sibling.
+  #
+  # `policies.yaml` is replaced per environment via `behavior: merge` in the prod
+  # overlay — prod pages, staging archives.
+  - name: grafana-alerting
+    namespace: kubelab
+    files:
+      - services/grafana-alerting/contact-points.yaml
+      - services/grafana-alerting/templates.yaml
+      - services/grafana-alerting/policies.yaml
+
 # Image tags synced from infra/config/values/common.yaml (SSOT).
 # Run `make sync-k8s-images` to refresh after bumping versions.
 images:

--- a/infra/k8s/base/services/grafana-alerting/contact-points.yaml
+++ b/infra/k8s/base/services/grafana-alerting/contact-points.yaml
@@ -1,0 +1,87 @@
+# Grafana alerting — contact points (OBS-007).
+#
+# Both severity tiers are declared HERE, in the shared base, and both exist in
+# every cluster. What differs per environment is which one the root notification
+# policy selects — see `policies.yaml` and the prod overlay's copy of it.
+#
+# Why that seam and not a per-environment contact point: the two receivers are
+# byte-identical apart from one tag, so splitting them across base and overlay
+# would duplicate the whole payload template and let the copies drift silently.
+# Splitting at the policy instead puts five lines in the overlay and makes drift
+# impossible. The effective tag still differs per environment, which is what
+# ADR-044's two tiers are for.
+#
+# No credential appears here, by design: ADR-044 Option B puts the Telegram bot
+# token inside `apprise-secrets` and has callers send only a tag. That is why
+# this is an ordinary ConfigMap and not an ADR-035 out-of-band Middleware.
+---
+apiVersion: 1
+
+contactPoints:
+  # Tier `page` — the push channel. Prod's root policy routes here.
+  - orgId: 1
+    name: apprise-page
+    receivers:
+      - uid: apprise-page
+        type: webhook
+        # Resolved notifications must be delivered: a rule that fires and never
+        # clears is a rule people learn to ignore.
+        disableResolveMessage: false
+        settings:
+          url: http://apprise:8000/notify/kubelab
+          httpMethod: POST
+          payload:
+            vars:
+              tag: page
+            # Grafana's stock webhook body is its own alert JSON — `title` and
+            # `message`, no `body` and no `tag`. Apprise requires `body` and
+            # routes on `tag`, so the default payload would be rejected. This
+            # template reshapes it to the contract in
+            # infra/n8n/workflows/notify-router.json.
+            #
+            # Built with coll.Dict | data.ToJSON rather than hand-written JSON so
+            # that quotes and newlines inside an alert annotation are escaped
+            # rather than producing a malformed body. Traefik's ACME errors do
+            # contain quotes.
+            # NOTE the conditional for `type` lives in a named sub-template
+            # rather than inline. Grafana's custom-payload parser rejects
+            # variable assignment: `{{ $type := "success" }}` fails at delivery
+            # time with `template: :1: unexpected ":=" in command`, and it fails
+            # at DELIVERY, not at provisioning — the contact point provisions
+            # cleanly and the API reports it present. Measured 2026-08-10.
+            # Full template syntax is fine inside a `templates.yaml` define.
+            template: |
+              {{- coll.Dict
+                    "tag"   .Vars.tag
+                    "type"  (tmpl.Exec "apprise.type" .)
+                    "title" (printf "%s: %s" .Status .CommonLabels.alertname)
+                    "body"  (tmpl.Exec "apprise.body" .)
+                  | data.ToJSON -}}
+
+  # Tier `log` — the archive channel. Staging's root policy routes here.
+  - orgId: 1
+    name: apprise-log
+    receivers:
+      - uid: apprise-log
+        type: webhook
+        disableResolveMessage: false
+        settings:
+          url: http://apprise:8000/notify/kubelab
+          httpMethod: POST
+          payload:
+            vars:
+              tag: log
+            # NOTE the conditional for `type` lives in a named sub-template
+            # rather than inline. Grafana's custom-payload parser rejects
+            # variable assignment: `{{ $type := "success" }}` fails at delivery
+            # time with `template: :1: unexpected ":=" in command`, and it fails
+            # at DELIVERY, not at provisioning — the contact point provisions
+            # cleanly and the API reports it present. Measured 2026-08-10.
+            # Full template syntax is fine inside a `templates.yaml` define.
+            template: |
+              {{- coll.Dict
+                    "tag"   .Vars.tag
+                    "type"  (tmpl.Exec "apprise.type" .)
+                    "title" (printf "%s: %s" .Status .CommonLabels.alertname)
+                    "body"  (tmpl.Exec "apprise.body" .)
+                  | data.ToJSON -}}

--- a/infra/k8s/base/services/grafana-alerting/policies.yaml
+++ b/infra/k8s/base/services/grafana-alerting/policies.yaml
@@ -1,0 +1,29 @@
+# Grafana alerting — the root notification policy (OBS-007).
+#
+# THIS IS THE PER-ENVIRONMENT FILE. The prod overlay ships its own copy selecting
+# `apprise-page`; this base copy is the staging value, following the repo idiom of
+# base-carries-staging + overlay-patches (see the authelia-config generator).
+#
+# Keep this file minimal. Everything that is genuinely shared — the contact
+# points and the message body — lives in the sibling files precisely so that the
+# duplicated-across-environments surface stays this small.
+#
+# Grafana ships a default root policy whose receiver is the literal string
+# `empty`, so without this file alerts are evaluated and then discarded. That is
+# not a hypothetical: `empty` is what was measured in staging on 2026-08-10.
+---
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    # staging -> archive channel. Staging is on-demand and non-critical, so it
+    # alerts without interrupting (ADR-044 tiers; decided in the spec 2026-08-09).
+    receiver: apprise-log
+    group_by:
+      - grafana_folder
+      - alertname
+    # Batch the first notification briefly so a burst of related ACME failures
+    # arrives as one message rather than one per domain.
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/infra/k8s/base/services/grafana-alerting/templates.yaml
+++ b/infra/k8s/base/services/grafana-alerting/templates.yaml
@@ -1,0 +1,31 @@
+# Grafana alerting — the shared message body (OBS-007).
+#
+# Defined once and referenced by both contact points in `contact-points.yaml`,
+# so the two severity tiers cannot drift apart in what they actually say.
+#
+# The environment is identified by `.ExternalURL`, which Grafana derives from
+# GF_SERVER_ROOT_URL — already per-environment in the existing config
+# (`grafana.staging.kubelab.live` in base, patched to the prod domain in the prod
+# overlay). That means the recipient can tell staging from prod without this file
+# carrying an environment name, and without a second per-environment value to
+# keep in sync. Satisfies the "names the environment" half of AC4; the affected
+# domain comes from the alert rule's own labels, which is the other half.
+---
+apiVersion: 1
+
+templates:
+  - orgId: 1
+    name: apprise-body
+    template: |
+      {{- define "apprise.type" -}}
+      {{ if eq .Status "firing" }}failure{{ else }}success{{ end }}
+      {{- end -}}
+
+      {{ define "apprise.body" }}
+      {{- range .Alerts }}
+      {{ if .Annotations.summary }}{{ .Annotations.summary }}{{ else }}{{ .Labels.alertname }}{{ end }}
+      {{ if .Labels.domain }}Domain: {{ .Labels.domain }}
+      {{ end }}Started: {{ .StartsAt }}
+      {{ end }}
+      Source: {{ .ExternalURL }}
+      {{- end }}

--- a/infra/k8s/base/services/grafana.yaml
+++ b/infra/k8s/base/services/grafana.yaml
@@ -154,6 +154,11 @@ spec:
             - name: dashboards
               mountPath: /var/lib/grafana/dashboards
               readOnly: true
+            # OBS-007. Read once at startup, not hot-reloaded — the ConfigMap
+            # keeps its name hash so a change rolls the pod (see base/kustomization.yaml).
+            - name: alerting
+              mountPath: /etc/grafana/provisioning/alerting
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /api/health
@@ -190,6 +195,9 @@ spec:
         - name: dashboards
           configMap:
             name: grafana-dashboards
+        - name: alerting
+          configMap:
+            name: grafana-alerting
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/overlays/prod/grafana-alerting/policies.yaml
+++ b/infra/k8s/overlays/prod/grafana-alerting/policies.yaml
@@ -1,0 +1,26 @@
+# Grafana alerting — prod's root notification policy (OBS-007).
+#
+# The ONLY thing that differs between environments: prod routes to the push
+# channel. Everything else — the two contact points and the shared message body —
+# comes from the base generator unchanged, so there is nothing here that can
+# drift out of step with it.
+#
+# Merged over the base ConfigMap via `behavior: merge` in kustomization.yaml,
+# which replaces this one key and leaves the sibling keys alone. Verify the
+# result by reading the RENDERED output of `kubectl kustomize`, never this file:
+# a patch that looks correct and changes nothing is exactly how a dead
+# certResolver survived months in prod (docs/lessons.md, 2026-08-09).
+---
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    # prod -> push channel. Prod is always-on and user-facing; a certificate
+    # failing here is worth an interruption.
+    receiver: apprise-page
+    group_by:
+      - grafana_folder
+      - alertname
+    group_wait: 30s
+    group_interval: 5m
+    repeat_interval: 4h

--- a/infra/k8s/overlays/prod/kustomization.yaml
+++ b/infra/k8s/overlays/prod/kustomization.yaml
@@ -27,6 +27,16 @@ configMapGenerator:
     files:
       - authelia-config/configuration.yml
 
+  # Route prod's alerts to the push tier (OBS-007). `merge` — not `replace` —
+  # so the base's contact-points.yaml and templates.yaml carry through untouched
+  # and only this one key is overridden. Using `replace` here would silently drop
+  # the contact points and leave prod routing to a receiver that does not exist.
+  - name: grafana-alerting
+    namespace: kubelab
+    behavior: merge
+    files:
+      - grafana-alerting/policies.yaml
+
 # Override base resources with prod-specific domains and config
 patches:
   - path: patches.yaml

--- a/specs/OBS-007-cert-expiry-alerting/proposal.md
+++ b/specs/OBS-007-cert-expiry-alerting/proposal.md
@@ -1,7 +1,7 @@
 ---
 id: "OBS-007-cert-expiry-alerting"
 type: spec
-status: draft # draft | implementing | verifying | archived
+status: implementing # draft | implementing | verifying | archived
 created: "2026-08-09"
 issue: "kubelab#799"   # repo#NNN — GitHub issue / Project item that tracks this spec
 tags: [spec, proposal]
@@ -68,7 +68,9 @@ Two findings that shrink the work, both measured today rather than assumed:
 - [ ] The rule does **not** fire on the `Testing certificate renew…` heartbeat, verified by leaving it enabled through at least one heartbeat with no ACME failure present.
 - [ ] The alert payload names the affected domain and the environment it came from, so the recipient can act without opening Grafana.
 - [ ] The teardown of the induced failure returns the rule to `Normal` and a resolved notification is delivered, confirming the rule recovers rather than latching.
-- [ ] `kubectl kustomize` renders tag `log` for the staging overlay and tag `page` for the prod overlay — asserted against the **rendered output**, not the patch file. #927 is the precedent: a patch that looked correct changed nothing, and only reading the rendered field would have caught it.
+- [x] `kubectl kustomize` renders the `log` tier for the staging overlay and the `page` tier for the prod overlay — asserted against the **rendered output**, not the patch file. #927 is the precedent: a patch that looked correct changed nothing, and only reading the rendered field would have caught it. ✓ 2026-08-10 — `tests/test_grafana_alerting_render.py`
+
+  **Amended during implementation (2026-08-10).** The criterion originally said the rendered *tag* differs per environment. It does not, and should not: the two contact points (`apprise-page`, `apprise-log`) are byte-identical apart from one tag, so putting one in base and one in the overlay would have duplicated the whole payload template across two files and let the copies drift silently. Both contact points now ship in the shared base, and what the prod overlay overrides is the **root notification policy's `receiver`** — five lines instead of twenty-five, with drift made structurally impossible. The effective tier per environment is unchanged, which is what the criterion was for. The rendered-output requirement is untouched and is the half that carries the weight.
 
 ## References
 

--- a/specs/OBS-007-cert-expiry-alerting/tasks.md
+++ b/specs/OBS-007-cert-expiry-alerting/tasks.md
@@ -23,10 +23,27 @@ created: "2026-08-09"
 
 ### Phase 1 — the delivery path, proven end to end before any query exists
 
-- [ ] [P] [AC1] Add a test to `tests/infra/test_k3s.py` asserting Grafana's provisioning API returns a non-empty contact-point list. **Fails now** — measured `[]` in both environments.
-- [ ] [AC1] Add `infra/k8s/base/services/grafana-alerting/` with the contact point (`http://apprise:8000/notify/kubelab`, tag `log`) and a notification policy, wired via `configMapGenerator` with `files:` following the `grafana-dashboards` sibling. Add the `provisioning/alerting` volume and mount to the Grafana Deployment — the deployed-config-schema change that put this through the Discipline Gate.
-- [ ] [AC6] Patch the tag to `page` in the prod overlay, then assert `kubectl kustomize` renders `log` for staging and `page` for prod. **Read the rendered output, not the patch** — #927 is the precedent for why that distinction is the whole point.
-- [ ] [AC1] [AC2] Deploy to staging and prove delivery with a throwaway always-firing rule: confirm a Telegram message actually arrives. Then remove the rule. Until a message lands, nothing downstream is trustworthy.
+- [x] [P] [AC1] Add a test asserting Grafana's provisioning API returns a non-empty contact-point list. **Fails now** — measured `[]` in both environments. ✓ 2026-08-10 — landed in a new `tests/infra/test_grafana_alerting.py` rather than `test_k3s.py`, whose docstring scopes it to "node status, pods, PVCs". Observed failing against staging before the manifest existed. A second test was added alongside it: Grafana's default root policy has receiver `empty`, so a contact point can provision cleanly while every alert is still discarded.
+- [x] [AC1] Add `infra/k8s/base/services/grafana-alerting/` with the contact points and a notification policy, wired via `configMapGenerator` with `files:`. Add the `provisioning/alerting` volume and mount to the Grafana Deployment — the deployed-config-schema change that put this through the Discipline Gate. ✓ 2026-08-10. **Diverges from the `grafana-dashboards` sibling on purpose:** that generator sets `disableNameSuffixHash: true` because dashboards are re-read on a timer. Alerting provisioning is read once at startup, so the hash suffix is what rolls the pod on a rule change. Same rationale as `authelia-config`.
+- [x] [AC6] Route prod to the `page` tier in the overlay, then assert `kubectl kustomize` renders the right tier per environment. **Read the rendered output, not the patch.** ✓ 2026-08-10 — `tests/test_grafana_alerting_render.py`. See the AC6 amendment in `proposal.md`: the overridden field is the root policy's `receiver`, not the tag, which shrinks the per-environment surface from ~25 lines to 5 and makes drift structurally impossible. Negative control: rendering `infra/k8s/base` alone emits the staging value, so a no-op merge in prod is visible.
+- [x] [AC1] [AC2] Deploy to staging and prove delivery with a throwaway always-firing rule: confirm a Telegram message actually arrives. Then remove the rule. Until a message lands, nothing downstream is trustworthy. ✓ 2026-08-10 — operator confirmed both messages in the archive channel.
+  - Deployed to staging 2026-08-10; contact points provisioned and both AC1 tests went red -> green.
+  - **The ordering earned its keep immediately.** The first delivery attempt failed with `template: :1: unexpected ":=" in command` — Grafana's custom-payload parser rejects variable assignment. It failed at *delivery*, not at provisioning: the contact point was present and healthy in the API the whole time. Had the LogQL rule been written first, this would have looked like a query that matches nothing. Fixed by moving the conditional into a `templates.yaml` define, where full template syntax is accepted.
+
+> **Both branches exercised — corrected 2026-08-10.** This note first recorded the
+> resolved path as unexercised, because the probe rule was deleted without checking
+> for a resolved delivery. It was wrong: deleting the rule DID fire the resolve, and
+> the operator received both messages five minutes apart —
+> `firing: OBS-007 delivery probe` then `resolved: OBS-007 delivery probe`. So the
+> `apprise.type` else-branch and `disableResolveMessage: false` are both confirmed
+> working, and AC5's *mechanism* is proven for the delivery path. AC5 itself still
+> belongs to phase 3, which must show the real ACME rule recovers rather than latches.
+>
+> The delivered body also settles AC4 ahead of schedule: it carried
+> `Domain: probe.staging.kubelab.live` from the rule's label and
+> `Source: https://grafana.staging.kubelab.live/` from `.ExternalURL`, so the
+> recipient can identify both the domain and the environment without opening Grafana
+> — and without any per-environment value in the config.
 
 ### Phase 2 — the query, on a delivery path already known to work
 
@@ -48,7 +65,7 @@ created: "2026-08-09"
 
 - [ ] Record in `docs/runbooks/` what a firing alert looks like and what to do about it. An alert whose recipient does not know the next step is a notification, not an alert. (Housekeeping, not tied to a criterion — it documents the change rather than producing an observable behaviour.)
 - [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
-- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command — **still owed; not started.** The file does not exist yet.
 - [ ] `make test-infra ENV=staging` and `ENV=prod` green
 - [ ] Type checks pass (`make type`)
 - [ ] Lint passes (`make lint`)

--- a/tests/infra/test_grafana_alerting.py
+++ b/tests/infra/test_grafana_alerting.py
@@ -9,11 +9,18 @@ That distinction is the point: a mounted ConfigMap proves a file arrived, wherea
 the provisioning API proves Grafana parsed it and accepted it. A malformed rule
 mounts perfectly and provisions nothing.
 
-Auth note: the provisioning API is admin-only, so these run through
-`kubectl exec` with the credentials from the `grafana-admin` Secret rather than
-through the public route as `testuser` (a Viewer, which gets 403). The admin
-username is READ FROM THE SECRET, never hardcoded — see AUTH-002 (#951), where
-prod's Grafana database kept the built-in `admin` because
+Two deliberate choices about how the API is reached, both from review on #953:
+
+  - **`kubectl port-forward` plus a local HTTP client, not `kubectl exec … wget`.**
+    The provisioning API is admin-only, and passing `Authorization: Basic …` as an
+    exec argument puts the credential where `ps` can read it locally AND inside the
+    `pods/exec` request URI, which the API server's audit log retains. With a
+    port-forward the header never leaves this process.
+  - **Argument lists, never `shell=True`.** `env` arrives from the `--env` pytest
+    option, so interpolating it into a shell string would let its value execute.
+
+Auth note: the admin username is READ FROM THE SECRET, never hardcoded — see
+AUTH-002 (#951), where prod's Grafana database kept the built-in `admin` because
 `GF_SECURITY_ADMIN_USER` is honoured only at database creation while the Secret
 has declared `manu` for months.
 """
@@ -23,7 +30,12 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import subprocess
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterator
 from typing import Any
 
 import pytest
@@ -31,25 +43,30 @@ import pytest
 pytestmark = pytest.mark.infra
 
 _KUBECONFIG_PATTERN = "~/.kube/kubelab-{env}-config"
+_PORT_FORWARD_READY_TIMEOUT = 20.0
 
-#: The Apprise endpoint the contact point must target. Stated literally rather
+#: The Apprise endpoint the contact points must target. Stated literally rather
 #: than parsed from the manifest under test: a test that reads its expectation
 #: from the file it validates compares intent against intent and passes for any
 #: value (docs/lessons.md, 2026-08-09 — `tls: {}`).
 EXPECTED_APPRISE_URL = "http://apprise:8000/notify/kubelab"
 
-#: Per-environment Apprise tag. Prod pages, staging archives (ADR-044 tiers).
+#: Which Apprise tier each environment must actually route to. Prod pages,
+#: staging archives (ADR-044 tiers). An environment absent from this map is a
+#: hard failure, not a skip: `--env` accepts any string, and silently passing on
+#: an unknown environment would make this whole module vacuous for that value.
 EXPECTED_TAG_BY_ENV = {"staging": "log", "prod": "page"}
 
 
 def _kubeconfig(env: str) -> str:
+    """Path to the per-environment kubeconfig."""
     return os.path.expanduser(_KUBECONFIG_PATTERN.format(env=env))
 
 
-def _kubectl(args: str, env: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+def _kubectl(args: list[str], env: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    """Run kubectl with a fixed argument list — no shell, so `env` cannot execute."""
     return subprocess.run(
-        f"kubectl --kubeconfig {_kubeconfig(env)} {args}",
-        shell=True,
+        ["kubectl", "--kubeconfig", _kubeconfig(env), *args],
         capture_output=True,
         text=True,
         check=False,
@@ -58,61 +75,118 @@ def _kubectl(args: str, env: str, timeout: int = 30) -> subprocess.CompletedProc
 
 
 def _secret_value(env: str, key: str) -> str:
+    """Decode one key of the `grafana-admin` Secret."""
     result = _kubectl(
-        f"get secret grafana-admin -n kubelab -o jsonpath='{{.data.{key}}}'", env
+        ["get", "secret", "grafana-admin", "-n", "kubelab", "-o", f"jsonpath={{.data.{key}}}"],
+        env,
     )
     if result.returncode != 0 or not result.stdout.strip():
         pytest.skip(f"Secret grafana-admin has no '{key}' in {env}: {result.stderr.strip()}")
     return base64.b64decode(result.stdout.strip()).decode()
 
 
+#: A callable that GETs a provisioning path and returns the parsed body.
+ProvisioningGet = Callable[[str], Any]
+
+
 @pytest.fixture(scope="module")
-def grafana_reachable(env: str) -> None:
-    """Skip when the cluster or the Grafana pod is not there to answer."""
+def grafana_api(env: str) -> Iterator[ProvisioningGet]:
+    """Yield an authenticated getter for Grafana's provisioning API.
+
+    Opens one `kubectl port-forward` for the module and closes it afterwards. The
+    local port is chosen by the kernel and read back from kubectl's output, so
+    concurrent sessions (this repo is worked in parallel worktrees) cannot collide
+    on a hardcoded port.
+    """
     if not os.path.exists(_kubeconfig(env)):
         pytest.skip(f"Kubeconfig not found: {_kubeconfig(env)}")
-    result = _kubectl("get deploy grafana -n kubelab -o name", env, timeout=15)
-    if result.returncode != 0:
-        pytest.skip(f"Grafana unreachable in {env}: {result.stderr.strip()}")
+    if _kubectl(["get", "deploy", "grafana", "-n", "kubelab", "-o", "name"], env, timeout=15).returncode != 0:
+        pytest.skip(f"Grafana unreachable in {env}")
+
+    user = _secret_value(env, "admin-user")
+    auth = base64.b64encode(f"{user}:{_secret_value(env, 'password')}".encode()).decode()
+
+    proc = subprocess.Popen(
+        ["kubectl", "--kubeconfig", _kubeconfig(env), "port-forward",
+         "-n", "kubelab", "deploy/grafana", ":3000"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True,
+    )
+    try:
+        port = _await_port(proc)
+        if port is None:
+            pytest.skip(f"port-forward to Grafana in {env} never became ready")
+
+        def get(path: str) -> Any:
+            """GET one provisioning path over the open port-forward."""
+            return _get_provisioning(port, auth, path, env=env, user=user)
+
+        yield get
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
 
 
-def _provisioning(path: str, env: str) -> Any:
-    """GET Grafana's provisioning API from inside the pod, as the declared admin.
+def _await_port(proc: subprocess.Popen[str]) -> int | None:
+    """Read the local port kubectl chose, or None if it never reported one."""
+    deadline = time.monotonic() + _PORT_FORWARD_READY_TIMEOUT
+    assert proc.stdout is not None
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if not line:
+            if proc.poll() is not None:
+                return None
+            continue
+        if match := re.search(r"Forwarding from 127\.0\.0\.1:(\d+)", line):
+            return int(match.group(1))
+    return None
 
-    Three outcomes are kept distinct on purpose, because collapsing them is how a
-    check comes to report success on the thing it exists to catch:
 
-      - transport failure  -> skip (the cluster could not be asked)
-      - HTTP 401           -> skip naming #951 (the DECLARED identity was refused;
-                              this is an identity defect, not an alerting one)
-      - HTTP 200           -> return the parsed body, and let the caller assert
+def _get_provisioning(port: int, auth: str, path: str, *, env: str, user: str) -> Any:
+    """GET a provisioning path, keeping three outcomes distinct.
+
+    Collapsing them is how a check comes to report success on the very thing it
+    exists to catch:
+
+      - transport failure -> skip (the cluster could not be asked)
+      - HTTP 401          -> skip naming #951 (the DECLARED identity was refused;
+                             an identity defect, not an alerting one)
+      - HTTP 200          -> return the parsed body, and let the caller assert
 
     A 401 must never surface as "no contact points" — that would read as this
-    spec's own failure and send the next person to the wrong file entirely.
+    spec's own failure and send the next person to entirely the wrong file.
     """
-    user = _secret_value(env, "admin-user")
-    password = _secret_value(env, "password")
-    auth = base64.b64encode(f"{user}:{password}".encode()).decode()
-
-    result = _kubectl(
-        "exec -n kubelab deploy/grafana -- wget -qO- "
-        f'--header="Authorization: Basic {auth}" '
-        f"http://localhost:3000/api/v1/provisioning/{path}",
-        env,
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{port}/api/v1/provisioning/{path}",
+        headers={"Authorization": f"Basic {auth}"},
     )
-
-    if result.returncode != 0:
-        combined = f"{result.stdout} {result.stderr}"
-        if "401" in combined:
+    try:
+        with urllib.request.urlopen(request, timeout=20) as response:
+            return json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        if exc.code == 401:
             pytest.skip(
                 f"Grafana in {env} refused the admin user '{user}' declared in the "
                 f"grafana-admin Secret (HTTP 401). This is AUTH-002 (#951) — the "
                 f"database kept a different username — NOT an alerting defect. "
                 f"OBS-007 cannot be verified in {env} until #951 is fixed."
             )
-        pytest.skip(f"Could not query Grafana provisioning API in {env}: {combined.strip()}")
+        pytest.skip(f"Grafana provisioning API returned HTTP {exc.code} in {env}")
+    except (urllib.error.URLError, TimeoutError) as exc:
+        pytest.skip(f"Could not reach Grafana's provisioning API in {env}: {exc}")
 
-    return json.loads(result.stdout)
+
+def _expected_tag(env: str) -> str:
+    """The tier `env` must route to. Unknown environments fail rather than skip."""
+    if env not in EXPECTED_TAG_BY_ENV:
+        pytest.fail(
+            f"No expected Apprise tier declared for environment {env!r}. Add it to "
+            f"EXPECTED_TAG_BY_ENV — skipping here would make this module silently "
+            f"vacuous for that environment."
+        )
+    return EXPECTED_TAG_BY_ENV[env]
 
 
 class TestAlertDelivery:
@@ -124,16 +198,17 @@ class TestAlertDelivery:
     way to separate them.
     """
 
-    def test_contact_point_is_provisioned(self, grafana_reachable: None, env: str) -> None:
-        """Grafana must hold a contact point pointing at Apprise.
+    def test_contact_points_target_apprise(self, grafana_api: ProvisioningGet, env: str) -> None:
+        """Grafana must hold contact points pointing at Apprise.
 
-        Fails today: measured `[]` in staging and prod on 2026-08-10.
+        Failed before the manifests existed: measured `[]` in staging and prod on
+        2026-08-10.
         """
-        contact_points = _provisioning("contact-points", env)
+        contact_points = grafana_api("contact-points")
 
         assert contact_points, (
             f"Grafana in {env} has NO contact points, so a firing alert reaches nobody. "
-            f"Expected one targeting {EXPECTED_APPRISE_URL}."
+            f"Expected ones targeting {EXPECTED_APPRISE_URL}."
         )
 
         urls = [
@@ -147,18 +222,53 @@ class TestAlertDelivery:
             f"so this endpoint needs no credential)."
         )
 
-    def test_notification_policy_routes_to_apprise(self, grafana_reachable: None, env: str) -> None:
-        """A contact point nothing routes to is decoration.
+    def test_policy_routes_to_the_tier_for_this_environment(
+        self, grafana_api: ProvisioningGet, env: str
+    ) -> None:
+        """Prod must page and staging must archive — asserted, not assumed.
 
-        Grafana ships a default policy whose receiver is the literal string
-        `empty` — measured in staging on 2026-08-10. A contact point can therefore
-        exist and provision cleanly while every alert still goes nowhere, which is
-        precisely the failure this asserts against.
+        Two failures are covered here. Grafana ships a default root policy whose
+        receiver is the literal string `empty` (measured in staging on
+        2026-08-10), so a contact point can provision cleanly while every alert is
+        discarded. And an overlay that merges the wrong way round would leave
+        staging paging, which is silent until it wakes someone at 3 AM.
         """
-        policy = _provisioning("policies", env)
-        receiver = policy.get("receiver")
+        expected_receiver = f"apprise-{_expected_tag(env)}"
+        receiver = grafana_api("policies").get("receiver")
 
         assert receiver and receiver != "empty", (
-            f"Grafana in {env} still routes to the default receiver "
-            f"{receiver!r} — alerts are evaluated and then discarded."
+            f"Grafana in {env} still routes to the default receiver {receiver!r} — "
+            f"alerts are evaluated and then discarded."
+        )
+        assert receiver == expected_receiver, (
+            f"Grafana in {env} routes to {receiver!r}, expected {expected_receiver!r}. "
+            f"Prod pages and staging archives (ADR-044 tiers); routing staging to the "
+            f"push tier would interrupt for a non-critical, on-demand environment."
+        )
+
+    def test_selected_contact_point_carries_the_right_tag(
+        self, grafana_api: ProvisioningGet, env: str
+    ) -> None:
+        """The receiver name is not enough — Apprise routes on the payload tag.
+
+        A contact point could be named `apprise-page` and still carry `tag: log`
+        in its payload variables, in which case the policy looks right and every
+        page lands silently in the archive channel instead.
+        """
+        expected_tag = _expected_tag(env)
+        expected_receiver = f"apprise-{expected_tag}"
+
+        selected = [
+            cp for cp in grafana_api("contact-points") if cp.get("name") == expected_receiver
+        ]
+        assert selected, (
+            f"No contact point named {expected_receiver!r} exists in {env}, so the root "
+            f"policy routes to a receiver that is not there."
+        )
+
+        tag = selected[0].get("settings", {}).get("payload", {}).get("vars", {}).get("tag")
+        assert tag == expected_tag, (
+            f"Contact point {expected_receiver!r} in {env} sends Apprise tag {tag!r}, "
+            f"expected {expected_tag!r}. The name and the tag have diverged, so alerts "
+            f"would be delivered to the wrong Telegram channel while every name looks right."
         )

--- a/tests/infra/test_grafana_alerting.py
+++ b/tests/infra/test_grafana_alerting.py
@@ -1,0 +1,164 @@
+"""Infrastructure: Grafana alerting is provisioned from git, not clicked into the UI.
+
+OBS-007. Grafana held zero alert rules and zero contact points when this spec was
+written — measured, not assumed — so there was nothing watching certificate
+renewal and a five-week staging outage in June 2026 was found by a browser error.
+
+These assertions read Grafana's *provisioning* API rather than the filesystem.
+That distinction is the point: a mounted ConfigMap proves a file arrived, whereas
+the provisioning API proves Grafana parsed it and accepted it. A malformed rule
+mounts perfectly and provisions nothing.
+
+Auth note: the provisioning API is admin-only, so these run through
+`kubectl exec` with the credentials from the `grafana-admin` Secret rather than
+through the public route as `testuser` (a Viewer, which gets 403). The admin
+username is READ FROM THE SECRET, never hardcoded — see AUTH-002 (#951), where
+prod's Grafana database kept the built-in `admin` because
+`GF_SECURITY_ADMIN_USER` is honoured only at database creation while the Secret
+has declared `manu` for months.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import subprocess
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.infra
+
+_KUBECONFIG_PATTERN = "~/.kube/kubelab-{env}-config"
+
+#: The Apprise endpoint the contact point must target. Stated literally rather
+#: than parsed from the manifest under test: a test that reads its expectation
+#: from the file it validates compares intent against intent and passes for any
+#: value (docs/lessons.md, 2026-08-09 — `tls: {}`).
+EXPECTED_APPRISE_URL = "http://apprise:8000/notify/kubelab"
+
+#: Per-environment Apprise tag. Prod pages, staging archives (ADR-044 tiers).
+EXPECTED_TAG_BY_ENV = {"staging": "log", "prod": "page"}
+
+
+def _kubeconfig(env: str) -> str:
+    return os.path.expanduser(_KUBECONFIG_PATTERN.format(env=env))
+
+
+def _kubectl(args: str, env: str, timeout: int = 30) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        f"kubectl --kubeconfig {_kubeconfig(env)} {args}",
+        shell=True,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=timeout,
+    )
+
+
+def _secret_value(env: str, key: str) -> str:
+    result = _kubectl(
+        f"get secret grafana-admin -n kubelab -o jsonpath='{{.data.{key}}}'", env
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        pytest.skip(f"Secret grafana-admin has no '{key}' in {env}: {result.stderr.strip()}")
+    return base64.b64decode(result.stdout.strip()).decode()
+
+
+@pytest.fixture(scope="module")
+def grafana_reachable(env: str) -> None:
+    """Skip when the cluster or the Grafana pod is not there to answer."""
+    if not os.path.exists(_kubeconfig(env)):
+        pytest.skip(f"Kubeconfig not found: {_kubeconfig(env)}")
+    result = _kubectl("get deploy grafana -n kubelab -o name", env, timeout=15)
+    if result.returncode != 0:
+        pytest.skip(f"Grafana unreachable in {env}: {result.stderr.strip()}")
+
+
+def _provisioning(path: str, env: str) -> Any:
+    """GET Grafana's provisioning API from inside the pod, as the declared admin.
+
+    Three outcomes are kept distinct on purpose, because collapsing them is how a
+    check comes to report success on the thing it exists to catch:
+
+      - transport failure  -> skip (the cluster could not be asked)
+      - HTTP 401           -> skip naming #951 (the DECLARED identity was refused;
+                              this is an identity defect, not an alerting one)
+      - HTTP 200           -> return the parsed body, and let the caller assert
+
+    A 401 must never surface as "no contact points" — that would read as this
+    spec's own failure and send the next person to the wrong file entirely.
+    """
+    user = _secret_value(env, "admin-user")
+    password = _secret_value(env, "password")
+    auth = base64.b64encode(f"{user}:{password}".encode()).decode()
+
+    result = _kubectl(
+        "exec -n kubelab deploy/grafana -- wget -qO- "
+        f'--header="Authorization: Basic {auth}" '
+        f"http://localhost:3000/api/v1/provisioning/{path}",
+        env,
+    )
+
+    if result.returncode != 0:
+        combined = f"{result.stdout} {result.stderr}"
+        if "401" in combined:
+            pytest.skip(
+                f"Grafana in {env} refused the admin user '{user}' declared in the "
+                f"grafana-admin Secret (HTTP 401). This is AUTH-002 (#951) — the "
+                f"database kept a different username — NOT an alerting defect. "
+                f"OBS-007 cannot be verified in {env} until #951 is fixed."
+            )
+        pytest.skip(f"Could not query Grafana provisioning API in {env}: {combined.strip()}")
+
+    return json.loads(result.stdout)
+
+
+class TestAlertDelivery:
+    """The delivery path must exist before any alert rule is worth writing.
+
+    Ordering is deliberate (see specs/OBS-007-cert-expiry-alerting/tasks.md): with
+    the contact point proven first, a silent alert in phase 2 can only be the
+    query. Build the rule first and a silent alert has two candidate causes and no
+    way to separate them.
+    """
+
+    def test_contact_point_is_provisioned(self, grafana_reachable: None, env: str) -> None:
+        """Grafana must hold a contact point pointing at Apprise.
+
+        Fails today: measured `[]` in staging and prod on 2026-08-10.
+        """
+        contact_points = _provisioning("contact-points", env)
+
+        assert contact_points, (
+            f"Grafana in {env} has NO contact points, so a firing alert reaches nobody. "
+            f"Expected one targeting {EXPECTED_APPRISE_URL}."
+        )
+
+        urls = [
+            cp.get("settings", {}).get("url")
+            for cp in contact_points
+            if cp.get("type") == "webhook"
+        ]
+        assert EXPECTED_APPRISE_URL in urls, (
+            f"No webhook contact point targets Apprise in {env}. Found: {urls or 'none'}. "
+            f"Expected {EXPECTED_APPRISE_URL} (ADR-044: Apprise owns the tag->URL map, "
+            f"so this endpoint needs no credential)."
+        )
+
+    def test_notification_policy_routes_to_apprise(self, grafana_reachable: None, env: str) -> None:
+        """A contact point nothing routes to is decoration.
+
+        Grafana ships a default policy whose receiver is the literal string
+        `empty` — measured in staging on 2026-08-10. A contact point can therefore
+        exist and provision cleanly while every alert still goes nowhere, which is
+        precisely the failure this asserts against.
+        """
+        policy = _provisioning("policies", env)
+        receiver = policy.get("receiver")
+
+        assert receiver and receiver != "empty", (
+            f"Grafana in {env} still routes to the default receiver "
+            f"{receiver!r} — alerts are evaluated and then discarded."
+        )

--- a/tests/test_grafana_alerting_render.py
+++ b/tests/test_grafana_alerting_render.py
@@ -1,0 +1,158 @@
+"""OBS-007 / AC6: the per-environment alert tier must be checked in the RENDER.
+
+The prod overlay overrides one key of the `grafana-alerting` ConfigMap so that
+prod pages and staging archives. Every way of checking that by reading the
+overlay files is a check of intent against intent — the patch says what it wants,
+and says nothing about whether Kustomize honoured it.
+
+That distinction is not theoretical here. `overlays/prod/patches.yaml` carried a
+`tls: {}` block, complete with a comment claiming it removed the base's ACME
+resolver. An empty map in a strategic-merge patch means "change nothing", so the
+resolver survived and prod retried an impossible Let's Encrypt order roughly once
+a day for months. Every file-reading check agreed with the comment. Only the
+rendered output disagreed (docs/lessons.md, 2026-08-09; fixed in #927).
+
+So these assertions run `kubectl kustomize` and read what comes out.
+
+The base default is deliberately the STAGING value, which makes the failure mode
+observable: if the prod merge ever stops taking effect, prod renders
+`apprise-log` and `test_prod_and_staging_differ` fails. Verified by rendering
+`infra/k8s/base` alone on 2026-08-10 — it emits `apprise-log`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+#: Which Apprise tier each environment routes to. Stated here rather than read
+#: from the manifests: an expectation sourced from the file under test passes for
+#: any pair of values.
+EXPECTED_RECEIVER = {"staging": "apprise-log", "prod": "apprise-page"}
+
+#: Every key the ConfigMap must still carry after the prod overlay merges into
+#: it. `behavior: merge` keeps the siblings; `behavior: replace` would drop them
+#: and leave prod routing to a receiver that no longer exists — a failure that
+#: only shows up as alerts going nowhere.
+REQUIRED_KEYS = {"contact-points.yaml", "templates.yaml", "policies.yaml"}
+
+
+def _kustomize(path: str) -> list[dict]:
+    """Render a Kustomize directory, or skip loudly if kubectl is unavailable.
+
+    A skip here means CANNOT CHECK, which is not the same as OK and must never be
+    reported as one. GitHub-hosted runners may not carry kubectl; a developer
+    workstation and any pre-deploy run do.
+    """
+    if shutil.which("kubectl") is None:
+        pytest.skip(
+            "CANNOT CHECK: kubectl is not installed, so the rendered output cannot be "
+            "produced. This is not a pass — AC6 is unverified in this environment. "
+            "Run `make test` on a workstation, or before `make deploy-k8s`."
+        )
+
+    result = subprocess.run(
+        ["kubectl", "kustomize", str(REPO_ROOT / path)],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        pytest.fail(f"kubectl kustomize {path} failed:\n{result.stderr}")
+
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def _alerting_configmap(env: str) -> dict:
+    docs = _kustomize(f"infra/k8s/overlays/{env}")
+    cms = [
+        d
+        for d in docs
+        if d.get("kind") == "ConfigMap"
+        and d.get("metadata", {}).get("name", "").startswith("grafana-alerting")
+    ]
+    assert len(cms) == 1, (
+        f"Expected exactly one grafana-alerting ConfigMap in the {env} render, found "
+        f"{[c['metadata']['name'] for c in cms]}. Two would mean the overlay generator "
+        f"minted a second object instead of merging into the base one."
+    )
+    return cms[0]
+
+
+def _rendered_receiver(cm: dict) -> str:
+    policies = yaml.safe_load(cm["data"]["policies.yaml"])
+    return policies["policies"][0]["receiver"]
+
+
+class TestRenderedAlertTier:
+    """Read the emitted manifest, never the patch."""
+
+    @pytest.mark.parametrize("env", sorted(EXPECTED_RECEIVER))
+    def test_rendered_receiver_matches_the_tier(self, env: str) -> None:
+        cm = _alerting_configmap(env)
+        actual = _rendered_receiver(cm)
+
+        assert actual == EXPECTED_RECEIVER[env], (
+            f"{env} renders root receiver {actual!r}, expected "
+            f"{EXPECTED_RECEIVER[env]!r}. Prod must page and staging must archive "
+            f"(ADR-044 tiers). Check the configMapGenerator merge in "
+            f"infra/k8s/overlays/{env}/kustomization.yaml."
+        )
+
+    @pytest.mark.parametrize("env", sorted(EXPECTED_RECEIVER))
+    def test_merge_preserves_the_shared_keys(self, env: str) -> None:
+        """`behavior: replace` would silently drop the contact points."""
+        cm = _alerting_configmap(env)
+        missing = REQUIRED_KEYS - set(cm["data"])
+
+        assert not missing, (
+            f"The {env} render is missing {sorted(missing)} from the grafana-alerting "
+            f"ConfigMap. If the overlay uses `behavior: replace` instead of `merge`, "
+            f"the base keys are dropped and the policy routes to a receiver that "
+            f"does not exist — alerts are then discarded silently."
+        )
+
+    def test_policies_differ_only_in_the_receiver(self) -> None:
+        """The receiver is the ONLY field the overlay is allowed to change.
+
+        Design B keeps the per-environment surface to one file, but that file is
+        still a full copy of the policy — so `group_wait`, `group_interval` and
+        `repeat_interval` can drift apart between base and prod with nothing to
+        notice. This is the only drift surface the design leaves open, and it
+        costs one assertion to close.
+        """
+        staging = yaml.safe_load(_alerting_configmap("staging")["data"]["policies.yaml"])
+        prod = yaml.safe_load(_alerting_configmap("prod")["data"]["policies.yaml"])
+
+        s_policy = dict(staging["policies"][0])
+        p_policy = dict(prod["policies"][0])
+        s_policy.pop("receiver")
+        p_policy.pop("receiver")
+
+        assert s_policy == p_policy, (
+            "The staging and prod notification policies differ in a field other than "
+            "`receiver`. Only the tier may vary per environment; timing and grouping "
+            f"must not drift.\n  staging: {s_policy}\n  prod:    {p_policy}"
+        )
+
+    def test_prod_and_staging_differ(self) -> None:
+        """The whole point of the overlay. Guards against a no-op merge.
+
+        If the prod merge stops taking effect, prod inherits the base value and
+        this fails — which is the specific silent failure #927 taught.
+        """
+        staging = _rendered_receiver(_alerting_configmap("staging"))
+        prod = _rendered_receiver(_alerting_configmap("prod"))
+
+        assert staging != prod, (
+            f"Both environments render the same receiver {staging!r}, so the prod "
+            f"overlay changed nothing. The base default is the staging value, so "
+            f"this is what a no-op merge looks like."
+        )

--- a/tests/test_grafana_alerting_render.py
+++ b/tests/test_grafana_alerting_render.py
@@ -47,8 +47,15 @@ def _kustomize(path: str) -> list[dict]:
     """Render a Kustomize directory, or skip loudly if kubectl is unavailable.
 
     A skip here means CANNOT CHECK, which is not the same as OK and must never be
-    reported as one. GitHub-hosted runners may not carry kubectl; a developer
-    workstation and any pre-deploy run do.
+    reported as one.
+
+    Note on where this actually runs: no CI workflow invokes pytest at all — CI
+    runs `go test` for the API plus bandit/pip-audit over the toolkit, and the
+    Python suite executes only on a workstation (there is no pre-commit pytest
+    hook either). So this guard exists for the local case, not for CI, and the
+    coverage question for this module is answered by whoever runs `make test`
+    before deploying. Tracked separately; do not read a green PR as having run
+    these assertions.
     """
     if shutil.which("kubectl") is None:
         pytest.skip(
@@ -71,6 +78,7 @@ def _kustomize(path: str) -> list[dict]:
 
 
 def _alerting_configmap(env: str) -> dict:
+    """The single grafana-alerting ConfigMap emitted by an overlay's render."""
     docs = _kustomize(f"infra/k8s/overlays/{env}")
     cms = [
         d
@@ -87,6 +95,7 @@ def _alerting_configmap(env: str) -> dict:
 
 
 def _rendered_receiver(cm: dict) -> str:
+    """The root notification policy's receiver, as actually rendered."""
     policies = yaml.safe_load(cm["data"]["policies.yaml"])
     return policies["policies"][0]["receiver"]
 
@@ -96,6 +105,7 @@ class TestRenderedAlertTier:
 
     @pytest.mark.parametrize("env", sorted(EXPECTED_RECEIVER))
     def test_rendered_receiver_matches_the_tier(self, env: str) -> None:
+        """Each environment must render its own tier: prod pages, staging archives."""
         cm = _alerting_configmap(env)
         actual = _rendered_receiver(cm)
 


### PR DESCRIPTION
Phase 1 of OBS-007 (#799): build and prove the alert **delivery path** before writing any query.

Grafana held zero contact points and zero alert rules — measured on both clusters, not assumed. There was nothing watching certificate renewal, which is why a five-week staging outage in June was found by a browser error rather than by an alert, and why a live prod ACME failure repeated daily for months until #927.

## What this adds

```
infra/k8s/base/services/grafana-alerting/
  contact-points.yaml   both tiers: apprise-page, apprise-log
  templates.yaml        shared message body + type, defined once
  policies.yaml         root policy -> apprise-log   (staging value)
infra/k8s/overlays/prod/grafana-alerting/
  policies.yaml         root policy -> apprise-page  (the only per-env file)
```

Plus the `provisioning/alerting` volume and mount on the Grafana Deployment — the deployed-config-schema change that put this through the Discipline Gate.

No alert rule yet. That is phase 2, deliberately.

## Proof, not inference

A throwaway always-firing rule was created through the provisioning API, observed, then deleted:

```
03:59:13  apprise: POST /notify/kubelab 200 "Grafana"
          NOTIFY - Delivered Notification(s) - Tags: log
```

Both messages arrived in the archive channel and were confirmed by the operator — `firing`, then `resolved` five minutes later when the rule was deleted. The delivered body carried `Domain: probe.staging.kubelab.live` and `Source: https://grafana.staging.kubelab.live/`, so AC4's "names the domain and the environment" is already satisfied, and `.ExternalURL` supplies the environment with no per-environment value in the config.

## Why the ordering mattered

The contact point provisioned cleanly, `GET /api/v1/provisioning/contact-points` returned it, and the new test went green — and the first real send still failed:

```
notify retry canceled due to unrecoverable error after 1 attempts:
template: :1: unexpected ":=" in command
```

Grafana's custom **payload** parser rejects variable assignment, which ordinary Go templates accept and which is fine inside a `templates.yaml` define. It fails at *delivery*, never at provisioning. Had the LogQL rule been written first, this would have presented as a query that matches nothing — two candidate causes and no way to separate them.

A second trap sits behind it: Grafana applies newly provisioned alerting config roughly **60 seconds after the pod starts**, not at startup. For that first minute the old config is still notifying, so a fix looks like it did not work.

Both are recorded in `docs/lessons.md`.

## Design note: where the per-environment seam sits

The two contact points are byte-identical apart from one tag, so splitting them across base and overlay would have duplicated the whole payload template and let the copies drift. Instead both ship in the shared base and the overlay overrides the root policy's `receiver` — five lines instead of twenty-five, and a test asserts the two policy documents are identical modulo that one field, so even the remaining surface cannot drift.

This amends AC6, which originally said the rendered *tag* differs per environment. The amendment and its rationale are recorded in `proposal.md`; the rendered-output requirement is untouched and is the half that carries the weight.

`grafana-alerting` deliberately keeps its generated name hash, unlike its `grafana-dashboards` sibling which disables it. Dashboards are re-read on a timer; alerting provisioning is read once at startup, so the hash suffix is what rolls the pod on a rule change. Same rationale as `authelia-config`. There is a comment on the generator saying so, because "aligning" it with the sibling would silently stop rule changes taking effect.

## Checks run against states where they must fail

- The two provisioning tests were observed **red** against staging before the manifests existed (`assert []`, and the default root receiver `empty`).
- The render drift test was run against an **injected** `group_wait` change and observed failing, then the file was restored.
- Rendering `infra/k8s/base` alone emits the staging value, so a no-op merge in prod would be visible rather than silent.
- Inverting the expected tier makes the routing assertions fail, so they discriminate rather than restate.
- `test_grafana_alerting_render.py` skips loudly with `CANNOT CHECK` when kubectl is absent, rather than passing vacuously.

420 unit tests, `make lint`, `make type` all green. `make test-infra ENV=staging` green — **run on a workstation**.

> **These tests do not run in CI, and neither does any other Python test in this repo.** An earlier revision of this description claimed they would skip on CI for want of `kubectl`; that was wrong, and wrong in a way worth stating plainly. No workflow invokes pytest at all — CI runs `go test` for the API plus bandit/pip-audit over the toolkit, and there is no pytest pre-commit hook either. Filed as **#954**. Until that closes, a green check on this PR is not evidence that any assertion here executed.

## Known and tracked, not fixed here

**Prod AC1 verification is blocked on #951.** The prod test skips with a message naming that ticket rather than reporting a false pass: Grafana in prod refuses the admin username the `grafana-admin` Secret declares, because `GF_SECURITY_ADMIN_USER` is honoured only at database creation and prod's PVC predates it. Phases 2 and 3 do not depend on it; phase 4 does.

Found while establishing the baseline and filed rather than folded in:

- **#951 (AUTH-002)** — Grafana derives no role from Authelia groups (no `ROLE_ATTRIBUTE_PATH` anywhere), so `operator` is a member of `admins` and a Viewer in prod. Plus the admin-username drift above.
- **#952 (AUTH-003)** — no way to enumerate identities across the five planes; the above went unnoticed for months for exactly that reason.

#475 already covers the unpinned `grafana-oss:latest`, so no duplicate was filed.

Refs #799
