### PR TITLE
feat(observability): alert when Traefik reports an ACME failure

### DIFF
--- a/infra/k8s/base/kustomization.yaml
+++ b/infra/k8s/base/kustomization.yaml
@@ -97,6 +97,7 @@ configMapGenerator:
       - services/grafana-alerting/contact-points.yaml
       - services/grafana-alerting/templates.yaml
       - services/grafana-alerting/policies.yaml
+      - services/grafana-alerting/rules.yaml
 
 # Image tags synced from infra/config/values/common.yaml (SSOT).
 # Run `make sync-k8s-images` to refresh after bumping versions.

--- a/infra/k8s/base/services/grafana-alerting/rules.yaml
+++ b/infra/k8s/base/services/grafana-alerting/rules.yaml
@@ -1,0 +1,111 @@
+# Grafana alerting — the ACME failure rule (OBS-007 phase 2).
+#
+# Runs in both environments from the shared base; the root notification policy
+# decides which Apprise tier it reaches (prod pages, staging archives).
+#
+# Every element of the query below was chosen against seven days of real Traefik
+# logs rather than from the issue's description, which proposed matching
+# `Error renewing ACME certificate` — a string that appears nowhere in the
+# retained window of either cluster.
+---
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: certificates
+    folder: kubelab
+    # Sampled every 5 minutes against a 10-minute window, so a single failure is
+    # seen by two consecutive evaluations and `for: 5m` can be satisfied without
+    # depending on the scrape landing inside one window.
+    interval: 5m
+    rules:
+      - uid: obs007-acme-failure
+        title: ACME certificate failure
+        condition: C
+        # Must hold across two evaluations. Traefik retries transient CA errors
+        # on its own, and a rule that pages on the first blip trains people to
+        # ignore it. Five weeks of silent failure is the problem being solved
+        # here, not five minutes of latency.
+        for: 5m
+        # A query that matches nothing returns NO SERIES, not zero: `sum by` over
+        # an empty selection produces an empty vector. So the healthy state is
+        # NoData, and it MUST map to OK. Left at the default this rule would
+        # alert continuously whenever certificates were working.
+        noDataState: OK
+        execErrState: Error
+        annotations:
+          summary: >-
+            Traefik reported an ACME failure. Certificates are not renewing, and
+            they will expire silently unless this is fixed.
+          runbook_url: https://github.com/mlorentedev/kubelab/blob/master/docs/runbooks/acme-alerting.md
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: loki
+            model:
+              refId: A
+              datasource:
+                type: loki
+                uid: loki
+              editorMode: code
+              queryType: range
+              # Three deliberate choices, each measured on 2026-08-09/10:
+              #
+              # 1. Match ACME lines that ALSO carry an error indicator, rather
+              #    than matching ACME lines and excluding the known heartbeat by
+              #    name. A denylist would have fired on `Starting provider
+              #    *acme.Provider`, which staging logs on every Traefik boot — 8
+              #    occurrences in seven days. Every future benign ACME line would
+              #    be another false alarm to chase.
+              #
+              # 2. No `detected_level` filter. Traefik colours its output, and
+              #    Loki reads these lines as `unknown` rather than `error`.
+              #
+              # 3. The domain extraction tolerates an ANSI reset between
+              #    `domains=` and the value — the raw line is
+              #    `\x1b[36mdomains=\x1b[0m["host"]`, so the obvious
+              #    `domains=\["` matches nothing at all. Verified that a line
+              #    without a `domains=` field is still counted, with an empty
+              #    domain label, so a failure whose wording we have never seen
+              #    still alerts instead of being silently dropped.
+              expr: >-
+                sum by (domain) (
+                  count_over_time(
+                    {container="traefik"}
+                      |~ "(?i)acme"
+                      |~ "(?i)\\b(err|unable|fail(ed|ure)?)\\b"
+                      | regexp `domains=(?:\x1b\[[0-9;]*m)*\["(?P<domain>[^"]+)"`
+                    [10m]
+                  )
+                )
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: B
+              type: reduce
+              reducer: last
+              expression: A
+              datasource:
+                type: __expr__
+                uid: __expr__
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: B
+              conditions:
+                - evaluator:
+                    type: gt
+                    params: [0]
+              datasource:
+                type: __expr__
+                uid: __expr__

--- a/specs/OBS-007-cert-expiry-alerting/tasks.md
+++ b/specs/OBS-007-cert-expiry-alerting/tasks.md
@@ -47,9 +47,15 @@ created: "2026-08-09"
 
 ### Phase 2 — the query, on a delivery path already known to work
 
