### PR TITLE
docs(adr-059): fix release-trigger precision and stale baseline claim

### DIFF
--- a/docs/adr/adr-059-retire-calver-release-bundle.md
+++ b/docs/adr/adr-059-retire-calver-release-bundle.md
@@ -19,14 +19,16 @@ Accepted — 2026-08-11
 
 ## Context
 
-Two independent mechanisms created GitHub Releases on every push to `master`:
+Two independent mechanisms ran on every push to `master`, both capable of producing a GitHub
+Release:
 
-- `release.yml` (release-please) — per-component semver (`api-vX.Y.Z`, `errors-vX.Y.Z`),
-  gated on conventional commits touching that component's path, with a real changelog.
-  This is the sole semver authority per [ADR-046](adr-046-gitops-delivery-promotion-strategy.md) D2.
-- `ci-release.yml` ("Create Global Release Bundle") — unconditional on every push, tagged
-  `vYYYY.MM.DD[-HHMMSS]`, built a zip of `Makefile` + `infra/` + `toolkit/` + compose files,
-  and published it as a GitHub Release with instructions to `unzip && make deploy`.
+- `release.yml` (release-please) — per-component semver (`api-vX.Y.Z`, `errors-vX.Y.Z`), but
+  a release only cuts when conventional commits touching that component's path warrant a
+  bump, with a real changelog. This is the sole semver authority per
+  [ADR-046](adr-046-gitops-delivery-promotion-strategy.md) D2.
+- `ci-release.yml` ("Create Global Release Bundle") — unconditional: a release on every push,
+  no gate, tagged `vYYYY.MM.DD[-HHMMSS]`, with a zip of `Makefile` + `infra/` + `toolkit/` +
+  compose files attached, and instructions to `unzip && make deploy`.
 
 `ci-release.yml` predates the K3s/Argo CD migration. Its own deploy instructions no longer
 match the GitOps pull model (Argo CD syncs manifests directly from git; `make deploy` is not

--- a/docs/architecture/versioning-strategy.md
+++ b/docs/architecture/versioning-strategy.md
@@ -75,13 +75,13 @@ On `master` and `develop`, the CI automatically commits version bumps to config 
 
 Commit format: `chore(infra): update {app} version to {version} [skip ci]`
 
-## Current Baseline (2026-02-28)
+## Current Baseline
 
-All stale tags and releases from pre-restructuring CI were deleted. The versioning starts clean:
-
-- **Per-app baseline:** `0.0.0` (no `{app}-v*` tags exist yet)
-- **First stable release:** Will be created on first `develop → master` merge
-- **Expected first versions:** `api-v0.1.0`, `blog-v0.1.0`, `web-v0.1.0` (accumulated `feat:` commits)
+Stale from the 2026-02-28 pre-restructuring reset (`develop → master`, `blog`, no tags yet
+are no longer real — see DOCS-002 for the full rewrite). Current state: `api-v*` and
+`errors-v*` tags exist and are cut by release-please as described above; `web-v*` tags remain
+from before the `web` app was extracted to its own repo (ADR-048) and are not produced here
+anymore. Nothing resets this baseline going forward — releases accumulate normally.
 
 ## Workflow Files
 


### PR DESCRIPTION
## Summary

Two CodeRabbit findings from #985's review, applied here since #985 already merged:

- ADR-059's context section implied both release mechanisms fired unconditionally on every push; only `ci-release.yml` did — `release.yml` is gated on qualifying commits (already stated two lines down, but the summary line was loose about it).
- `versioning-strategy.md`'s "Current Baseline" section still claimed a clean `0.0.0` baseline with no `{app}-v*` tags — directly contradicting ADR-059's own statement (in the same repo) that `api-v*`/`errors-v*`/`web-v*` tags exist and were deliberately preserved during the tag cleanup.

Doc-only, no behavior change.