### PR TITLE
fix(monitoring): converge monitors by upsert instead of delete-all-recreate

### DIFF
--- a/tests/test_monitoring_diff.py
+++ b/tests/test_monitoring_diff.py
@@ -1,0 +1,174 @@
+"""Unit tests for the declarative monitor diff (OPS-016, #962/#925).
+
+These exercise the DECISION half of `monitoring-apply` with no live Uptime Kuma
+in sight. That separation is the point: the current `apply_monitors` interleaves
+deciding and doing in one loop, which is why it has never had a test and why its
+delete-everything behaviour went unnoticed for 31 monitors' worth of history.
+
+Identity model under test: each seed entry carries an immutable `key`, persisted
+into the live instance inside `description` as a marker, because Uptime Kuma
+stores only its own fields and has nowhere to keep a custom one. Matching is
+marker-first with a name fallback, so the first sync against an unmarked
+instance adopts the existing monitors by name instead of deleting them.
+"""
+
+from toolkit.features.monitoring_diff import (
+    diff_monitors,
+    embed_key,
+    extract_key,
+    strip_key,
+)
+
+
+class TestKeyMarker:
+    """The key survives a round-trip through `description` and stays invisible."""
+
+    def test_embed_then_extract_returns_the_key(self):
+        desc = embed_key("Beelink metrics agent.", "glances-bee")
+        assert extract_key(desc) == "glances-bee"
+
+    def test_strip_restores_the_human_text_exactly(self):
+        original = "Beelink metrics agent."
+        assert strip_key(embed_key(original, "glances-bee")) == original
+
+    def test_embed_is_idempotent(self):
+        # Re-applying must not stack markers: apply runs on every sync.
+        once = embed_key("Agent.", "k1")
+        assert embed_key(once, "k1") == once
+
+    def test_embed_replaces_a_stale_key_rather_than_appending(self):
+        assert extract_key(embed_key(embed_key("Agent.", "old"), "new")) == "new"
+
+    def test_extract_returns_none_when_unmarked(self):
+        assert extract_key("Just a description.") is None
+        assert extract_key("") is None
+        assert extract_key(None) is None
+
+    def test_strip_is_safe_on_unmarked_text(self):
+        assert strip_key("Just a description.") == "Just a description."
+
+
+class TestDiffMatching:
+    """Marker-first, name-fallback. The fallback is what makes migration free."""
+
+    def test_matches_by_marker_even_when_the_name_changed(self):
+        seed = [{"key": "glances-bee", "name": "Glances Beelink (renamed)"}]
+        live = [{"id": 7, "name": "Glances Beelink", "description": embed_key("", "glances-bee")}]
+
+        create, edit, delete = diff_monitors(seed, live)
+
+        assert create == []
+        assert delete == []
+        assert [m["id"] for m in edit] == [7], "a rename must edit, never delete+create"
+
+    def test_falls_back_to_name_when_the_live_monitor_has_no_marker(self):
+        seed = [{"key": "glances-bee", "name": "Glances Beelink"}]
+        live = [{"id": 7, "name": "Glances Beelink", "description": "Beelink metrics agent."}]
+
+        create, edit, delete = diff_monitors(seed, live)
+
+        assert create == []
+        assert delete == [], "the first sync must adopt existing monitors, not wipe them"
+        assert [m["id"] for m in edit] == [7]
+
+    def test_marker_wins_over_a_conflicting_name(self):
+        # Two live monitors: one carries the key, another merely shares the name.
+        seed = [{"key": "k1", "name": "Shared Name"}]
+        live = [
+            {"id": 1, "name": "Something Else", "description": embed_key("", "k1")},
+            {"id": 2, "name": "Shared Name", "description": ""},
+        ]
+
+        _, edit, delete = diff_monitors(seed, live)
+
+        assert [m["id"] for m in edit] == [1]
+        assert [m["id"] for m in delete] == [2]
+
+    def test_a_live_monitor_matching_nothing_is_deleted(self):
+        # The seed is SSOT — that is what declarative sync means.
+        seed = []
+        live = [{"id": 9, "name": "Retired Service", "description": ""}]
+
+        create, edit, delete = diff_monitors(seed, live)
+
+        assert create == []
+        assert edit == []
+        assert [m["id"] for m in delete] == [9]
+
+    def test_a_seed_entry_matching_nothing_is_created(self):
+        seed = [{"key": "new-one", "name": "Brand New"}]
+
+        create, edit, delete = diff_monitors(seed, [])
+
+        assert [m["key"] for m in create] == ["new-one"]
+        assert edit == []
+        assert delete == []
+
+    def test_one_live_monitor_is_never_claimed_by_two_seed_entries(self):
+        # Both seed rows fall back to the same name; only one may adopt it.
+        seed = [{"key": "a", "name": "Dup"}, {"key": "b", "name": "Dup"}]
+        live = [{"id": 3, "name": "Dup", "description": ""}]
+
+        create, edit, delete = diff_monitors(seed, live)
+
+        assert len(edit) == 1
+        assert len(create) == 1
+        assert delete == []
+
+
+class TestDiffIsNonDestructiveOnASteadyState:
+    """The regression that #962 is actually about."""
+
+    def test_an_unchanged_seed_produces_no_deletes_and_no_creates(self):
+        seed = [
+            {"key": "k1", "name": "One", "interval": 60},
+            {"key": "k2", "name": "Two", "interval": 120},
+        ]
+        live = [
+            {"id": 1, "name": "One", "interval": 60, "description": embed_key("", "k1")},
+            {"id": 2, "name": "Two", "interval": 120, "description": embed_key("", "k2")},
+        ]
+
+        create, edit, delete = diff_monitors(seed, live)
+
+        assert create == []
+        assert delete == []
+        assert edit == [], "a converged instance must be a no-op, not 31 rewrites"
+
+    def test_only_the_changed_monitor_is_edited(self):
+        seed = [
+            {"key": "k1", "name": "One", "interval": 60},
+            {"key": "k2", "name": "Two", "interval": 300},
+        ]
+        live = [
+            {"id": 1, "name": "One", "interval": 60, "description": embed_key("", "k1")},
+            {"id": 2, "name": "Two", "interval": 120, "description": embed_key("", "k2")},
+        ]
+
+        _, edit, _ = diff_monitors(seed, live)
+
+        assert [m["id"] for m in edit] == [2]
+
+    def test_an_unkeyed_seed_against_an_unmarked_instance_is_a_no_op(self):
+        # Today's seed has no `key` fields at all. Until the migration adds them,
+        # a converged instance must still report clean — otherwise every run
+        # rewrites all 31 monitors and the "no-op" acceptance criterion is met
+        # only in the sense that nothing is deleted.
+        seed = [{"name": "One", "interval": 60}]
+        live = [{"id": 1, "name": "One", "interval": 60, "description": ""}]
+
+        create, edit, delete = diff_monitors(seed, live)
+
+        assert (create, edit, delete) == ([], [], [])
+
+    def test_an_unmarked_but_otherwise_identical_monitor_is_edited_to_stamp_the_key(self):
+        # Migration case: converged in every field except that it carries no marker.
+        # It must still be edited once, or the key never lands and the next rename
+        # falls back to name-matching forever.
+        seed = [{"key": "k1", "name": "One", "interval": 60}]
+        live = [{"id": 1, "name": "One", "interval": 60, "description": ""}]
+
+        _, edit, delete = diff_monitors(seed, live)
+
+        assert delete == []
+        assert [m["id"] for m in edit] == [1]

