### PR TITLE
feat(ci): page on build failure, not just log on success

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -155,29 +155,43 @@ jobs:
           echo "- Branch: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- Commit SHA: ${{ inputs.sha }}" >> $GITHUB_STEP_SUMMARY
 
-  # ADR-044: envelope-shaped notification into the n8n routing brain (domain/
-  # severity/title/body/source) instead of an ad-hoc payload. `severity: log`
-  # matches ADR-044's reference audit ("push on failure, log on success") — this
-  # job only runs on success, so it never needs a push tier.
+  # ADR-044 / NOTIFY-004: envelope-shaped notification into the n8n routing
+  # brain (domain/severity/title/body/source) instead of an ad-hoc payload.
+  # page-on-fail, log-on-ok, per ADR-044's reference audit for this source.
   notify-build-completion:
     name: Notify Build Completion
     runs-on: ${{ fromJSON(inputs.runner) }}
     needs: [docker-build-push]
-    if: always() && (needs.docker-build-push.result == 'success')
+    if: always()
     steps:
       - name: Notify via Secure Webhook
         run: |
+          RESULT="${{ needs.docker-build-push.result }}"
           BUILD_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          IMAGE="${{ needs.docker-build-push.outputs.full_image }}"
-          REGISTRY="${{ needs.docker-build-push.outputs.registry_url }}"
-          BODY="${IMAGE} pushed to ${REGISTRY}."
-          BODY="${BODY} Branch ${{ github.ref_name }}, commit ${{ inputs.sha }}."
-          BODY="${BODY} ${BUILD_URL}"
+
+          if [ "$RESULT" = "success" ]; then
+            SEVERITY="log"
+            TITLE="Docker build completed: ${{ inputs.app }} ${{ inputs.tag }}"
+            IMAGE="${{ needs.docker-build-push.outputs.full_image }}"
+            REGISTRY="${{ needs.docker-build-push.outputs.registry_url }}"
+            BODY="${IMAGE} pushed to ${REGISTRY}."
+            BODY="${BODY} Branch ${{ github.ref_name }}, commit ${{ inputs.sha }}."
+            BODY="${BODY} ${BUILD_URL}"
+          elif [ "$RESULT" = "failure" ]; then
+            SEVERITY="page"
+            TITLE="Docker build FAILED: ${{ inputs.app }} ${{ inputs.tag }}"
+            BODY="Branch ${{ github.ref_name }}, commit ${{ inputs.sha }}."
+            BODY="${BODY} ${BUILD_URL}"
+          else
+            echo "Build result was '$RESULT' (cancelled/skipped) — no notification"
+            exit 0
+          fi
+
           PAYLOAD=$(cat <<EOF
           {
             "domain": "dev",
-            "severity": "log",
-            "title": "Docker build completed: ${{ inputs.app }} ${{ inputs.tag }}",
+            "severity": "${SEVERITY}",
+            "title": "${TITLE}",
             "body": "${BODY}",
             "source": "github-actions/ci-publish"
           }

--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -158,49 +158,54 @@ jobs:
   # ADR-044 / NOTIFY-004: envelope-shaped notification into the n8n routing
   # brain (domain/severity/title/body/source) instead of an ad-hoc payload.
   # page-on-fail, log-on-ok, per ADR-044's reference audit for this source.
+  #
+  # All workflow/context values arrive via `env:`, never interpolated directly
+  # into the script text — a `${{ }}` expansion inside `run:` is expanded by
+  # the Actions runner into raw script text before bash sees it, so any of
+  # these values (ref_name and tag can carry attacker-influenced text, e.g. a
+  # fork PR's branch name) could otherwise inject shell commands. `env:` sets
+  # a real environment variable instead, which bash treats as inert data.
+  # `jq -n --arg` builds the JSON so it's escaped, not string-concatenated.
   notify-build-completion:
     name: Notify Build Completion
     runs-on: ${{ fromJSON(inputs.runner) }}
     needs: [docker-build-push]
     if: always()
+    env:
+      APP: ${{ inputs.app }}
+      TAG: ${{ inputs.tag }}
+      SHA: ${{ inputs.sha }}
+      REF_NAME: ${{ github.ref_name }}
+      REPOSITORY: ${{ github.repository }}
+      RUN_ID: ${{ github.run_id }}
+      RESULT: ${{ needs.docker-build-push.result }}
+      IMAGE: ${{ needs.docker-build-push.outputs.full_image }}
+      REGISTRY: ${{ needs.docker-build-push.outputs.registry_url }}
+      WEBHOOK_URL: ${{ secrets.N8N_WEBHOOK_URL }}
+      WEBHOOK_TOKEN: ${{ secrets.N8N_DEPLOY_TOKEN }}
     steps:
       - name: Notify via Secure Webhook
         run: |
-          RESULT="${{ needs.docker-build-push.result }}"
-          BUILD_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          BUILD_URL="https://github.com/${REPOSITORY}/actions/runs/${RUN_ID}"
 
           if [ "$RESULT" = "success" ]; then
             SEVERITY="log"
-            TITLE="Docker build completed: ${{ inputs.app }} ${{ inputs.tag }}"
-            IMAGE="${{ needs.docker-build-push.outputs.full_image }}"
-            REGISTRY="${{ needs.docker-build-push.outputs.registry_url }}"
-            BODY="${IMAGE} pushed to ${REGISTRY}."
-            BODY="${BODY} Branch ${{ github.ref_name }}, commit ${{ inputs.sha }}."
-            BODY="${BODY} ${BUILD_URL}"
+            TITLE="Docker build completed: ${APP} ${TAG}"
+            BODY="${IMAGE} pushed to ${REGISTRY}. Branch ${REF_NAME}, commit ${SHA}. ${BUILD_URL}"
           elif [ "$RESULT" = "failure" ]; then
             SEVERITY="page"
-            TITLE="Docker build FAILED: ${{ inputs.app }} ${{ inputs.tag }}"
-            BODY="Branch ${{ github.ref_name }}, commit ${{ inputs.sha }}."
-            BODY="${BODY} ${BUILD_URL}"
+            TITLE="Docker build FAILED: ${APP} ${TAG}"
+            BODY="Branch ${REF_NAME}, commit ${SHA}. ${BUILD_URL}"
           else
             echo "Build result was '$RESULT' (cancelled/skipped) — no notification"
             exit 0
           fi
 
-          PAYLOAD=$(cat <<EOF
-          {
-            "domain": "dev",
-            "severity": "${SEVERITY}",
-            "title": "${TITLE}",
-            "body": "${BODY}",
-            "source": "github-actions/ci-publish"
-          }
-          EOF
-          )
-
-          # Send notification with retry logic and better error handling
-          WEBHOOK_URL="${{ secrets.N8N_WEBHOOK_URL }}"
-          WEBHOOK_TOKEN="${{ secrets.N8N_DEPLOY_TOKEN }}"
+          PAYLOAD=$(jq -n \
+            --arg severity "$SEVERITY" \
+            --arg title "$TITLE" \
+            --arg body "$BODY" \
+            '{domain: "dev", severity: $severity, title: $title, body: $body, source: "github-actions/ci-publish"}')
 
           if [ -z "$WEBHOOK_URL" ] || [ -z "$WEBHOOK_TOKEN" ]; then
             echo "::warning::Webhook URL or token not configured, skipping notification"
@@ -218,7 +223,6 @@ jobs:
               --retry 0 2>/dev/null)
 
             HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-            RESPONSE_BODY=$(echo "$RESPONSE" | head -n -1)
 
             if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
               echo "✅ Docker build notification sent successfully (HTTP $HTTP_CODE)"


### PR DESCRIPTION
## Summary

#985 (already merged) migrated `ci-publish.yml`'s build-completion job to the ADR-044 envelope, but only for the success path — the job's `if:` was still gated on `result == 'success'`, so a failed build was never notified at all.

This PR was pushed as a second commit on the same branch, two minutes after #985 was merged — the squash-merge only captured what was on the branch at merge time, so this commit never landed on master. Opening it as its own PR against the now-updated master; the diff below is just the residual failure-leg change.

Extends the same job to run `always()` and branch on `needs.docker-build-push.result`:
- `success` → `severity: log` (unchanged from #985)
- `failure` → `severity: page` (new)
- anything else (cancelled/skipped) → no notification

Completes NOTIFY-004's (#683) acceptance criteria at the code level. Delivery (Slack destination + n8n routing) is still pending — see the comment on #683.

Closes #985 residual — no separate ticket, this is a direct continuation of that PR's own commit.