### PR TITLE
docs(lessons): yamllint CI coverage gap

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -3565,3 +3565,18 @@ What caught it was not a test. It was running the plan **read-only against the l
 - **A negative control can be invalid in a way that flatters you.** Adding `expiryNotification` to the writable set did *not* reproduce the bug — because the fix makes that field written *and* compared. Reproducing it required breaking the symmetry itself. A control that passes may be testing nothing.
 
 **Tags:** `#declarative-sync` `#uptime-kuma` `#ssot` `#false-negative` `#test-fixtures` `#dry-run` `#negative-control` `#ops-016` `#gotcha`
+
+### [2026-08-11] `.yamllint`'s own header claimed CI coverage it doesn't have
+
+**Context:** OPS-020 (#966) needed a two-line edit to `infra/config/values/common.yaml` — dropping the redundant `domain:` keys for crowdsec/loki, since every environment already overrides them.
+
+**Problem:** The pre-commit hook failed on `yamllint`, reporting 19 indentation errors scattered across the file, none on the lines touched. Confirmed via `git stash` that the same 19 errors exist unmodified on `master` — pre-existing, unrelated to the edit. The `.yamllint` file's own header comment reads "the single SSOT consumed by pre-commit **AND CI**", but `.github/workflows/ci.yml`'s yamllint step is `yamllint .github/workflows/` — it never touches `infra/config/values/`, `infra/k8s/`, or anything else. The claim was true about which config file governs the rules, and false about where those rules actually get enforced. Nobody had committed to this specific file since the yamllint SSOT was unified (2026-06-27, #795) without hitting the local hook, so the violations accumulated invisibly — CI stayed green because it was never looking.
+
+**Solution:** The 19 errors were all `indentation: wrong indentation, expected N but found N-2` — yamllint's inherited default (`indent-sequences: true`) rejecting this file's actual, uniform, pre-existing style of flush-left sequences. Reformatting the file to satisfy the strict rule would have turned a 2-line fix into a 60-100 line whitespace diff across the single most load-bearing config file in the repo. Set `indentation.indent-sequences: whatever` in `.yamllint` instead — accepts both styles, so it can only remove errors, never introduce new ones elsewhere in the repo (verified: `yamllint infra/config/values/` clean afterward, no new violations surfaced).
+
+**Rule:**
+- **A comment claiming "X enforces this" is a claim, not a guarantee — check what X actually runs, not what its header says it runs.** `ci.yml`'s yamllint step covers one directory; nothing else in the repo is CI-linted for YAML at all, so any of the other values/K8s/ansible YAML files could carry the same kind of dormant violation today.
+- **When a lint failure's errors don't touch your diff, check master first.** `git stash && yamllint <file>` before assuming the failure is yours to fix as part of the change — it decides whether the fix belongs in this PR or is separable policy work.
+- **Reformatting to satisfy a linter and relaxing the linter to match reality are different fixes with different blast radii.** The existing style was uniform across the whole file, not sloppy — that made it the file's convention, not a defect, and the config was wrong for not accepting it.
+
+**Tags:** `#yamllint` `#ci-gap` `#pre-commit` `#false-assumption` `#config-drift` `#ops-020` `#gotcha`


### PR DESCRIPTION
Docs-only lesson from OPS-020 (#966, PR #995, merged): while fixing two dead public DNS records, an unrelated pre-existing yamllint failure surfaced in `infra/config/values/common.yaml` (19 indentation errors, none on the touched lines).

Root cause: `.github/workflows/ci.yml`'s yamllint step only ever lints `.github/workflows/`, despite `.yamllint`'s own header claiming to be consumed by pre-commit AND CI. Any other YAML in the repo could carry the same kind of dormant violation, invisible until someone edits it locally.

No code change here — just capturing the lesson per the session handoff's knowledge-harvest step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a lesson explaining the scope and behavior of YAML linting in CI.
  * Documented accepted sequence-indentation styles and guidance for interpreting lint failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->