### PR TITLE
docs: record both worktree locations and what skipping worktree-init costs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ ON-DEMAND (homelab, powered when working):
 
 - **Commits**: User commits manually or via Claude when explicitly requested. Never commit autonomously.
 - **Branching**: Trunk-based development. `master` only. PRs with squash merge. See CI workflows.
-- **New git worktree**: run `make worktree-init` once in every new worktree under `.worktrees/`. Installs the per-worktree `.venv` via Poetry (~30s first run, ~1s no-op afterwards). Pre-commit hooks are shared automatically via `core.hooksPath` set at `make setup` time — no per-worktree re-install needed.
+- **New git worktree**: run `make worktree-init` once in **every** new worktree, wherever it lives. Installs the per-worktree `.venv` via Poetry (~30s first run, ~1s no-op afterwards). Pre-commit hooks are shared automatically via `core.hooksPath` set at `make setup` time — no per-worktree re-install needed. **Two locations are in use today** and this line used to name only the first: `<repo>/.worktrees/<topic>` (e.g. `.worktrees/dns-cleanup`) and the sibling form `~/Projects/kubelab-<topic>-wt` (`kubelab-improvements-wt`, `kubelab-release-wt`, `kubelab-architecture-wt`). The global Standing Order is *worktrees-outside-repo*, so the sibling form is the one to use for anything new; the in-repo ones are pre-existing. Skipping the init is not a soft failure — the toolkit package is not importable without the `.venv`, so `make test-e2e` dies on `PackageNotFoundError: No package metadata was found for toolkit` rather than on anything that names the real cause.
 - **IaC-first**: Version-controlled config > declarative > automated > manual.
 - **Source of truth**: `infra/config/values/*.yaml` (never .env files)
 - **VPS is ARM**: Multi-arch Docker builds (amd64+arm64) required.


### PR DESCRIPTION
One line in `CLAUDE.md`, from an inconsistency found while scoping ADR028-004 (#988) — unrelated to that spec, so it ships separately.

## Two conventions, one documented

The line said to run `make worktree-init` "in every new worktree under `.worktrees/`". Both locations are live right now:

```
$ git worktree list
/home/manu/Projects/kubelab                          [master]
/home/manu/Projects/kubelab-architecture-wt          [docs/architecture-decisions]
/home/manu/Projects/kubelab-improvements-wt          [feat/improvements]
/home/manu/Projects/kubelab-release-wt               [chore/fix-adr-060-renumber]
/home/manu/Projects/kubelab/.worktrees/dns-cleanup   [fix/dns-record-cleanup]
```

Three of four use the sibling `kubelab-<topic>-wt` form, which is also what the global Standing Order (*worktrees-outside-repo*) prescribes. The instruction was describing the minority case as though it were the only one — so an agent reading it would either put a new worktree inside the repo, against the Standing Order, or conclude the init does not apply to a sibling worktree. The second reading is the expensive one.

## Why the failure mode is worth a clause

Skipping the init is not a soft failure, and it does not name its own cause. Without the per-worktree `.venv` the toolkit package is not importable, so the next command fails like this:

```
ImportError while loading conftest 'tests/e2e/conftest.py'.
toolkit/__init__.py:7: in <module>
    __version__ = version("toolkit")
E   importlib.metadata.PackageNotFoundError: No package metadata was found for toolkit
```

That mentions neither the missing bootstrap nor the fix. It cost two dead runs of `make test-e2e ENV=prod` before being recognised as "this worktree was never initialised", so the clause is there to shorten that path for the next reader.

## Related, not included

`make worktree-init` also fails outright on a machine with no reachable D-Bus SecretService — Poetry raises `SecretServiceNotAvailableException` and the target exits non-zero. Filed separately as #1002 with the scope deliberately unverified: it is not established whether that reproduces in an interactive shell or only in a process without a session bus, and the fix belongs in different places depending on the answer.
