### PR TITLE
docs(spec): ADR028-004 stateful service placement — proposal and lesson

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -3565,3 +3565,30 @@ What caught it was not a test. It was running the plan **read-only against the l
 - **A negative control can be invalid in a way that flatters you.** Adding `expiryNotification` to the writable set did *not* reproduce the bug — because the fix makes that field written *and* compared. Reproducing it required breaking the symmetry itself. A control that passes may be testing nothing.
 
 **Tags:** `#declarative-sync` `#uptime-kuma` `#ssot` `#false-negative` `#test-fixtures` `#dry-run` `#negative-control` `#ops-016` `#gotcha`
+---
+
+### [2026-08-11] Nine stateful services were duplicated across environments by a packaging choice, not a decision
+
+**Context:** A question about whether Gitea should run in both staging and prod — a git host duplicated across environments has no obvious meaning — generalised into an audit of every stateful service.
+
+**Problem:** Nine PVCs run in both overlays: `gitea`, `n8n`, `minio`, `postgres`, `loki`, `grafana`, `authelia`, `crowdsec-db`, `crowdsec-config`. No ADR decided that. They are all in `infra/k8s/base/`, and both overlays inherit base, so the topology was set as a side effect of where a file was filed.
+
+Three of them turned out to be inert. Staging `gitea`, `n8n` and `minio` are empty and unused — the operator tests directly in prod — and staging `minio` has no consumer whatsoever, because the only writer is the PVC backup CronJob in `overlays/prod/backup.yaml`, which exists solely in the prod overlay.
+
+Two premises that felt solid were wrong. The vault's `context.md` hardware inventory said Gitea runs on Beelink; the manifests say it is in `base/` and serving on both `gitea.staging.kubelab.live` and `gitea.kubelab.live`, and it appears nowhere in `beelink_services`. A prod e2e run confirmed it live (`TestAPIJsonKeys::test_api_json_contains_keys[gitea]` green against `/api/v1/version`). So #507 — "Deploy Gitea on VPS prod K3s", open and untouched since 2026-06-11 — describes work whose headline was already done.
+
+**Solution:** Two independent axes, not one, recorded as ADR028-004 (#988):
+
+- **Axis 1, environment:** does the state have a promotion path in git? Grafana dashboards and Authelia config do (they are ConfigMaps in git), so staging validates and prod receives the same thing. Gitea repos, n8n workflows and MinIO objects do not.
+- **Axis 2, location:** ADR-028's 3 AM test. Independent of axis 1 — "prod" is an environment, not a machine.
+
+A reference audit found no counter-example: `khuedoan/homelab` declares multi-environment support for workloads but defines `platform/gitea` once; `onedr0p/home-ops` runs one cluster; GitLab's own docs prescribe testing upgrades on a *clone* of production and name "automating production-to-staging restores"; a Gitea mirror is read-only by design to preserve one canonical instance; and the Argo CD management/workload split exists specifically to avoid duplicating platform services per environment.
+
+**Rule:**
+- **If the state has no promotion path, a second instance is not a test bed — it is a fork.** That single question sorts the platform tier from the workload tier, and it is mechanisable, unlike "which services feel like they should be duplicated".
+- **`base/` in Kustomize is a silent multiplier.** Putting a stateful service there is a topology decision wearing a packaging decision's clothes. It duplicates the PVC per overlay with nothing recording that anyone chose it.
+- **The cheapest moment to place a stateful service is before it has state.** Empty means "delete and redeploy"; six months of repos later the same move is a migration with a downtime window and metadata (issues, PRs, webhooks) that git clones do not replicate.
+- **Do not host your control plane's source of truth behind the infrastructure that control plane rebuilds.** Argo CD keeps reconciling from GitHub rather than from the self-hosted Gitea, for the same reason ADR-015 keeps Headscale outside K3s and the Ansible inventory addresses the VPS by public IP — third instance of one doctrine, in three layers.
+- **Trust order held, and it is worth re-stating because the stale source was the vault:** code > repo ADRs > `context.md` > auto-memory. Verify placement against manifests, then against a live probe; never against a hardware inventory in prose.
+
+**Tags:** `#kustomize` `#topology` `#stateful` `#gitea` `#minio` `#n8n` `#adr-028` `#adr-037` `#circular-dependency` `#ssot-drift` `#adr028-004`

--- a/specs/ADR028-004-classify-stateful-service-placement/proposal.md
+++ b/specs/ADR028-004-classify-stateful-service-placement/proposal.md
@@ -1,0 +1,77 @@
+---
+id: "ADR028-004-classify-stateful-service-placement"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-11"
+issue: "mlorentedev/kubelab#988"   # repo#NNN — GitHub issue / Project item that tracks this spec
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# ADR028-004-classify-stateful-service-placement
+
+> **Naming**: file lives at `<repo>/specs/ADR028-004-classify-stateful-service-placement/proposal.md`. `ADR028-004-classify-stateful-service-placement` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #988: ADR028-004: Classify stateful platform services by state promotion and availability -->
+
+Nine stateful PVCs run in both staging and prod for no decided reason: they sit in `infra/k8s/base/`, and both overlays inherit base, so a topology decision was made as a side effect of a packaging choice and no ADR records it. Three of them — `gitea`, `n8n`, `minio` — are verified empty and unused (the operator tests directly in prod, and staging `minio` has no consumer at all since `overlays/prod/backup.yaml` is prod-only), so their second instance is not a test bed but latent divergence. Real data is about to land in Gitea and MinIO, which makes this the last moment the placement is a free decision rather than a stateful migration with a downtime window and metadata that git clones do not replicate.
+
+## What
+
+- A two-axis classification, recorded as an ADR amending [ADR-028](../../docs/adr/adr-028-operational-topology.md) and [ADR-037](../../docs/adr/adr-037-environment-promotion-strategy.md), applied to all nine stateful services: axis 1 asks whether the state has a promotion path in git (dual vs singleton), axis 2 applies ADR-028's 3 AM test (always-on vs on-demand). The axes are independent — "prod" is an environment, not a location.
+- The staging twins of `gitea`, `n8n` and `minio` no longer exist: they leave `base/` and the platform tier becomes singleton. Its intended test path is an ephemeral restore from a prod backup rather than a permanently-live second instance — **declared as doctrine here, not operational**: #487 (verified restore) is open, so that path does not exist yet. It must NOT appear in this spec's acceptance criteria or the spec can never archive.
+- The ADR's table emits a value on **both** axes for **every** service, not only for Gitea. A singleton's location is a separate decision per service: n8n's row is currently blank, and whether its singleton stays in prod K3s or follows Gitea to the platform plane depends on R2's answer.
+- A CI gate fails when a stateful service in `base/` carries no classification, or when state with no git promotion path is duplicated across overlays — turning the rule from prose into something enforced.
+
+## Out of scope
+
+This spec spans more than one PR (the Discipline Gate names a multi-PR sequence as its own trigger), but a single PR still carries a single concern under the ~300-line cap. The list below is out of the **spec**, not merely out of its first PR.
+
+- **MinIO's migration.** MinIO is classified here; it is not moved. Its destination follows from R3 and from the backup path chosen in the wider backup/DR work — moving it before that is deciding the offsite tier by accident.
+- **A promotion path for n8n workflows.** They live in the database with no export/import route, which is why n8n's second instance can only drift. This spec only classifies n8n as a singleton. The gap is **already tracked, twice under one id**: [#501](https://github.com/mlorentedev/kubelab/issues/501) and [#688](https://github.com/mlorentedev/kubelab/issues/688) are both open as `APP-CONFIG-003` (a collision the 2026-07-02 platform audit already named), with [#691](https://github.com/mlorentedev/kubelab/issues/691) closed as `TOOL-009` on the import half. Reconciling those three belongs to the backlog triage ([#823](https://github.com/mlorentedev/kubelab/issues/823)), not here — filing a fourth ticket for the same concern is the pathology, not the fix.
+- **[#264](https://github.com/mlorentedev/kubelab/issues/264) (official Helm charts) and [#503](https://github.com/mlorentedev/kubelab/issues/503) (Gitea mirror, org/team, webhooks).** Both touch the same three services and both already have tickets with their own gates. Absorbing ticketed work here would orphan or duplicate those gates — the ID-collision pathology the 2026-07-02 platform audit documented (ANSIBLE-026 across two issues, TOOL-009 across three places). Packaging is also orthogonal to placement: doing both at once means a break cannot be attributed.
+- **Restructuring `base/` into a `platform/` tier.** Removing three services invites reorganising the rest along the management/workload split the reference audit found. That is a layout refactor and it depends on this classification being settled first.
+- **[#479](https://github.com/mlorentedev/kubelab/issues/479) and [#487](https://github.com/mlorentedev/kubelab/issues/487) (offsite age key, verified restore).** They gate *using* these services with real data. They do not gate *deciding* their placement, and this spec closes without them.
+
+## Risks / open questions
+
+**All six below are MUST-RESOLVE, so `tasks.md` stays unfrozen — each needs an answer backed by measurement, not by inference.**
+
+- **R1 — Which node Gitea lands on.** Its role is settled (private repos and private experiments only; Argo CD keeps reconciling from GitHub), so it no longer inherits prod's always-on requirement and the operator only pushes with the homelab powered on. The doctrine points at Beelink — ADR-028's own "Platform Node", already hosting MinIO and the GitHub runner — but that is 8 GB with three services in it. **Measure the headroom; do not infer it.** Without R1 there is no deployment task to write.
+- **R2 — Beelink is Docker Compose, not K3s.** Placing Gitea there also removes it from Kustomize and from Argo CD's reconciliation. Decide explicitly whether the platform plane being Ansible-managed is the intended shape (defensible: the management plane is deliberately governed differently, and the Argo CD hub already lives outside both clusters) or a GitOps regression that invalidates R1's answer. This is a doctrine question, not a deployment detail.
+- **R3 — The prod backup CronJob loses its destination.** `overlays/prod/backup.yaml` writes the gitea/n8n/authelia PVCs to in-cluster MinIO. If MinIO moves to an on-demand node, that job stops running on schedule and fails silently at 03:00. The likely resolution is that it should never have targeted MinIO: ADR-049 D3 puts the offsite tiers at Hetzner Storage Box and R2, and `minio-data` is already excluded from its own backup as circular. Resolving R3 may relocate the backup target rather than MinIO.
+- **R4 — Where the classification is asserted from.** The repo's own doctrine narrows this close to an answer rather than leaving it open: `common.yaml` already carries a service taxonomy at `apps.services.{core,automation,data,observability,security,network}`, and the SSOT rule forbids a second home for configuration. A manifest annotation would therefore BE a second SSOT. The discriminating question is only whether anything prevents the classification from being fields under `common.yaml`, read by a static test in the style of `tests/test_spoke_rbac_covers_manifests.py` — which runs with the homelab powered off. A gate that parses the ADR prose is the weakest option and is the exact pattern this spec exists to stop.
+
+  The gate's acceptance criterion must assert the **negative** control, not just the positive: "the test FAILS when a stateful service is left unclassified". Two vacuous controls shipped on a single day during OBS-007 — a negative control that broke unreferenced code, and a guard whose bad import was swallowed by a broad `except`, silently skipping 13 tests while reporting green. A gate that cannot be shown to fail is not a gate.
+
+- **R6 — Retiring from `base/` has a blast radius, and one part of it breaks on the first `kubectl kustomize`.** `overlays/prod/patches.yaml` patches **seven** targets that live in `base/`: `gitea-config`, `gitea`, `n8n-config`, `n8n`, `minio-config`, `minio-api`, `minio-console`. Kustomize fails when a patch has no target, so removing these from base without moving the resources into the prod overlay in the same change breaks the prod render immediately. **This fixes the task order; it is not optional sequencing.**
+
+  Cross-cutting consumers that also carry a staging-shaped assumption, all verified present:
+  - `tests/e2e/expectations.py` — entries for all three (lines 111, 114, 122). Without `skip_in_envs=("staging",)` the staging e2e breaks. The precedent is the stale `uptime_kuma` entry that CLAUDE.md documents as not belonging in that list.
+  - `SECRET_CATALOG` in `toolkit/features/secrets_manager.py` — gitea and minio secrets registered `envs=("dev","staging","prod")`. Leaving them makes `secrets-audit` report a staging requirement whose consumer no longer exists (the ANSIBLE-033 class: `envs` is the audit dimension, not the storage location).
+  - Homepage `services.yaml`, Authelia's staging access rules and OIDC clients, and the `apps.services.*` tree in `common.yaml`.
+
+  Rather than enumerate every file in `tasks.md` and miss one, force the sweep with an outcome: both overlays must render and `make test-e2e ENV=staging` must be green after the retirement.
+- **R5 — "Empty" must be proven per instance before any PVC is deleted, not assumed.** The operator reports staging `gitea`, `n8n` and `minio` unused, and staging `minio` provably has no consumer. Deleting a PVC is irreversible and #479 (offsite age key) and #487 (verified restore) are both still open, so there is no recovery path if the report is wrong for one of the three. Require a per-instance emptiness check — repo count, workflow count, bucket listing — captured as output in `verification.md` before the deletion task runs.
+
+## Acceptance criteria
+
+Observable outcomes. Each must be testable.
+
+Deliberately absent: anything asserting the ephemeral restore-from-prod-backup test path. That is declared doctrine, not present capability (#487 is open), and an acceptance criterion depending on it would make this spec unarchivable.
+
+- [ ] **AC1** — The ADR is merged and emits a value on **both** axes for all nine stateful services, with a location cell filled per singleton (not only for Gitea).
+- [ ] **AC2** — The classification is readable from a single SSOT, and a static test fails when a stateful service in `infra/k8s/base/` carries no classification. Verified by **demonstrating the failure**: remove one service's classification, show the test red, restore it, show it green. A passing test alone does not satisfy this criterion.
+- [ ] **AC3** — After the retirement, `kubectl kustomize` renders **both** overlays without error and `make test-e2e ENV=staging` is green. This is the criterion that forces the consumer sweep in R6 rather than an enumeration that can miss a file.
+- [ ] **AC4** — Per-instance emptiness evidence for staging `gitea`, `n8n` and `minio` — repo count, workflow count, bucket listing — is captured as command output in `verification.md` **before** any PVC deletion task runs.
+
+## References
+
+- Bitácora: [kubelab#988](https://github.com/mlorentedev/kubelab/issues/988) — carries the full reference audit and the disposition on #507.
+- Amends: `docs/adr/adr-028-operational-topology.md` (node classification, the 3 AM test), `docs/adr/adr-037-environment-promotion-strategy.md` (what staging is for).
+- Constrains: `docs/adr/adr-049-edge-object-storage-placement-doctrine.md` D3 — MinIO is `tier-object-store`; the offsite tiers are Hetzner Storage Box + R2, so the in-cluster backup hop is not the offsite copy.
+- Precedent for the rejected Argo-CD-from-Gitea option: `docs/adr/adr-015-*` (Headscale outside K3s) and the VPS-uses-public-IP rule in `CLAUDE.md` — the same circular-dependency doctrine, third instance.
+- Related tickets: #507 (headline already done, remainder redistributed), #264 (Helm charts), #503 (mirror/org/webhook config), #479 + #487 (gate *using* these services with real data, not deciding their placement).
+- Vault: `10_projects/kubelab/research/2026-08-10-fronts-inventory-and-lane-split.md` — how this front was scoped, and the stale-`context.md` correction it rests on.

--- a/specs/ADR028-004-classify-stateful-service-placement/tasks.md
+++ b/specs/ADR028-004-classify-stateful-service-placement/tasks.md
@@ -1,0 +1,60 @@
+---
+tags: [spec, tasks, templates]
+created: "2026-08-11"
+---
+
+# Tasks - ADR028-004-classify-stateful-service-placement
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers** (optional, additive — borrowed from `github/spec-kit`, adapt-not-adopt per #141):
+> - `[P]` — this task has **no dependency on another unchecked task**, so it is safe to run in parallel (fan out to a `Workflow`, or just batch). TDD chains (test → implement → refactor of the *same* behavior) are sequential and must NOT carry `[P]`; independent behaviors can.
+> - `[AC<n>]` — this task helps satisfy **acceptance criterion #`<n>`** from `proposal.md`. Lets `/spec check` map coverage deterministically; omit it and the check falls back to semantic judgment.
+
+## Setup
+
+- [ ] Branch created from main: `feat/ADR028-004-classify-stateful-service-placement`
+- [ ] `proposal.md` is complete and acceptance criteria are testable
+- [ ] No open questions left in `proposal.md` "Risks / open questions"
+
+## Implementation
+
+> Replace these with the actual steps for this feature. Keep them small (one commit each) and in TDD order.
+> The `[P]` / `[AC<n>]` markers are optional — see the legend above. Behaviors 1 and 2 below are independent, so their *first* test task carries `[P]`.
+
+- [ ] [P] [AC1] Write failing test for <behavior 1>
+- [ ] [AC1] Implement <module/function> to make it pass
+- [ ] Refactor for clarity (extract, rename, dedupe)
+- [ ] [P] [AC2] Write failing test for <behavior 2>
+- [ ] [AC2] Implement to make it pass
+- [ ] ...
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` (see below) with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/ADR028-004-classify-stateful-service-placement/features.json`):
+
+```json
+[
+  {
+    "id": "ADR028-004-classify-stateful-service-placement-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/ADR028-004-classify-stateful-service-placement/verification.md
+++ b/specs/ADR028-004-classify-stateful-service-placement/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-11"
+---
+
+# Verification - ADR028-004-classify-stateful-service-placement
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+-
+-
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what>
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/ADR028-004-classify-stateful-service-placement/` -> `specs/archive/ADR028-004-classify-stateful-service-placement/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
Scopes the service-placement front. **Documentation only — no manifest, config or code changes.** The retirement this proposal describes is not in this PR.

## What prompted it

Whether Gitea should run in both staging and prod. Generalising the question found nine stateful PVCs duplicated across environments — `gitea`, `n8n`, `minio`, `postgres`, `loki`, `grafana`, `authelia`, `crowdsec-db`, `crowdsec-config` — with no ADR recording that choice. They all sit in `infra/k8s/base/`, and both overlays inherit base, so the topology follows from where a file was filed.

Three are inert: staging `gitea`, `n8n` and `minio` are empty and unused, and staging `minio` has no consumer at all, because the only writer is the PVC backup CronJob in `overlays/prod/backup.yaml` — prod overlay only.

## A premise correction worth flagging

`context.md` in the knowledge store said Gitea runs on Beelink. It does not: it is in `base/`, and it appears nowhere in `beelink_services`. Since a manifest is not live state, this was closed with a probe rather than an argument — `make test-e2e ENV=prod` returned 60 passed / 0 failed including `TestAPIJsonKeys::test_api_json_contains_keys[gitea]`, which asserts `gitea.kubelab.live/api/v1/version` returns JSON carrying a `version` key.

**So #507's headline — "Deploy Gitea on VPS prod K3s" — is already done**, while the issue has been open and untouched since 2026-06-11. The proposal records the disposition: Helm chart to #264, mirror/org/webhooks to #503, "replaces Gitea on K3s staging" to this spec, and the Argo CD source swap to the rejection list.

The inventory has been corrected in the knowledge store. The trust order in the 2026-07-02 platform audit held exactly as written, and the stale source was the vault: code > repo ADRs > `context.md` > auto-memory.

## The classification

Two **independent** axes, one already governed by ADR-037 and the other by ADR-028:

| | Axis 1 — environment | Axis 2 — location |
|---|---|---|
| Question | does the state have a promotion path in git? | ADR-028's 3 AM test |
| Output | dual vs singleton | always-on vs on-demand |

Independent, because **prod is an environment, not a machine** — a prod singleton may legitimately live on the on-demand homelab.

Grafana dashboards and Authelia config promote (they are ConfigMaps in git), Loki logs and CrowdSec decisions are per-env by nature, Postgres is the apps' test database — all correctly dual. Gitea repos, n8n workflows and MinIO objects have no route back from staging, which is the whole finding: **if the state has no promotion path, a second instance is not a test bed, it is a fork.**

## Reference audit

Five sources, one discriminating question — *does it run a second permanently-live instance of a stateful platform service, or a restore-based test path?* — and no counter-example:

| Reference | Second live instance? |
|---|---|
| `khuedoan/homelab` | No — declares multi-environment support for workloads, yet `platform/gitea` is defined once |
| `onedr0p/home-ops` | No — one cluster, no staging tier |
| GitLab official docs | No — prescribes testing upgrades on a *clone* of production; names "automating production-to-staging restores" |
| Gitea mirroring | No — a mirror is read-only by design, to preserve one canonical instance |
| Argo CD architectures | No — the management/workload split exists to avoid duplicating platform services per environment |

The platform tier's test path is a restore from a prod backup, which doubles as a DR drill. That is recorded as **declared doctrine, not present capability** — #487 is open — and is deliberately excluded from the acceptance criteria, since a criterion depending on it would make this spec unarchivable.

## Gitea's role, and why Argo CD keeps reconciling from GitHub

Gitea is for private repos and private experiments. The Argo CD source swap that #507 proposed is on the rejection list, with a reason: a GitOps source hosted behind the infrastructure that control plane rebuilds cannot be reached to repair that infrastructure.

This is the **third instance of one doctrine already in this repo** — ADR-015 keeps Headscale outside K3s because K3s nodes need Tailscale and Tailscale needs Headscale, and the Ansible inventory addresses the VPS by public IP for the same reason. Recording it as a rejection with its rationale is worth more than deleting the line from #507.

Consequence: Gitea no longer inherits prod's availability requirement from GitOps reconciliation, so its location becomes a free choice governed only by its consumers.

## Why `tasks.md` is empty

All six risks in the proposal are MUST-RESOLVE, and the spec workflow forbids drafting tasks over unresolved risks. Two need measurement rather than inference — Beelink's real headroom for a third service on 8 GB, and where the prod backup CronJob should point if MinIO moves to an on-demand node (ADR-049 D3 puts the offsite tiers at Hetzner Storage Box and R2).

One risk is worth surfacing here because it fixes task ordering rather than merely warning: **`overlays/prod/patches.yaml` patches seven targets that live in `base/`** — `gitea-config`, `gitea`, `n8n-config`, `n8n`, `minio-config`, `minio-api`, `minio-console`. Kustomize fails on a patch with no target, so the retirement must move those resources into the overlay in the same change or the prod render breaks immediately. Its cross-cutting consumers are verified present too: `tests/e2e/expectations.py:111,114,122`, and `SECRET_CATALOG` entries for gitea and minio registered `envs=("dev","staging","prod")`.

## Also in this PR

A `docs/lessons.md` entry, as a second commit. Its transferable content is the discriminator above plus the reason the audit went wrong twice: `base/` in Kustomize is a silent multiplier, and a hardware inventory in prose is not evidence of placement.

Refs #988
