### PR TITLE
fix(monitoring): derive the comparison set from the fields the sync writes

### DIFF
--- a/toolkit/features/monitoring.py
+++ b/toolkit/features/monitoring.py
@@ -11,7 +11,14 @@ from uptime_kuma_api import UptimeKumaApi
 
 from toolkit.core.logging import logger
 from toolkit.features.configuration import ConfigurationManager
-from toolkit.features.monitoring_diff import diff_monitors, embed_key, extract_key, strip_key
+from toolkit.features.monitoring_diff import (
+    SEED_TO_API_FIELD,
+    WRITABLE_FIELDS,
+    diff_monitors,
+    embed_key,
+    extract_key,
+    strip_key,
+)
 
 # Fields to export per monitor (skip volatile/internal fields)
 _MONITOR_EXPORT_FIELDS = [
@@ -261,47 +268,18 @@ def apply_monitors(project_root: Path) -> None:
         # Get default notification ID for linking
         default_notif_ids = [n["id"] for n in api.get_notifications() if n.get("isDefault")]
 
-        # Only pass fields that _build_monitor_data accepts
-        _ACCEPTED = {
-            "type",
-            "name",
-            "url",
-            "hostname",
-            "port",
-            "interval",
-            "retryInterval",
-            "maxretries",
-            "method",
-            "keyword",
-            "ignoreTls",
-            "upsideDown",
-            "accepted_statuscodes",
-            "description",
-            "httpBodyEncoding",
-            "maxredirects",
-            "parent",
-            "resendInterval",
-            "body",
-            "headers",
-            "basic_auth_user",
-            "basic_auth_pass",
-            "proxyId",
-            "timeout",
-            # notificationIDList excluded — IDs change between instances.
-            # After apply, link notifications manually or via separate sync step.
-        }
-
         def _params(m: dict[str, Any]) -> dict[str, Any]:
-            """Map a seed entry onto the fields the API accepts."""
+            """Map a seed entry onto the fields the API accepts.
+
+            Both the payload and the diff's comparison derive from
+            `WRITABLE_FIELDS`, so "compare exactly what you write" holds by
+            construction instead of by two hand-maintained lists.
+            """
             params: dict[str, Any] = {}
             for k, v in m.items():
-                if v is None:
+                if v is None or k not in WRITABLE_FIELDS:
                     continue
-                # Map snake_case export fields to camelCase API fields
-                if k == "retry_interval":
-                    params["retryInterval"] = v
-                elif k in _ACCEPTED:
-                    params[k] = v
+                params[SEED_TO_API_FIELD.get(k, k)] = v
             # The key rides inside description — Uptime Kuma has no custom field.
             if m.get("key"):
                 params["description"] = embed_key(params.get("description", ""), m["key"])

--- a/toolkit/features/monitoring_diff.py
+++ b/toolkit/features/monitoring_diff.py
@@ -23,22 +23,51 @@ from __future__ import annotations
 import re
 from typing import Any
 
-# Fields excluded from the comparison, applied to BOTH sides.
+# The fields the sync actually writes, named as they appear in the seed.
 #
-# The rule is: compare exactly the fields the sync would write. A field that the
-# apply path never sends can never be reconciled, so flagging it as a difference
-# produces an edit that cannot clear the flag — the monitor is then rewritten on
-# every run, forever. An earlier version stripped these from the live side only,
-# which made all 31 real monitors permanently dirty.
-_IGNORED_IN_COMPARISON = frozenset(
+# This is the SSOT for both halves of the contract: `monitoring._params()` builds
+# its payload from it, and the comparison below is restricted to it. Deriving one
+# from the other is the point — the rule "compare exactly the fields you write"
+# has to be structural, because maintaining it as two hand-kept lists is how the
+# seed ended up with 31 permanently-dirty monitors.
+#
+# A field absent here is one the apply path never sends, so flagging it as a
+# difference would request an edit that cannot clear the flag. Known members of
+# that set, all observed live: `expiryNotification` (in the seed but in neither
+# `_MONITOR_EXPORT_FIELDS` nor the API payload — 20 monitors), `tags` (applied via
+# add_monitor_tag), `notificationIDList` (ids differ per instance), `active`
+# (paused/resumed at runtime), `id`, and `key` (ours; it travels in `description`).
+WRITABLE_FIELDS = frozenset(
     {
-        "key",  # ours, not Uptime Kuma's — it travels inside `description`
-        "id",  # assigned by the instance
-        "active",  # paused/resumed at runtime, not owned by the seed
-        "tags",  # applied through add_monitor_tag, not through edit
-        "notificationIDList",  # excluded from `_ACCEPTED`: ids differ per instance
+        "type",
+        "name",
+        "url",
+        "hostname",
+        "port",
+        "interval",
+        "retry_interval",  # sent as `retryInterval`
+        "maxretries",
+        "method",
+        "keyword",
+        "ignoreTls",
+        "upsideDown",
+        "accepted_statuscodes",
+        "description",
+        "httpBodyEncoding",
+        "maxredirects",
+        "parent",
+        "resendInterval",
+        "body",
+        "headers",
+        "basic_auth_user",
+        "basic_auth_pass",
+        "proxyId",
+        "timeout",
     }
 )
+
+# Seed field names that the API expects under a different name.
+SEED_TO_API_FIELD = {"retry_interval": "retryInterval"}
 
 _MARKER_TEMPLATE = "[kuma-key:{key}]"
 _MARKER_RE = re.compile(r"\n?\[kuma-key:(?P<key>[A-Za-z0-9._-]+)\]")
@@ -74,10 +103,10 @@ def embed_key(description: str | None, key: str) -> str:
 def _comparable(monitor: dict[str, Any]) -> dict[str, Any]:
     """Project a monitor onto the fields that decide whether it differs.
 
-    Both sides go through this, with the same exclusion set — an asymmetric
+    Both sides go through this, restricted to the same set — an asymmetric
     projection is what made every monitor look permanently dirty.
     """
-    out = {k: v for k, v in monitor.items() if k not in _IGNORED_IN_COMPARISON}
+    out = {k: v for k, v in monitor.items() if k in WRITABLE_FIELDS}
     # The marker is an implementation detail of identity, not a user-visible
     # difference — compare the human text so a stamped monitor is not seen as
     # permanently drifted from its own seed entry.
@@ -107,7 +136,10 @@ def _needs_edit(seed_entry: dict[str, Any], live_monitor: dict[str, Any]) -> boo
 
     desired = _comparable(seed_entry)
     current = _comparable(live_monitor)
-    return any(current.get(field) != value for field, value in desired.items())
+    # A `None` in the seed is skipped by the apply path rather than written, so it
+    # cannot be reconciled either. 11 seed entries carry `httpBodyEncoding: null`
+    # against a live `'json'`, which is Uptime Kuma's own default.
+    return any(current.get(field) != value for field, value in desired.items() if value is not None)
 
 
 def diff_monitors(


### PR DESCRIPTION
Follow-up to #992, found by running its plan read-only against the live instance before ever writing to it.

## What the dry run showed

Against rpi3's real 31 monitors, #992 as merged reported **31 edits on a converged seed** — 0 creates, 0 deletes, but every single monitor dirty. Not destructive, but it means every `make monitoring-apply` would rewrite all 31, and the flag could never clear.

Two causes, both the same class #992 fixed *by hand* and therefore missed:

| Field | Seed entries | Why it can never reconcile |
|---|---|---|
| `expiryNotification` | 20 | Present in the seed, but in neither `_MONITOR_EXPORT_FIELDS` nor the API payload — never written. Seed `True`, live `False`. |
| `httpBodyEncoding: null` | 11 | The apply path skips `None` rather than writing it; Kuma reports its own default `'json'`. |

20 + 11 = 31.

## The actual fix

#992 enumerated the excluded fields by hand, which left "compare exactly the fields you write" as a list someone has to keep in sync. It held for the three fields I knew about and silently failed for the two I did not.

`WRITABLE_FIELDS` is now one SSOT that **both** the payload builder and the comparison derive from, so they cannot drift, and a `None`-valued seed field is excluded because the apply path skips it. The duplicated `_ACCEPTED` set is gone — two lists describing the same contract is what caused this.

## Verification

Read-only dry run against rpi3, connecting and diffing locally without writing:

```
=== DRY RUN vs http://100.64.0.6:3001 — nothing written ===
seed=31  live=31
PLAN: create=0  edit=0  delete=0
```

That is AC1's evidence measured against the real instance rather than against fixtures, and it is the thing #992's unit tests could not have produced — the defect lived in the gap between the real seed and what the write path accepts.

- `make test` — 452 passed
- `ruff` and `mypy` clean
- A single altered `interval` is still reported as one edit, so the guard does not silence real drift

## Note for review

This is the second time the same rule was broken in this file, which is why the fix is structural rather than another entry in an exclusion list. The lesson worth keeping: a unit fixture cleaner than production data cannot test the case that matters.

Refs #962, #992
