### PR TITLE
fix(ansible): bind Uptime Kuma to the tailnet and make the VPS glances tag selectable

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -3478,3 +3478,25 @@ Two corollaries that generalise past git:
 - **Distinguish a check that ran and passed from a check that never ran.** Any composite command where an early step can fail must report `CANNOT CHECK` distinctly from `OK`; a grep over an error message finds no matches and looks exactly like success.
 
 **Tags:** `#git` `#stale-ref` `#parallel-sessions` `#verification` `#positive-control` `#silent-failure` `#false-positive` `#sops` `#sec-001` `#gotcha`
+
+---
+
+### [2026-08-10] Containers keep running with no published ports, and every restart reports success
+
+**Context:** The homepage cockpit showed every Glances widget dark. The obvious reading was that the on-demand nodes were powered off.
+
+**Problem:** All seven nodes were up. Glances answered on two. Probing further, `iptables -t nat -S DOCKER` returned only `-N DOCKER` — the chain present with zero rules — on ace1, ace2, beelink, rpi4 and vps. Every Docker-published port on those five nodes was unreachable: Glances everywhere, MinIO on beelink. Nothing reported an error. `docker ps` listed the containers, `docker inspect` reported correct `PortBindings`, the processes inside were listening, and the healthchecks passed. The only node whose rules were intact, rpi3, was the only node without ufw.
+
+`systemctl restart docker` did not repair it. Neither did `docker restart <name>` — rc=0, chain still empty. A throwaway container with a published port, however, got its DNAT rule created normally on *both* a broken node and the healthy one.
+
+**Solution:** The damage is per container, not per daemon. Containers that survived a daemon restart via `live-restore: true` lost their rules, and restarting them preserves the network sandbox where the damage lives. Only recreation reprograms them — `docker compose up -d --force-recreate`. Tracked as #959.
+
+The cause of the original flush is **not** settled, and the reason is worth recording: rpi3 lacks `base_system` (so it has no ufw) **and** lacks the `docker` role (so it has no `daemon.json`, so no `live-restore`). Those two differences travel together across the whole fleet, so comparing rpi3 against a ufw node varies two things at once. Matching Docker versions between rpi3 and rpi4 felt like a controlled comparison and was not one.
+
+**Rule:**
+- **A container reporting healthy says nothing about whether its port is reachable.** Health probes run inside the container; port publishing is kernel state outside it. Assert the DNAT rule or an external request, never the container's own status.
+- **A ufw rule cannot restrict a Docker-published port.** Docker's DNAT is evaluated before ufw's filter chains and `DOCKER-USER` is empty on every node here, so the access control for a container is its bind address and nothing else. Interface-scoped ufw rules on published ports look like protection and are decoration.
+- **Before calling a comparison a control, list what else differs between the two sides.** A node that never ran a role differs by everything that role installs, not by the one variable under test.
+- Fourth same-day instance of a check that passed *because it could not run*: `ignore_errors: true` on a ufw task whose ufw was never installed; a role invocation missing `tags:` so `TAGS=glances` matched nothing and reported success; a `| head` that truncated the evidence a conclusion rested on; and a corrective Ansible task that reported `changed` while fixing nothing. Extends the 2026-08-09 `CANNOT CHECK` rule from composite commands to **any** gate: require that it has been observed failing at least once.
+
+**Tags:** `#docker` `#ufw` `#iptables` `#live-restore` `#silent-failure` `#false-positive` `#confounded-control` `#glances` `#ops-016` `#gotcha`

--- a/infra/ansible/playbooks/provision-rpi3.yml
+++ b/infra/ansible/playbooks/provision-rpi3.yml
@@ -111,6 +111,8 @@
         uptime_kuma_image: "{{ config.apps.services.observability.uptime_kuma.image }}"
         uptime_kuma_port: "{{ config.apps.services.observability.uptime_kuma.default_port }}"
         restart_policy: "{{ config.global.restart_policy }}"
+        # Consumed by the compose port bind (see the comment in the template).
+        tailscale_ip: "{{ config.networking.nodes.rpi3.tailscale_ip }}"
 
     - role: ../roles/glances
       tags: [monitoring, glances]

