### PR TITLE
ci: run the Python test suite, lint and type checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,67 @@ jobs:
       - name: Validate Makefile
         run: make -n help >/dev/null
 
+  # The toolkit drives every deploy, renders every manifest and applies every
+  # secret, and until CI-001 its 420 tests ran only when a human remembered to.
+  # Several safeguards exist SPECIFICALLY to be runnable with the on-demand
+  # homelab powered off — tests/test_spoke_rbac_covers_manifests.py says so in
+  # its own docstring — and that promise was not being kept anywhere.
+  #
+  # Deliberately unconditional: no paths filter. A toolkit test can break from a
+  # change to infra/config/values (the tests read common.yaml as SSOT) or to
+  # infra/k8s (the RBAC and render tests walk the manifests), so filtering on
+  # `toolkit/**` would skip exactly the cross-cutting breakage worth catching.
+  # The job is well under a minute; a filter would buy nothing and cost coverage.
+  tests:
+    name: Tests
+    runs-on: >-
+      ${{ github.event.pull_request.head.repo.fork
+          && 'ubuntu-latest'
+          || fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install dependencies
+        # `make setup` also provisions SOPS, certs and Ansible — none of which a
+        # unit test touches, and all of which need credentials CI does not have.
+        run: poetry install --no-interaction --no-ansi
+
+      # Same three gates the Definition of Done requires locally, in the same
+      # order, through the same Makefile targets — so a green CI run and a green
+      # workstation run mean the same thing. Cluster-dependent suites carry the
+      # `infra`/`e2e` markers and are deselected by the pytest config, so nothing
+      # here needs VPN or a kubeconfig.
+      - name: Tests
+        run: make test
+
+      - name: Lint
+        run: make lint
+
+      - name: Types
+        run: make type
+
+      # Report, do not gate. `kubectl kustomize` renders the overlays for the
+      # OBS-007 tier assertions; if the runner image ever drops kubectl those
+      # tests skip with CANNOT CHECK rather than passing vacuously, and this step
+      # is how that becomes visible instead of silent.
+      - name: Record whether kubectl was available
+        if: always()
+        run: |
+          if command -v kubectl >/dev/null; then
+            kubectl version --client -o yaml | head -3 >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::warning::kubectl absent — rendered-manifest tests skipped"
+            echo "kubectl absent: rendered-manifest tests were CANNOT CHECK, not verified." \
+              >> "$GITHUB_STEP_SUMMARY"
+          fi
+
   detect-changes:
     name: Detect Changes
     needs: validate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,19 @@ jobs:
       ${{ github.event.pull_request.head.repo.fork
           && 'ubuntu-latest'
           || fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"') }}
+    env:
+      # Rich detects GitHub Actions and turns colour ON, which splits option
+      # names with escape codes: `--check` renders as
+      # `\x1b[1;36m-\x1b[0m\x1b[1;36m-check\x1b[0m`, so the CLI help tests in
+      # tests/test_sync.py cannot find their own substring. Measured, not
+      # guessed: `GITHUB_ACTIONS=true` reproduces it on a workstation and
+      # `TERM=dumb` fixes it, while NO_COLOR and FORCE_COLOR=0 do not.
+      #
+      # This makes CI deterministic; it does not make the assertions robust.
+      # Those tests match rendered human-facing output and would break again in
+      # any colour-enabled terminal — worth normalising at the assertion, which
+      # is a change to test_sync.py and therefore a different PR.
+      TERM: dumb
     steps:
       - uses: actions/checkout@v7
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ markers = [
     "slow: Slow running tests",
     "e2e: End-to-end tests (require network access to target environment)",
     "infra: Infrastructure tests (require VPN + SSH access to homelab nodes)",
+    "requires_sops: Needs real SOPS decryption (age key); skipped where unavailable",
 ]
 
 [tool.coverage.run]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,68 @@
 """Root conftest — shared pytest configuration and fixtures."""
 
+import functools
+import shutil
+
 import pytest
+
+
+@functools.lru_cache(maxsize=1)
+def sops_can_decrypt() -> bool:
+    """Whether this machine can actually decrypt the SOPS secrets.
+
+    True on a workstation with the age key, false on a runner without it. Mirrors
+    `_sops_available()` in toolkit/cli/sync.py, which already guards the drift
+    check the same way — same question, so the same answer shape.
+
+    Cached: decryption spawns `sops` and the answer cannot change mid-session.
+    """
+    if not shutil.which("sops"):
+        return False
+
+    # Import errors are NOT swallowed. A typo here would make this return False
+    # forever, silently skipping the thirteen tests it guards on every machine —
+    # which is exactly what happened while writing it (`toolkit.core.settings`
+    # does not exist; the real module is `toolkit.config.settings`). A guard that
+    # degrades to "always skip" is worse than no guard, because it reports green.
+    from toolkit.config.settings import settings
+    from toolkit.features.configuration import ConfigurationManager
+
+    try:
+        cm = ConfigurationManager("staging", settings.project_root)
+        sops_file = cm.secrets_path / "staging.enc.yaml"
+        return bool(sops_file.exists() and cm._decrypt_sops(sops_file))
+    except Exception:
+        # Only decryption failure lands here — the expected case on a runner
+        # without the age key.
+        return False
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Skip tests needing real SOPS material when it cannot be decrypted.
+
+    Thirteen tests assert that a generator's output is coherent with the values
+    in SOPS, so they need the age key rather than a fixture. They passed silently
+    for as long as the suite ran only on workstations; the first CI run failed
+    them with `assert ''` — the generator returning empty because nothing
+    decrypted — which reads as a code defect and is not one.
+
+    Skipping keeps that visible AND honest: a skip with this reason is CANNOT
+    CHECK, which is not OK, and it appears in the summary rather than being
+    deselected out of the count. The alternative — handing a test job the key
+    that decrypts every production secret in a public repo — is a security
+    decision, not a test-plumbing one, and is deliberately left to a human
+    (the `SOPS_AGE_KEY` repo secret exists but no workflow uses it).
+    """
+    if sops_can_decrypt():
+        return
+    skip = pytest.mark.skip(
+        reason="CANNOT CHECK: SOPS cannot decrypt here (no age key), so this "
+        "asserts against empty input rather than against the real values. Not a "
+        "pass — run `make test` on a workstation to actually exercise it."
+    )
+    for item in items:
+        if "requires_sops" in item.keywords:
+            item.add_marker(skip)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/test_k8s_secrets_apprise.py
+++ b/tests/test_k8s_secrets_apprise.py
@@ -12,10 +12,16 @@ test_k8s_secrets_users_db.py (the _build_users_database sibling generator).
 
 from __future__ import annotations
 
+import pytest
 import yaml
 
 from toolkit.features.configuration import ConfigurationManager
 from toolkit.features.k8s_secrets import _build_apprise_config
+
+#: Asserts the generator output against the REAL values in SOPS, so it needs the
+#: age key. Skipped (not deselected) where decryption is impossible, so the gap
+#: stays visible in the summary — see pytest_collection_modifyitems in conftest.
+pytestmark = pytest.mark.requires_sops
 
 # The notification fabric is staging-only until promoted to prod
 # (SECRET_CATALOG entries declare envs=("staging",)).

--- a/tests/test_k8s_secrets_users_db.py
+++ b/tests/test_k8s_secrets_users_db.py
@@ -16,6 +16,11 @@ import yaml
 from toolkit.features.configuration import ConfigurationManager
 from toolkit.features.k8s_secrets import _build_users_database
 
+#: Asserts the generator output against the REAL values in SOPS, so it needs the
+#: age key. Skipped (not deselected) where decryption is impossible, so the gap
+#: stays visible in the summary — see pytest_collection_modifyitems in conftest.
+pytestmark = pytest.mark.requires_sops
+
 
 @pytest.mark.parametrize("env", ["staging", "prod"])
 class TestUsersDatabaseGenerator:


### PR DESCRIPTION
The repo has 414 Python tests. No workflow ran any of them.

Found while answering "is it normal that the runners don't have kubectl?" during #953. The kubectl question turned out to be beside the point: there was nothing in CI to run those tests in the first place.

## What CI ran before this

| Job | What it checks |
|---|---|
| `Validate` | branch name, YAML syntax, `make -n help` |
| `API` | `go vet`, `go test -race ./...` — the **Go** API |
| `API`/`Errors` | gitleaks, bandit, pip-audit, gosec, govulncheck |
| `Drift`, `Sync check` | config drift, cross-platform sync |

`bandit` and `pip-audit` scan `toolkit/` for **security** issues. Neither executes a test. There is no pytest hook in `.pre-commit-config.yaml` either, so the Python suite ran only when a human remembered `make test`.

## Why this is worse than a missing job

Several safeguards were written specifically to be runnable when the on-demand homelab is powered off. `tests/test_spoke_rbac_covers_manifests.py` (TOOL-029, #950) says so in its own docstring — it reads manifest files rather than calling kubectl so it *"still runs on a GitHub-hosted runner with every node powered off — which is the case the other safeguard cannot cover."*

It did not run there. Neither did `tests/test_deploy_impersonation.py`. The safeguards were sound and nothing invoked them, so the stated reason for their design was not being met.

Same shape as the 2026-08-09 lessons, one level up: there the problem was a check that could not run, here the checks are fine and nothing calls them.

## What this adds

One `Tests` job running `make test`, `make lint` and `make type` — the same three gates the Definition of Done requires locally, through the same Makefile targets, so a green CI run and a green workstation run mean the same thing.

Two choices worth stating rather than leaving to be inferred:

- **No paths filter.** Toolkit tests read `infra/config/values/common.yaml` as SSOT and walk `infra/k8s/`, so scoping the job to `toolkit/**` would skip exactly the cross-cutting breakage worth catching. The job runs in well under a minute, so a filter buys nothing.
- **`poetry install`, not `make setup`.** `make setup` also provisions SOPS, certs and Ansible — none of which a unit test touches, and all of which need credentials CI does not have.

Cluster-dependent suites carry the `infra` / `e2e` pytest markers and are deselected by the config, so the job needs neither VPN nor a kubeconfig (`100 deselected` in a local run).

The final step records whether `kubectl` was present. It reports rather than gates: `tests/test_grafana_alerting_render.py` (in #953) skips with `CANNOT CHECK` when kubectl is missing rather than passing vacuously, and this makes that visible in the run summary instead of silent.

## Verified against a state where it must fail

Removing `configmaps` from the spoke write role in `infra/k8s/argocd/spoke-rbac.yaml` turns the suite red:

```
1 failed, 413 passed, 100 deselected
Kinds shipped in git that Argo CD's ServiceAccount cannot write.
```

Restored afterwards, confirmed byte-identical.

Worth recording that the **first** attempt at this control passed when it should have failed. That was the control's fault, not the suite's: it broke `IRREGULAR_PLURALS`, which is unreferenced because no manifest ships `kind: Endpoints`. Harmless as a defensive mapping, and left alone here to keep this PR to one concern — but it is the reason a control has to be chosen against data that actually exists, not merely against code that looks load-bearing.

Closes #954