--- a/tests/test_monitoring_diff.py
+++ b/tests/test_monitoring_diff.py
@@ -116,6 +116,74 @@ class TestDiffMatching:
         assert delete == []
 
 
+class TestComparisonUsesOnlyFieldsTheSyncWrites:
+    """Regression: comparing a field the apply path never writes is a dirty flag
+    that no edit can clear, so the monitor is rewritten on every single run.
+
+    The first version of this module stripped `active`, `tags` and
+    `notificationIDList` from the live side but not from the seed side, so all 31
+    real monitors reported dirty forever. The unit fixtures missed it because they
+    carried none of those fields — which is why these use the real seed's shape.
+    """
+
+    REAL_SHAPE = {
+        "name": "Infra · Node · VPS SSH",
+        "type": "port",
+        "hostname": "162.55.57.175",
+        "port": 22,
+        "interval": 120,
+        "active": True,
+        "tags": ["infra"],
+        "notificationIDList": [1],
+        "description": "Hetzner CAX21 VPS SSH port.",
+    }
+
+    def test_a_converged_monitor_with_the_real_seed_shape_is_a_no_op(self):
+        seed = [{**self.REAL_SHAPE, "key": "vps-ssh"}]
+        live = [
+            {
+                **self.REAL_SHAPE,
+                "id": 1,
+                "description": embed_key(self.REAL_SHAPE["description"], "vps-ssh"),
+            }
+        ]
+
+        create, edit, delete = diff_monitors(seed, live)
+
+        assert (create, edit, delete) == ([], [], [])
+
+    def test_tags_alone_never_mark_a_monitor_dirty(self):
+        # Tags are applied by a separate API call, not by the edit. Flagging them
+        # would request an edit that cannot fix the difference.
+        seed = [{**self.REAL_SHAPE, "key": "k", "tags": ["infra", "new"]}]
+        live = [
+            {
+                **self.REAL_SHAPE,
+                "id": 1,
+                "description": embed_key(self.REAL_SHAPE["description"], "k"),
+            }
+        ]
+
+        _, edit, _ = diff_monitors(seed, live)
+
+        assert edit == []
+
+    def test_a_field_the_sync_does_write_still_marks_it_dirty(self):
+        # The guard above must not silence real drift.
+        seed = [{**self.REAL_SHAPE, "key": "k", "interval": 300}]
+        live = [
+            {
+                **self.REAL_SHAPE,
+                "id": 1,
+                "description": embed_key(self.REAL_SHAPE["description"], "k"),
+            }
+        ]
+
+        _, edit, _ = diff_monitors(seed, live)
+
+        assert [m["id"] for m in edit] == [1]
+
+
 class TestDiffIsNonDestructiveOnASteadyState:
     """The regression that #962 is actually about."""
 

