### PR TITLE
chore(release): add infra and toolkit as optional release-please packages

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,4 +1,6 @@
 {
   "apps/api": "1.1.4",
-  "edge/errors": "1.1.5"
+  "edge/errors": "1.1.5",
+  "infra": "0.0.0",
+  "toolkit": "0.0.0"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "tag-separator": "-",
+  "bootstrap-sha": "1e6cf424eb8a2e4b149386e5b63e2840aed3bf01",
   "changelog-sections": [
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},
@@ -19,6 +20,16 @@
     "edge/errors": {
       "release-type": "simple",
       "component": "errors"
+    },
+    "infra": {
+      "release-type": "simple",
+      "component": "infra",
+      "initial-version": "0.1.0"
+    },
+    "toolkit": {
+      "release-type": "simple",
+      "component": "toolkit",
+      "initial-version": "0.1.0"
     }
   }
 }


### PR DESCRIPTION
Closes #989 (VER-009), the optional follow-up flagged in ADR-059.

## What

Adds `infra` and `toolkit` as two separate release-please packages, so both
can get a human-gated `infra-vX.Y.Z` / `toolkit-vX.Y.Z` release with a real
changelog — showcase/communication value for a public portfolio repo, per
the design already resolved in ADR-059. Neither has a technical consumer
pinned to a fixed version (Argo CD syncs `infra/k8s` from git HEAD, the
toolkit CLI runs at HEAD via `poetry run`), so this stays optional/P3.

- `release-please-config.json`: two new `simple` packages, `infra` and
  `toolkit`, each with `initial-version: 0.1.0`.
- Top-level `bootstrap-sha` pinned to this branch's base commit, so the
  first release-please pass for these two new packages doesn't scan the
  entire repo history under `infra/`/`toolkit/` for conventional commits
  (verified below — without it, the first pass proposed `toolkit: 1.0.0`
  with a changelog going back to the 2026 K3s migration).
- `.release-please-manifest.json`: seeded both paths at `0.0.0` (the
  bootstrap placeholder release-please itself will overwrite once the
  first real release PR merges).

`apps/api`/`edge/errors` are untouched — same `release-type`, no
`bootstrap-sha` (they already have real tags, so it's dormant for them
per release-please's own docs: it only applies "for the initial release
of a library").

## Verification

No CI job builds anything for these two packages (checked `release.yml`
end to end — `publish-api`/`publish-errors`/`promote-errors` are all
gated on `api_release_created`/`errors_release_created` specifically, so
`infra`/`toolkit`'s new release-please outputs are inert until something
is deliberately wired to them).

Local dry-runs against an isolated scratch clone (`release-please
release-pr --dry-run --local`, never touching the real repo or opening
anything):

1. Clean bootstrap: 0 commits found for `infra`/`toolkit` right after the
   bootstrap commit — `Would open 0 pull requests`, no changelog dump.
2. No double-counting: a synthetic `fix(api):` commit only bumped
   `apps/api` (1 commit); a synthetic `fix(infra):` commit only bumped
   `infra` (1 commit, proposed version `0.1.0`, changelog contained just
   that one commit) — `edge/errors` and `toolkit` both stayed at 0
   commits in both cases.
3. Accumulate-then-merge flow matches the existing `apps/api`/`edge/errors`
   mechanism (`separate-pull-requests: false` groups everything pending
   into one PR) — no new mechanism introduced.

## Test plan

- [x] `python3 -c "import json; json.load(open(...))"` — both files valid JSON
- [x] Local dry-run: clean bootstrap (0 commits, 0 PRs)
- [x] Local dry-run: synthetic `apps/api` commit does not bump `infra`/`toolkit`
- [x] Local dry-run: synthetic `infra` commit does not bump `apps/api`/`edge/errors`/`toolkit`
- [ ] Real first release-please pass on `master` (will only fire once a
      commit actually touches `infra/` or `toolkit/`, per design)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added release tracking for the `infra` and `toolkit` packages.
  * Initialized package versions for upcoming releases.
  * Stabilized release configuration with a fixed baseline reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->