### PR TITLE
fix(toolkit): drop dead blog/wiki app references from orchestrator

### DIFF
--- a/toolkit/features/orchestrator.py
+++ b/toolkit/features/orchestrator.py
@@ -156,7 +156,9 @@ class DeploymentOrchestrator:
         self._run_ansible_playbook("setup.yml")
 
     def _build_applications(self) -> None:
-        applications = ["api", "web", "blog", "wiki"]
+        # web is a platform app (deployed via promote-prod.yml/web-image-receiver.yml)
+        # but its source lives in mlorentedev/web (ADR-053) — nothing to build locally.
+        applications = ["api"]
         for app in applications:
             try:
                 app_dir = self.settings.project_root / PATH_STRUCTURES.APPS_DIR / app
@@ -180,7 +182,7 @@ class DeploymentOrchestrator:
 
     def _deploy_applications(self) -> None:
         if self.env == "dev":
-            applications = ["api", "web", "blog", "wiki"]
+            applications = ["api"]
             for app in applications:
                 command.run(
                     f"poetry run toolkit apps up {app} --env dev",
@@ -224,14 +226,19 @@ class DeploymentOrchestrator:
             logger.warning(f"Status check failed: {e}")
 
     def _check_prod_status(self) -> None:
+        # blog was killed and wiki was retired into `toolkit docs` (see common.yaml);
+        # web's source lives in mlorentedev/web (ADR-053) but is still deployed here.
         production_services = {
             "api": "https://api.kubelab.live/health",
             "web": "https://mlorente.dev",
-            "blog": "https://blog.mlorente.dev",
-            "wiki": "https://wiki.mlorente.dev",
         }
-        for _service, url in production_services.items():
-            command.run(f"curl -s -o /dev/null {url}", check=False)
+        for service, url in production_services.items():
+            result = command.run(f"curl -s -o /dev/null -w '%{{http_code}}' {url}", check=False)
+            status_code = result.stdout.strip() if result.returncode == 0 else ""
+            if status_code.startswith(("2", "3")):
+                logger.success(f"✓ {service} is reachable ({url}, HTTP {status_code})")
+            else:
+                logger.warning(f"✗ {service} did not respond as expected ({url})")
 
         try:
             self._run_ansible_playbook("main.yml", extra_args=["--tags", "verify", "--check"])


### PR DESCRIPTION
Quick-win fix found incidentally while researching a docs rewrite (versioning-strategy.md/cicd.md).

## What was wrong

`DeploymentOrchestrator._build_applications`/`_deploy_applications` iterated
`["api", "web", "blog", "wiki"]` for local dev build/deploy. Harmless in
practice — `apps/blog` and `apps/wiki` don't exist, so the `app_dir.exists()`
guard already skipped them — but misleading to read.

`_check_prod_status` was a real (if silent) bug: it curled
`blog.mlorente.dev` and `wiki.mlorente.dev` — blog was killed, wiki was
retired into `toolkit docs` (see the comment at `apps.platform.wiki` in
`common.yaml`) — and discarded every curl result without ever inspecting
the exit code or printing anything. `toolkit deployment status --env prod`
has been reporting nothing for the prod-status check regardless of whether
prod was actually up.

## What changed

- `_build_applications`/`_deploy_applications`: app list is just `["api"]`
  now. `web`'s source lives in `mlorentedev/web` (ADR-053) — nothing to
  build locally even though its deployment is still tracked in this repo.
- `_check_prod_status`: checks only the two real prod services (`api`,
  `web`), captures the HTTP status code, and logs success/failure per
  service instead of discarding the result.

## Verification

- [x] `ruff check` / `mypy` clean on the changed file
- [x] Full suite: 452 passed (`DeploymentOrchestrator` has zero existing
      test coverage — nothing to update, nothing regressed)
- [x] Grepped the rest of `toolkit/` for other `blog`/`wiki`-as-deployable-app
      residue: none found. The remaining `wiki` hits (`generator_wiki.py`,
      `config.py`'s `generate` command) are the real, currently-functioning
      `toolkit docs` generator — unrelated, correctly scoped, not touched.