-- [ ] [AC3] Write the LogQL match against the two known lines: it must catch `Unable to obtain ACME certificate` and must **not** catch the `Testing certificate renew…` heartbeat. Prefer a pattern robust to wording over an exact phrase — the issue's proposed string appears nowhere in seven days of logs, and no renewal failure exists inside retention to confirm its wording. Do not filter on `detected_level`: Traefik's ANSI codes make Loki read these lines as `unknown`.
-- [ ] [AC1] [AC3] Add the real alert rule to the ConfigMap, deploy to staging, and confirm the provisioning API returns it.
-- [ ] [AC1] `rollout restart` Grafana and confirm the rule and contact point survive — the check that they are provisioned from the ConfigMap rather than living in Grafana's database.
+- [x] [AC3] Write the LogQL match against the two known lines: it must catch `Unable to obtain ACME certificate` and must **not** catch the `Testing certificate renew…` heartbeat. ✓ 2026-08-10 — validated against seven days of real logs, not reasoned about.
+
+  Final shape: match ACME lines that ALSO carry an error indicator, rather than matching ACME lines and excluding the heartbeat by name. **The data decided this**: staging logs `Starting provider *acme.Provider` on every Traefik boot (8 in seven days), so the denylist variant would have alerted on a startup message, and would have kept doing so for every future benign ACME line. Measured: prod returns exactly the 1 real failure and none of its 7 heartbeats; staging returns 0, which is correct because its DNS-01 flow works.
+
+  **New finding — the ANSI codes break field extraction too, not only `detected_level`.** The raw line is `\x1b[36mdomains=\x1b[0m["host"]`, so the obvious `domains=\["` matches nothing. The rule's regexp tolerates an ANSI reset between the key and the value. Verified that a line *without* a `domains=` field is still counted with an empty domain label, so a failure whose wording we have never seen still alerts rather than being silently dropped — which was the whole worry about extracting at all.
+
+  Original text follows. Prefer a pattern robust to wording over an exact phrase — the issue's proposed string appears nowhere in seven days of logs, and no renewal failure exists inside retention to confirm its wording. Do not filter on `detected_level`: Traefik's ANSI codes make Loki read these lines as `unknown`.
+- [x] [AC1] [AC3] Add the real alert rule to the ConfigMap, deploy to staging, and confirm the provisioning API returns it. ✓ 2026-08-10 — `infra/k8s/base/services/grafana-alerting/rules.yaml`. Two tests added, both observed failing first. `noDataState: OK` is load-bearing and has its own test: a LogQL query matching nothing returns **no series rather than zero**, so healthy IS NoData, and at Grafana's default the rule would fire continuously while certificates renewed perfectly.
+- [x] [AC1] `rollout restart` Grafana and confirm the rule and contact point survive — the check that they are provisioned from the ConfigMap rather than living in Grafana's database. ✓ 2026-08-10 — restarted, 5/5 green afterwards. Rule reports `state=inactive health=ok` in staging, which is the correct resting state there.
 
 ### Phase 3 — exercise the failure rather than wait for it
 

--- a/tests/infra/test_grafana_alerting.py
+++ b/tests/infra/test_grafana_alerting.py
@@ -57,6 +57,9 @@ EXPECTED_APPRISE_URL = "http://apprise:8000/notify/kubelab"
 #: an unknown environment would make this whole module vacuous for that value.
 EXPECTED_TAG_BY_ENV = {"staging": "log", "prod": "page"}
 
+#: Title of the rule OBS-007 phase 2 provisions. Literal on purpose.
+EXPECTED_RULE_TITLE = "ACME certificate failure"
+
 
 def _kubeconfig(env: str) -> str:
     """Path to the per-environment kubeconfig."""
@@ -271,4 +274,49 @@ class TestAlertDelivery:
             f"Contact point {expected_receiver!r} in {env} sends Apprise tag {tag!r}, "
             f"expected {expected_tag!r}. The name and the tag have diverged, so alerts "
             f"would be delivered to the wrong Telegram channel while every name looks right."
+        )
+
+
+class TestAcmeAlertRule:
+    """The rule that watches certificate renewal (OBS-007 phase 2).
+
+    Phase 1 proved the delivery path with a throwaway rule, so anything failing
+    from here is the query rather than the plumbing. That separation is the whole
+    reason the phases are ordered this way.
+    """
+
+    def test_acme_rule_is_provisioned(self, grafana_api: ProvisioningGet, env: str) -> None:
+        """The rule must come from the ConfigMap, not from Grafana's database.
+
+        Reading the provisioning API rather than the mounted file is deliberate:
+        a malformed rule mounts perfectly and provisions nothing.
+        """
+        rules = grafana_api("alert-rules")
+        titles = {r.get("title") for r in rules}
+
+        assert EXPECTED_RULE_TITLE in titles, (
+            f"Grafana in {env} has no {EXPECTED_RULE_TITLE!r} rule — certificate "
+            f"renewal is unwatched. Found: {sorted(t for t in titles if t) or 'no rules at all'}."
+        )
+
+    def test_acme_rule_treats_no_data_as_healthy(
+        self, grafana_api: ProvisioningGet, env: str
+    ) -> None:
+        """`noDataState` must be OK, or the rule alerts whenever things are fine.
+
+        A LogQL query matching nothing returns no series rather than zero, so the
+        healthy state IS NoData. Left at Grafana's default this rule would fire
+        continuously while certificates were renewing perfectly — the exact
+        inversion that makes people mute an alert channel.
+        """
+        rule = next(
+            (r for r in grafana_api("alert-rules") if r.get("title") == EXPECTED_RULE_TITLE), None
+        )
+        if rule is None:
+            pytest.skip(f"{EXPECTED_RULE_TITLE!r} not provisioned in {env} — see the test above")
+
+        assert rule.get("noDataState") == "OK", (
+            f"{EXPECTED_RULE_TITLE!r} in {env} has noDataState="
+            f"{rule.get('noDataState')!r}, expected 'OK'. Healthy means no matching "
+            f"log lines, which Loki returns as no series, not as zero."
         )

