### PR TITLE
docs: remove remaining stale ci-release.yml references

### DIFF
--- a/docs/architecture/versioning-strategy.md
+++ b/docs/architecture/versioning-strategy.md
@@ -91,7 +91,6 @@ All stale tags and releases from pre-restructuring CI were deleted. The versioni
 | `ci-pipeline.yml` | Per-app: version calculation, build, test, security scan, Docker push, GitOps update |
 | `ci-publish.yml` | Reusable: Docker build + push + Trivy scan |
 | `release.yml` | release-please: per-component semver, build-once re-tag (ADR-056) |
-| `ci-release.yml` | Global: system release bundle creation |
 
 ## Best Practices
 

--- a/docs/architecture/versioning-strategy.md
+++ b/docs/architecture/versioning-strategy.md
@@ -90,7 +90,7 @@ All stale tags and releases from pre-restructuring CI were deleted. The versioni
 | `ci.yml` | Orchestrator: validate, detect changes, dispatch per-app pipelines |
 | `ci-pipeline.yml` | Per-app: version calculation, build, test, security scan, Docker push, GitOps update |
 | `ci-publish.yml` | Reusable: Docker build + push + Trivy scan |
-| `release.yml` | release-please: per-component semver, build-once re-tag (ADR-056) |
+| `release.yml` | release-please: per-component semver; `api` re-tags the staging digest instead of rebuilding (build-once, ADR-056), `errors` still rebuilds |
 
 ## Best Practices
 

--- a/docs/audits/docs-audit-2026-07-07.md
+++ b/docs/audits/docs-audit-2026-07-07.md
@@ -510,7 +510,7 @@ Priority = unblocking value for onboarding/operations.
 
 ## 7. Open questions (maintainer)
 
-1. **ci-release.yml** — is the CalVer zip-bundle release still wanted alongside release-please, or retire it? (D62; affects the cicd.md rewrite.)
+1. ~~**ci-release.yml** — is the CalVer zip-bundle release still wanted alongside release-please, or retire it? (D62; affects the cicd.md rewrite.)~~ **Resolved 2026-08-11**: retired. See [ADR-059](../adr/adr-059-retire-calver-release-bundle.md) and #564.
 2. **apps/wiki/generated_docs** — who consumes the wiki today? Regenerate in CI, or gitignore the mirror and treat docs/ as the only SoT? (D59)
 3. **components/kubelab-{agents,console}.md** — retire to stubs pointing at the vault, or re-import the vault specs into the repo? The extraction note says vault is SoT; the repo copies disagree with it. (D46)
 4. **toolkit.md vs toolkit/README.md** — agree the runbook dies and the README is regenerated? Or keep a thin "toolkit concepts" runbook? (D20)

--- a/docs/runbooks/cicd.md
+++ b/docs/runbooks/cicd.md
@@ -36,11 +36,16 @@ ci.yml (entry point)
         ├── Trivy scan → GitHub Security tab
         └── n8n webhook notification
 
-ci-release.yml (triggered by workflow_run after CI succeeds)
-├── CalVer tag        → v{YYYY}.{MM}.{DD} (master) or v{...}-rc.{sha} (develop)
-├── Deployment ZIP    → Makefile + infra/ + toolkit/ + compose files
-└── GitHub Release    → artifact + changelog
+release.yml (release-please, on push to master)
+├── Per-component semver PR → api-v{X.Y.Z}, errors-v{X.Y.Z}
+└── On merge → re-tag the staging-validated digest (build-once, ADR-056)
 ```
+
+There is no global/CalVer release step. `ci-release.yml` (the `vYYYY.MM.DD` + zip bundle
+this diagram used to show here) was retired — see
+[ADR-059](../adr/adr-059-retire-calver-release-bundle.md). This file otherwise predates the
+current pipeline (`ci-pipeline.yml`, `paulhatch/semantic-version`, `develop`, `blog`/`web`
+below are no longer real) — full rewrite tracked as DOCS-002.
 
 ## Docker Registry
 
@@ -197,7 +202,7 @@ git push
 - `.github/workflows/ci.yml` — entry point, validation, change detection
 - `.github/workflows/ci-pipeline.yml` — build, test, version, security scan
 - `.github/workflows/ci-publish.yml` — Docker build + push + Trivy
-- `.github/workflows/ci-release.yml` — deployment bundle + GitHub Release
+- `.github/workflows/release.yml` — release-please, per-component semver + build-once re-tag (ADR-056)
 
 ## Branch Protection Rules
 

--- a/docs/runbooks/cicd.md
+++ b/docs/runbooks/cicd.md
@@ -38,7 +38,7 @@ ci.yml (entry point)
 
 release.yml (release-please, on push to master)
 ├── Per-component semver PR → api-v{X.Y.Z}, errors-v{X.Y.Z}
-└── On merge → re-tag the staging-validated digest (build-once, ADR-056)
+└── On merge → api re-tags the staging digest (build-once, ADR-056); errors rebuilds
 ```
 
 There is no global/CalVer release step. `ci-release.yml` (the `vYYYY.MM.DD` + zip bundle
@@ -202,7 +202,7 @@ git push
 - `.github/workflows/ci.yml` — entry point, validation, change detection
 - `.github/workflows/ci-pipeline.yml` — build, test, version, security scan
 - `.github/workflows/ci-publish.yml` — Docker build + push + Trivy
-- `.github/workflows/release.yml` — release-please, per-component semver + build-once re-tag (ADR-056)
+- `.github/workflows/release.yml` — release-please, per-component semver; `api` build-once re-tag (ADR-056), `errors` rebuilds
 
 ## Branch Protection Rules
 


### PR DESCRIPTION
## Summary

Small follow-up to #985/ADR-059. Two docs still described `ci-release.yml` as live after it was retired:

- `docs/runbooks/cicd.md` — pipeline diagram and workflow-file list
- `docs/architecture/versioning-strategy.md` — a leftover row in the workflow table that survived the first pass

Also resolves open question #1 in `docs/audits/docs-audit-2026-07-07.md` ("is the CalVer zip-bundle release still wanted... or retire it?") — marked resolved, pointing at ADR-059.

Doc-only, no behavior change.