--- a/infra/ansible/playbooks/provision-vps.yml
+++ b/infra/ansible/playbooks/provision-vps.yml
@@ -424,6 +424,10 @@
 
   roles:
     - role: ../roles/glances
+      # The other six playbooks tag this role; the VPS did not, so
+      # `make provision NODE=vps TAGS=glances` selected nothing and reported
+      # success — the role was unreachable through the documented entry point.
+      tags: [monitoring, glances]
       vars:
         restart_policy: "{{ config.global.restart_policy }}"
         tailscale_ip: "{{ config.networking.vps.tailscale_ip }}"

--- a/infra/ansible/roles/rpi3_services/templates/compose.yml.j2
+++ b/infra/ansible/roles/rpi3_services/templates/compose.yml.j2
@@ -6,8 +6,19 @@ services:
     image: {{ uptime_kuma_image }}
     container_name: uptime-kuma
     restart: {{ restart_policy }}
+    # Bound to the Tailscale address, NOT 0.0.0.0 — same pattern as
+    # roles/glances. Previously {% raw %}`"{{ uptime_kuma_port }}:3001"`{% endraw %}, which made
+    # Docker listen on every interface: this node has a home-WiFi address
+    # (10.0.0.157) and GLOBALLY ROUTABLE IPv6, so `[::]:3001` was a path to
+    # Uptime Kuma that bypassed VPS Traefik, CrowdSec and the security headers
+    # entirely. Public access is intentional but must arrive through the edge:
+    #   internet -> Cloudflare (DNS only) -> VPS Traefik -> tailnet -> here.
+    #
+    # A ufw rule cannot substitute for this. Docker's DNAT is evaluated before
+    # ufw's filter chains and DOCKER-USER is empty fleet-wide, so the bind
+    # address is the only control that actually holds.
     ports:
-      - "{{ uptime_kuma_port }}:3001"
+      - "{{ tailscale_ip }}:{{ uptime_kuma_port }}:3001"
     volumes:
       - uptime-kuma-data:/app/data
     dns:


### PR DESCRIPTION
## What

Two independent fixes, both narrow on purpose.

**Uptime Kuma binds to the Tailscale address** instead of every interface. rpi3 carries a home-WiFi address and a globally routable IPv6 alongside its tailnet address, so `[::]:3001` and `10.0.0.157:3001` were paths into the service that bypassed VPS Traefik and therefore the CrowdSec and security-header middlewares. Public access is intentional — `status.kubelab.live` is meant to answer from anywhere — but it has to arrive through the edge. This matches what `roles/glances` already does on the same node.

**`provision-vps.yml` tags the glances role.** The other six playbooks tag it, so `make provision NODE=vps TAGS=glances` matched no tasks and reported success.

## Scope of the exposure this closes, measured not assumed

A request to `[2601:...]:3001` from the VPS — which has working IPv6, so the check could actually run — times out. Inbound IPv6 is already dropped upstream of the node. What the bind removes is reachability from the home LAN and from any tailnet peer, not from the internet.

A ufw rule could not have done this: Docker's DNAT is evaluated before ufw's filter chains and `DOCKER-USER` is empty on every node, so a published port is governed by its bind address and nothing else.

## Deploy note

Applying this recreates the Uptime Kuma container. That was a risk worth checking, because five of seven nodes currently cannot program DNAT rules for existing containers (#959) — recreating Kuma on a node in that state would take down the monitoring of record and `status.kubelab.live` together.

Verified safe before merging: a throwaway container with a published port on rpi3 gets its DNAT rule created normally. rpi3 can still program port rules; only already-live-restored containers are affected.

Deploy with `make provision NODE=rpi3 ENV=prod TAGS=services`, then confirm `status.kubelab.live` answers and `10.0.0.157:3001` no longer does.

## Not in this PR

An earlier revision of this branch also carried a repair for #959 and wired `base_system` into `provision-rpi3.yml`. Both were removed: the repair was demonstrated not to work (the corrective task reported `changed` and the nat chain stayed empty), and installing ufw on rpi3 would risk the one node whose Docker port publishing still functions. Tracked as #959 and #960.
