### PR TITLE
chore(ansible): stop the Ollama cleanup probe from printing a fatal on every run

### DIFF
--- a/infra/ansible/roles/beelink_services/tasks/main.yml
+++ b/infra/ansible/roles/beelink_services/tasks/main.yml
@@ -12,7 +12,15 @@
   command: systemctl cat ollama
   register: _ollama_check
   changed_when: false
-  ignore_errors: true
+  # `failed_when: false`, not `ignore_errors: true`. Both let the play continue,
+  # but ignore_errors still prints a red `fatal:` — and this probe is EXPECTED to
+  # fail on every node where the cleanup already ran, i.e. everywhere since
+  # AI-007 retired Ollama (2026-08-09). A green play that prints a fatal on every
+  # run teaches the operator to skim past red output, which is the same habit
+  # this role's sibling warns about in roles/glances/defaults/main.yml: "a check
+  # that fails on a working deploy is worse than no check". The probe's non-zero
+  # rc is still the signal — it is consumed by `when: _ollama_check.rc == 0`.
+  failed_when: false
 
 - name: Stop Ollama systemd service
   systemd:


### PR DESCRIPTION
Rescued from #978 — this commit was pushed after that PR had already been squash-merged, so its content never reached master while the other three did. Caught by grepping `origin/master` for each change rather than trusting the PR's MERGED state; with squash-merge the commit hashes differ, so `git log` comparisons prove nothing about content.

`systemctl cat ollama` is a probe whose non-zero exit **is** the signal — it is consumed by `when: _ollama_check.rc == 0` to decide whether the teardown tasks run. The logic is correct; the output is not. `ignore_errors` still prints a red `fatal:`, and since AI-007 retired Ollama the probe is expected to fail on every node, on every run, forever. Observed live during a `make provision NODE=bee TAGS=minio` run on 2026-08-11: `fatal: [beelink]` printed inside a play that finished `ok=27 changed=2 failed=0`.

`failed_when: false` continues the play identically without the red line.

Why it matters is stated in this role's own sibling, `roles/glances/defaults/main.yml`: "A check that fails on a working deploy is worse than no check — it teaches you to ignore the red." A play that reports success while printing a fatal trains exactly that habit, and this session found four separate defects that survived precisely because someone had learned to skim past output that looked routine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when checking whether the Ollama service exists.
  * Prevented expected check failures from producing fatal error output while preserving cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->