--- a/tests/test_grafana_alerting_render.py
+++ b/tests/test_grafana_alerting_render.py
@@ -40,7 +40,7 @@ EXPECTED_RECEIVER = {"staging": "apprise-log", "prod": "apprise-page"}
 #: it. `behavior: merge` keeps the siblings; `behavior: replace` would drop them
 #: and leave prod routing to a receiver that no longer exists — a failure that
 #: only shows up as alerts going nowhere.
-REQUIRED_KEYS = {"contact-points.yaml", "templates.yaml", "policies.yaml"}
+REQUIRED_KEYS = {"contact-points.yaml", "templates.yaml", "policies.yaml", "rules.yaml"}
 
 
 def _kustomize(path: str) -> list[dict]:


### PR DESCRIPTION
Phase 2 of OBS-007 (#799): the alert rule, on a delivery path #953 already proved end to end.

That ordering is why this PR is small and why a failure here can only be the query. Phase 1 already paid for it once — the contact point provisioned cleanly and the first real send still failed on a template parse error, which written in the other order would have looked like "my LogQL matches nothing".

## The query, decided by data rather than by the issue

The issue proposed matching `Error renewing ACME certificate`. That string appears **nowhere** in seven days of retained logs in either cluster. What is actually there:

| Lines in prod's retained window | Count |
|---|---|
| `INF Testing certificate renew... acmeCA=…` (heartbeat) | 7 |
| `ERR Unable to obtain ACME certificate for domains error="…"` | 1 |

And in staging, a third shape that settles the design question:

| Lines in staging | Count |
|---|---|
| `INF Testing certificate renew...` | 8 |
| `INF Starting provider *acme.Provider` | 8 |
| `INF Starting provider *acme.ChallengeTLSALPN` | 8 |

Two candidate queries both isolate the failure in prod. Only one survives staging:

```logql
{container="traefik"} |~ "(?i)acme" != "Testing certificate renew"      # denylist
{container="traefik"} |~ "(?i)acme" |~ "(?i)\b(err|unable|fail(ed|ure)?)\b"   # chosen
```

The denylist variant would have alerted on `Starting provider *acme.Provider` — a startup message — and would keep doing so for every future benign ACME line anyone adds. **Matching on failure semantics is not stylistic here; the alternative fires on boot.**

Measured on the final query: prod returns exactly the 1 real failure and none of its 7 heartbeats. Staging returns 0, which is correct — its DNS-01 flow works.

## New finding: the ANSI escapes break field extraction, not just log level

`docs/lessons.md` recorded that Traefik's colour codes make Loki read these lines as `detected_level=unknown`. The consequence is broader than that. The raw line is:

```
\x1b[36mdomains=\x1b[0m["loki.internal.kubelab.local"]
```

There is an ANSI reset **between the key and the value**, so the obvious `domains=\["` matches nothing at all — silently, with no error, just an empty label. The rule's regexp tolerates it.

Extracting at all was the one thing worth hesitating over, because a `| regexp` that drops non-matching lines would drop exactly the renewal-failure shape nobody has ever observed. Tested directly against the heartbeat lines, which carry no `domains=` field: **they are kept, with an empty domain label.** So an unrecognised failure still alerts. That is the property that made extraction safe, and it was verified rather than assumed.

## `noDataState: OK` is load-bearing

A LogQL query matching nothing returns **no series**, not zero. The healthy state is therefore NoData, and at Grafana's default this rule would fire continuously while certificates renewed perfectly — the exact inversion that gets an alert channel muted. It has its own test.

## Verification

- Both new tests observed **failing** against staging before the manifest existed.
- Deployed to staging; the provisioning API returns the rule.
- `rollout restart` performed; rule and contact point survive — the check that they come from the ConfigMap rather than Grafana's database.
- Rule reports `state=inactive health=ok` in staging, the correct resting state there.
- 420 unit tests, `make lint`, `make type` green. `make test-infra ENV=staging` 5/5.

Prod verification of the provisioning API remains blocked on **#951**, and the test skips there with that ticket named rather than reporting a false pass.

## Filed, not fixed

**#957** — Grafana logs `Failed to install plugin pluginId=elasticsearch … permission denied` at error level on every pod start, in both environments. Nothing breaks, but a permanent unexplained error inside the component that now does the watching is the kind of noise that trains people to skim past error lines.

## What is left

Phase 3 induces a real ACME failure in staging to prove the rule fires and clears, and confirms it stays quiet across a heartbeat. Phase 4 is prod. Neither is in this PR.

Refs #799
