### PR TITLE
docs(adr): renumber Strands Agents ADR to 060, fixing a collision

### DIFF
--- a/docs/adr/adr-060-strands-agents-reference-only.md
+++ b/docs/adr/adr-060-strands-agents-reference-only.md
@@ -1,5 +1,5 @@
 ---
-id: "adr-059-strands-agents-reference-only"
+id: "adr-060-strands-agents-reference-only"
 type: adr
 status: accepted
 created: "2026-08-10"
@@ -11,7 +11,7 @@ issue: mlorentedev/kubelab#990
 owner: manu
 ---
 
-# ADR-059: Strands Agents — reference only, not adopted
+# ADR-060: Strands Agents — reference only, not adopted
 
 ## Status
 


### PR DESCRIPTION
## Summary

Two parallel worktrees both merged an ADR-059 today: `adr-059-retire-calver-release-bundle.md` (#985) and `adr-059-strands-agents-reference-only.md` (#994). Neither caught it before merge — flagged in this session's handoff but the other session merged #994 as-is anyway.

Renumbers the Strands one to `adr-060` (next free, confirmed against `origin/master`). Only its own `id:` frontmatter and `#` title referenced the old number — no other file in the repo cross-references it, so this is a clean rename.

Doc-only, no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Architecture Decision Record identifier and heading from ADR-059 to ADR-060.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->