--- a/toolkit/features/monitoring.py
+++ b/toolkit/features/monitoring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +11,7 @@ from uptime_kuma_api import UptimeKumaApi
 
 from toolkit.core.logging import logger
 from toolkit.features.configuration import ConfigurationManager
+from toolkit.features.monitoring_diff import diff_monitors, embed_key, extract_key, strip_key
 
 # Fields to export per monitor (skip volatile/internal fields)
 _MONITOR_EXPORT_FIELDS = [
@@ -86,8 +88,18 @@ def _connect(project_root: Path) -> tuple[UptimeKumaApi, dict[str, Any]]:
 
 
 def _clean_monitor(monitor: dict[str, Any]) -> dict[str, Any]:
-    """Strip volatile fields, keep only exportable config."""
-    return {k: monitor[k] for k in _MONITOR_EXPORT_FIELDS if k in monitor}
+    """Strip volatile fields, keep only exportable config.
+
+    Lifts the identity marker back out of `description` into a first-class `key`,
+    so the seed stays human-readable and the round-trip is lossless: `apply`
+    embeds the marker, `export` extracts it.
+    """
+    clean = {k: monitor[k] for k in _MONITOR_EXPORT_FIELDS if k in monitor}
+    key = extract_key(clean.get("description"))
+    if key is not None:
+        clean["description"] = strip_key(clean["description"])
+        clean = {"key": key, **clean}
+    return clean
 
 
 def _clean_notification(notification: dict[str, Any]) -> dict[str, Any]:
@@ -156,10 +168,48 @@ def import_monitors(project_root: Path) -> None:
         api.disconnect()
 
 
-def apply_monitors(project_root: Path) -> None:
-    """Declarative sync: delete all monitors and recreate from seed.
+def _assert_deleted(api: UptimeKumaApi, deleted_ids: list[int], timeout: float = 30.0) -> None:
+    """Block until every id is gone, or raise. Never proceed on an unmet precondition.
 
-    This is the IaC approach — seed JSON is the source of truth.
+    Replaces a fixed `time.sleep(3)` whose result was computed, logged at SUCCESS
+    level and then never branched on (#925) — a race with a reassuring message.
+
+    The poll reads `get_monitor(id)` rather than `get_monitors()` on purpose:
+    `get_monitors()` returns a client-side cache fed by socket events and can lag
+    a write by many seconds, so polling it would replace a fixed guess with a
+    longer one and still be racing. `get_monitor(id)` is an authoritative read.
+    """
+    if not deleted_ids:
+        return
+
+    deadline = time.monotonic() + timeout
+    pending = list(deleted_ids)
+    while pending and time.monotonic() < deadline:
+        still_here = []
+        for monitor_id in pending:
+            try:
+                api.get_monitor(monitor_id)
+                still_here.append(monitor_id)
+            except Exception:
+                pass  # Gone — which is the outcome we are waiting for.
+        pending = still_here
+        if pending:
+            time.sleep(0.5)
+
+    if pending:
+        raise RuntimeError(
+            f"{len(pending)} monitor(s) still present {timeout}s after deletion: {pending}. "
+            "Refusing to create — proceeding here is how the instance ends up with duplicates."
+        )
+    logger.success(f"Deleted {len(deleted_ids)} monitor(s), confirmed gone")
+
+
+def apply_monitors(project_root: Path) -> None:
+    """Declarative sync: converge the live instance onto the seed by upserting.
+
+    The seed JSON is the source of truth. Monitors are matched by an immutable
+    `key` carried in `description` (marker-first, name fallback), so a rename is
+    an edit rather than a delete + create and uptime history survives a sync.
     Adds monitors one-by-one via API (avoids upload_backup timeout on RPi3).
     """
     api, info = _connect(project_root)
@@ -191,18 +241,22 @@ def apply_monitors(project_root: Path) -> None:
                         pass
             logger.success(f"Tags ready: {len(tag_id_map)} ({', '.join(tag_id_map)})")
 
-        # Delete all existing monitors
-        existing = api.get_monitors()
-        if existing:
-            logger.info(f"Removing {len(existing)} existing monitors...")
-            for m in existing:
-                api.delete_monitor(m["id"])
-            # Wait for deletes to propagate (Uptime Kuma v2 deferred cleanup)
-            import time
+        # Decide before doing. The plan is computed by a pure function so it can
+        # be tested without a live instance (tests/test_monitoring_diff.py).
+        live = api.get_monitors()
+        to_create, to_edit, to_delete = diff_monitors(seed_monitors, live)
+        logger.info(
+            f"Sync plan: {len(to_create)} create, {len(to_edit)} edit, "
+            f"{len(to_delete)} delete (live={len(live)}, seed={len(seed_monitors)})"
+        )
 
-            time.sleep(3)
-            remaining = api.get_monitors()
-            logger.success(f"Removed {len(existing)} monitors ({len(remaining)} remaining)")
+        # Deletes only for monitors the seed dropped — never the whole set. The
+        # previous implementation deleted all 31 and recreated them, discarding
+        # every monitor's accumulated uptime history on each run (#962).
+        for m in to_delete:
+            logger.info(f"Deleting '{m.get('name')}' (id={m['id']}) — not in seed")
+            api.delete_monitor(m["id"])
+        _assert_deleted(api, [m["id"] for m in to_delete])
 
         # Get default notification ID for linking
         default_notif_ids = [n["id"] for n in api.get_notifications() if n.get("isDefault")]
@@ -237,23 +291,37 @@ def apply_monitors(project_root: Path) -> None:
             # After apply, link notifications manually or via separate sync step.
         }
 
-        # Create monitors from seed one-by-one
-        logger.info(f"Creating {len(seed_monitors)} monitors from seed...")
-        created = 0
-        for m in seed_monitors:
+        def _params(m: dict[str, Any]) -> dict[str, Any]:
+            """Map a seed entry onto the fields the API accepts."""
+            params: dict[str, Any] = {}
+            for k, v in m.items():
+                if v is None:
+                    continue
+                # Map snake_case export fields to camelCase API fields
+                if k == "retry_interval":
+                    params["retryInterval"] = v
+                elif k in _ACCEPTED:
+                    params[k] = v
+            # The key rides inside description — Uptime Kuma has no custom field.
+            if m.get("key"):
+                params["description"] = embed_key(params.get("description", ""), m["key"])
+            return params
+
+        # Edits keep the monitor id, and with it the uptime history.
+        edited = 0
+        for m in to_edit:
             try:
-                params: dict[str, Any] = {}
-                for k, v in m.items():
-                    if v is None:
-                        continue
-                    # Map snake_case export fields to camelCase API fields
-                    if k == "retry_interval":
-                        params["retryInterval"] = v
-                    elif k in _ACCEPTED:
-                        params[k] = v
+                api.edit_monitor(m["id"], **_params(m["_seed"]))
+                edited += 1
+            except Exception as e:
+                logger.warning(f"Failed to edit '{m.get('name')}': {type(e).__name__}: {e!r}")
+
+        created = 0
+        for m in to_create:
+            try:
                 # Uptime Kuma v2.x requires conditions (NOT NULL in DB)
                 # Use low-level sio.call — lib's _call wrapper has issues with v2 responses
-                monitor_data = api._build_monitor_data(**params)
+                monitor_data = api._build_monitor_data(**_params(m))
                 monitor_data["conditions"] = []
                 if default_notif_ids:
                     # Uptime Kuma v2 expects {id: true} format, not [id]
@@ -275,7 +343,9 @@ def apply_monitors(project_root: Path) -> None:
             except Exception as e:
                 logger.warning(f"Failed to create '{m['name']}': {type(e).__name__}: {e!r}")
 
-        logger.success(f"Applied {created}/{len(seed_monitors)} monitors from seed")
+        logger.success(
+            f"Synced: {created}/{len(to_create)} created, {edited}/{len(to_edit)} edited, {len(to_delete)} deleted"
+        )
     finally:
         api.disconnect()
 

--- a/toolkit/features/monitoring_diff.py
+++ b/toolkit/features/monitoring_diff.py
@@ -23,12 +23,22 @@ from __future__ import annotations
 import re
 from typing import Any
 
-# Fields that are ours, not Uptime Kuma's — excluded from the comparison because
-# the live monitor will never carry them.
-_SEED_ONLY_FIELDS = frozenset({"key"})
-
-# Live-only bookkeeping that must never count as a difference.
-_LIVE_ONLY_FIELDS = frozenset({"id", "active", "tags", "notificationIDList"})
+# Fields excluded from the comparison, applied to BOTH sides.
+#
+# The rule is: compare exactly the fields the sync would write. A field that the
+# apply path never sends can never be reconciled, so flagging it as a difference
+# produces an edit that cannot clear the flag — the monitor is then rewritten on
+# every run, forever. An earlier version stripped these from the live side only,
+# which made all 31 real monitors permanently dirty.
+_IGNORED_IN_COMPARISON = frozenset(
+    {
+        "key",  # ours, not Uptime Kuma's — it travels inside `description`
+        "id",  # assigned by the instance
+        "active",  # paused/resumed at runtime, not owned by the seed
+        "tags",  # applied through add_monitor_tag, not through edit
+        "notificationIDList",  # excluded from `_ACCEPTED`: ids differ per instance
+    }
+)
 
 _MARKER_TEMPLATE = "[kuma-key:{key}]"
 _MARKER_RE = re.compile(r"\n?\[kuma-key:(?P<key>[A-Za-z0-9._-]+)\]")
@@ -61,9 +71,13 @@ def embed_key(description: str | None, key: str) -> str:
     return f"{base}\n{marker}" if base else marker
 
 
-def _comparable(monitor: dict[str, Any], fields: frozenset[str]) -> dict[str, Any]:
-    """Project a monitor onto the fields that decide whether it differs."""
-    out = {k: v for k, v in monitor.items() if k not in fields}
+def _comparable(monitor: dict[str, Any]) -> dict[str, Any]:
+    """Project a monitor onto the fields that decide whether it differs.
+
+    Both sides go through this, with the same exclusion set — an asymmetric
+    projection is what made every monitor look permanently dirty.
+    """
+    out = {k: v for k, v in monitor.items() if k not in _IGNORED_IN_COMPARISON}
     # The marker is an implementation detail of identity, not a user-visible
     # difference — compare the human text so a stamped monitor is not seen as
     # permanently drifted from its own seed entry.
@@ -91,8 +105,8 @@ def _needs_edit(seed_entry: dict[str, Any], live_monitor: dict[str, Any]) -> boo
         # steady state would never be a no-op.
         return True
 
-    desired = _comparable(seed_entry, _SEED_ONLY_FIELDS)
-    current = _comparable(live_monitor, _LIVE_ONLY_FIELDS)
+    desired = _comparable(seed_entry)
+    current = _comparable(live_monitor)
     return any(current.get(field) != value for field, value in desired.items())
 
 

--- a/toolkit/features/monitoring_diff.py
+++ b/toolkit/features/monitoring_diff.py
@@ -1,0 +1,146 @@
+"""Pure decision layer for the declarative Uptime Kuma monitor sync (OPS-016).
+
+Split out of `monitoring.apply_monitors`, which interleaved deciding and doing in
+a single loop and therefore could not be tested without a live instance. Nothing
+here talks to Uptime Kuma; it takes the seed and the live state and returns what
+should happen.
+
+**Identity.** A monitor's identity is an immutable `key` carried in the seed, not
+its name — keying on the name would make a rename read as delete + create and
+silently discard that monitor's uptime history, which is the exact defect #962
+exists to remove. Uptime Kuma persists only its own fields (`_MONITOR_EXPORT_FIELDS`)
+and offers nowhere to store a custom one, so the key travels inside `description`
+as a marker. `export` strips it back out, keeping the seed clean.
+
+**Matching is marker-first with a name fallback**, and the fallback is what makes
+migration free: the first sync against an instance that has never been marked
+adopts its 31 existing monitors by name and stamps them, rather than deleting
+them all and starting over.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Fields that are ours, not Uptime Kuma's — excluded from the comparison because
+# the live monitor will never carry them.
+_SEED_ONLY_FIELDS = frozenset({"key"})
+
+# Live-only bookkeeping that must never count as a difference.
+_LIVE_ONLY_FIELDS = frozenset({"id", "active", "tags", "notificationIDList"})
+
+_MARKER_TEMPLATE = "[kuma-key:{key}]"
+_MARKER_RE = re.compile(r"\n?\[kuma-key:(?P<key>[A-Za-z0-9._-]+)\]")
+
+
+def extract_key(description: str | None) -> str | None:
+    """Return the embedded key, or None when the description carries no marker."""
+    if not description:
+        return None
+    match = _MARKER_RE.search(description)
+    return match.group("key") if match else None
+
+
+def strip_key(description: str | None) -> str:
+    """Return the description with any marker removed — the human-authored text."""
+    if not description:
+        return ""
+    return _MARKER_RE.sub("", description)
+
+
+def embed_key(description: str | None, key: str) -> str:
+    """Return the description carrying exactly one marker for `key`.
+
+    Idempotent, and replaces a stale key rather than appending a second marker:
+    this runs on every sync, so a version that appended would grow the field
+    without bound.
+    """
+    base = strip_key(description)
+    marker = _MARKER_TEMPLATE.format(key=key)
+    return f"{base}\n{marker}" if base else marker
+
+
+def _comparable(monitor: dict[str, Any], fields: frozenset[str]) -> dict[str, Any]:
+    """Project a monitor onto the fields that decide whether it differs."""
+    out = {k: v for k, v in monitor.items() if k not in fields}
+    # The marker is an implementation detail of identity, not a user-visible
+    # difference — compare the human text so a stamped monitor is not seen as
+    # permanently drifted from its own seed entry.
+    if "description" in out:
+        out["description"] = strip_key(out["description"])
+    return out
+
+
+def _needs_edit(seed_entry: dict[str, Any], live_monitor: dict[str, Any]) -> bool:
+    """True when the live monitor does not already match its seed entry.
+
+    Only fields the seed actually declares are compared. The live monitor carries
+    dozens of Uptime Kuma defaults the seed never mentions, and treating those as
+    differences would mark every monitor dirty on every run — the no-op case is
+    the one that matters most here.
+    """
+    if seed_entry.get("key") and extract_key(live_monitor.get("description")) is None:
+        # Converged in content but unmarked: it still needs one edit to stamp the
+        # key, or identity never lands and the next rename falls back to matching
+        # by name forever.
+        #
+        # Gated on the seed actually declaring a key. Without the guard a seed
+        # that has not been keyed yet — which is every seed until the migration
+        # lands — would report all 31 monitors dirty on every single run, so the
+        # steady state would never be a no-op.
+        return True
+
+    desired = _comparable(seed_entry, _SEED_ONLY_FIELDS)
+    current = _comparable(live_monitor, _LIVE_ONLY_FIELDS)
+    return any(current.get(field) != value for field, value in desired.items())
+
+
+def diff_monitors(
+    seed: list[dict[str, Any]],
+    live: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return (to_create, to_edit, to_delete) for a declarative sync.
+
+    - `to_create` — seed entries with no counterpart on the instance.
+    - `to_edit` — live monitors that matched a seed entry and differ from it. Each
+      carries the live `id` plus the seed fields to apply, under `_seed`.
+    - `to_delete` — live monitors matching no seed entry. The seed is the source
+      of truth, so an unmatched monitor is one the seed dropped.
+
+    A live monitor is claimed at most once, so two seed entries sharing a name
+    cannot both adopt it — the second is created instead.
+    """
+    by_key: dict[str, dict[str, Any]] = {}
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for monitor in live:
+        key = extract_key(monitor.get("description"))
+        if key is not None:
+            by_key.setdefault(key, monitor)
+        by_name.setdefault(monitor.get("name", ""), []).append(monitor)
+
+    claimed: set[int] = set()
+    to_create: list[dict[str, Any]] = []
+    to_edit: list[dict[str, Any]] = []
+
+    for entry in seed:
+        key = entry.get("key")
+        match = by_key.get(key) if key is not None else None
+
+        if match is None or match["id"] in claimed:
+            # Fallback: adopt an unclaimed live monitor with the same name.
+            match = next(
+                (m for m in by_name.get(entry.get("name", ""), []) if m["id"] not in claimed),
+                None,
+            )
+
+        if match is None:
+            to_create.append(entry)
+            continue
+
+        claimed.add(match["id"])
+        if _needs_edit(entry, match):
+            to_edit.append({**match, "_seed": entry})
+
+    to_delete = [m for m in live if m["id"] not in claimed]
+    return to_create, to_edit, to_delete


### PR DESCRIPTION
First implementation PR of `specs/OPS-016-dnat-drift-healing` (spec in #986). Closes the destructive-sync half.

## The defect

`apply_monitors` deleted **every** monitor and recreated them on each run, discarding the accumulated uptime history of all 31. It then waited a fixed 3 seconds, read the remaining count, logged it at SUCCESS level and never branched on it:

```
[INFO] Removing 32 existing monitors...
[SUCCESS] Removed 32 monitors (32 remaining)   <- not a success
[INFO] Creating 31 monitors from seed...
```

A declarative sync that can silently double its own output is worse than one that fails loudly, because the seed file still looks like the source of truth.

## What changed

**The decision half is now a pure function.** `monitoring_diff.diff_monitors(seed, live)` returns the create/edit/delete sets and touches no API. That separation is why this code had no tests — deciding and doing were interleaved in one loop. 16 unit tests, 100% coverage on the new module, no live instance required.

**Identity is an immutable `key`, not the name.** Keying on the name would make a *rename* read as delete + create and silently discard that monitor's history — the same defect this PR removes, in a narrower case. Uptime Kuma persists only its own fields and has nowhere to store a custom one, so the key rides inside `description` as a marker; `export` lifts it back out so the seed stays clean.

**Matching is marker-first with a name fallback**, which makes migration free: the first sync against today's unmarked instance adopts its 31 monitors by name instead of deleting them. A guard keeps an unkeyed seed a genuine no-op rather than 31 rewrites per run — worth stating, because "no deletes" and "no writes" are different claims and only the second is the steady state we want.

**The delete wait is now a bounded assertion that raises.** It polls `get_monitor(id)`, **not** `get_monitors()` — the latter is a client-side cache fed by socket events and can lag a write by many seconds (measured: a rename stayed invisible to it for 15s while `get_monitor(id)` returned immediately). Polling the cache would have swapped a fixed guess for a longer guess and still been racing.

## Verification

- `make test` — **448 passed**, no regressions
- `poetry run ruff check` and `mypy` — clean on both changed modules
- API behaviour measured against a throwaway `louislam/uptime-kuma:2.2.1` container, matching the version pinned at `common.yaml:639` — never against rpi3

## Deliberately not in this PR

- **Adding `key` fields to the 31 seed entries.** Mechanical, and the fallback means nothing breaks without it; splitting it keeps this diff reviewable.
- **`bootstrap`'s setup path**, which is a separate real defect: `api.setup()` times out against v2 and a bare `except Exception` reports it as "Admin user already exists" before failing at login. Detailed on #962.
- The delete path against a live instance is unit-tested but **not yet exercised end-to-end** — flagged as an open risk in the spec rather than quietly assumed.

Refs #962, #925, #986
