### PR TITLE
docs: rewrite versioning-strategy.md and cicd.md around release-please

### DIFF
--- a/docs/architecture/versioning-strategy.md
+++ b/docs/architecture/versioning-strategy.md
@@ -4,98 +4,98 @@ type: architecture
 status: active
 tags: [kubelab, ci-cd, versioning]
 created: "2026-02-21"
-updated: "2026-02-28"
+updated: "2026-08-12"
 owner: manu
 ---
 
 # Versioning Strategy
 
-KubeLab uses **two complementary versioning schemes** that follow industry standards for Gitflow monorepos.
+KubeLab versions each deployable component independently via [release-please](https://github.com/googleapis/release-please), driven by [Conventional Commits](https://www.conventionalcommits.org/). There is no global version — see [ADR-059](../adr/adr-059-retire-calver-release-bundle.md) for why a repo-wide CalVer bundle was retired rather than kept alongside it.
 
-## 1. Per-App Semantic Versioning
+## What gets a semver release
 
-Each application (`api`, `blog`, `web`) is versioned independently based on its own commit history. This is the standard approach for monorepos (Google, Uber, Netflix).
+release-please tracks two components in this repo (`release-please-config.json`), matching [ADR-046](../adr/adr-046-gitops-delivery-promotion-strategy.md) D2 (sole semver authority) and the pin-vs-HEAD rule from ADR-059 (a component gets a release only if something references it by a fixed version):
 
-**Tool:** `paulhatch/semantic-version@v5` in `ci-pipeline.yml`
-**Tag prefix:** `{app}-v` (e.g., `api-v1.2.3`)
+| Component | Path | Tag prefix | Consumer that pins to it |
+|---|---|---|---|
+| `api` | `apps/api/` | `api-v` | `infra/k8s/base/kustomization.yaml` image tag |
+| `errors` | `edge/errors/` | `errors-v` | `infra/k8s/base/kustomization.yaml` image tag |
 
-### Version by branch
+`infra/` and `toolkit/` are applied at git `HEAD` (Argo CD sync, `poetry run toolkit`) — nothing pins to a version of either, so they have no release-please package. `web` also carries an independent semver, but its source and release-please config live in its own repo (`mlorentedev/web`, extracted per [ADR-053](../adr/adr-053-platform-product-repos.md)) — only its *deployment* (staging/prod version pins) is tracked here, promoted the same way `api` is (see [gitops-delivery-promotion.md](../runbooks/gitops-delivery-promotion.md)).
 
-| Branch | Docker Tag | Git Tag | Example |
-|--------|-----------|---------|---------|
-| `master` | `{version}` + `:latest` | `{app}-v{version}` | `kubelab-api:1.2.3` |
-| `develop` | `{version}-rc.{increment}` + `:dev` | None | `kubelab-api:1.2.0-rc.5` |
-| `feature/*` | `0.0.0-dev.{sha}` + `:dev` | None | `kubelab-api:0.0.0-dev.a1b2c3d` |
-
-### Version bump rules (Conventional Commits)
+## Version bump rules (Conventional Commits)
 
 | Commit prefix | Bump | Example |
-|--------------|------|---------|
+|---|---|---|
 | `fix:` | Patch (x.y.**Z**) | `fix: resolve auth timeout` |
 | `feat:` | Minor (x.**Y**.0) | `feat: add user profile API` |
-| `feat!:` or `BREAKING CHANGE` | Major (**X**.0.0) | `feat!: change API response format` |
-| `docs:`, `chore:`, `style:`, `ci:` | None | `docs: update README` |
+| `feat!:` or `BREAKING CHANGE` footer | Major (**X**.0.0) | `feat!: change API response format` |
+| `docs:`, `chore:`, `style:`, `refactor:`, `ci:` | None | `docs: update README` |
 
-### Independent versioning
+Only commits touching a component's own path (`apps/api/**`, `edge/errors/**`) count toward its bump — `separate-pull-requests: false` still accumulates both into one combined release-please PR when both have pending changes, but the version math per component stays isolated (a commit under `apps/api/` never bumps `errors`, or vice versa).
 
-Apps version independently based on changes in their own `apps/{app}/` directory:
+## Docker image tag lifecycle
 
-```
-api: feat: new endpoint    → api-v0.2.0
-web: fix: button color     → web-v0.1.1
-blog: (no changes)         → (no build, no version bump)
-```
+There is no RC scheme (`-rc.N` was dropped — see `ci-cleanup.yml`'s comment and the janitor's own retention logic).
 
-### Docker image registry
+| Stage | Tag | Produced by | Mutable? |
+|---|---|---|---|
+| Feature/fix/hotfix/chore branch (pre-merge preview) | `sha-<short>` | `ci-pipeline.yml` → `ci-publish.yml` on the PR | No — one tag per commit |
+| Staging (continuous, every merge to `master`) | `sha-<short>` | `staging-deploy.yml` (`api`) / `web-image-receiver.yml` (`web`, cross-repo dispatch) | No |
+| Prod (`api`) | `X.Y.Z` + `:latest` | `release.yml`'s `publish-api` job — **re-tags** the staging-validated `sha-<short>` digest, never rebuilds ([ADR-056](../adr/adr-056-build-once-monorepo-apps.md), build-once) | No |
+| Prod (`errors`) | `X.Y.Z` | `release.yml`'s `publish-errors` job — rebuilds; `errors` is edge infra, explicitly out of the build-once staging-sha lane | No |
+| Prod (`web`) | `X.Y.Z` | Built in `mlorentedev/web`'s own CI, promoted here via `promote-prod.yml` | No |
 
-```
-{DOCKERHUB_USERNAME}/kubelab-api:{version}
-{DOCKERHUB_USERNAME}/kubelab-blog:{version}
-{DOCKERHUB_USERNAME}/kubelab-web:{version}
-```
+Build-once parity (`api` only) is verified in-job by comparing the staging and prod tag's manifest-list digest — a mismatch fails the release rather than silently shipping unvalidated bytes.
 
-`REGISTRY_PREFIX` defaults to `kubelab` (configurable via GitHub repo variable).
+## How a release actually ships
 
-## 2. No global release bundle
+This is release-please's job (cut the tag + changelog + Docker artifact); **getting that artifact into staging or prod is a separate, deliberate step** — see [gitops-delivery-promotion.md](../runbooks/gitops-delivery-promotion.md) for the full model. Two shapes exist:
+
+- **`api`/`web`**: staging tracks every merge automatically (an auto-opened PR, human merges); prod is promoted manually via the `promote-prod.yml` `workflow_dispatch` (pick app + version, human merges the resulting PR).
+- **`errors`**: `release.yml`'s `promote-errors` job auto-opens a PR pinning the new tag — one version, both environments (`edge.errors.version` is a single env-agnostic SSOT, [DELIVERY-003](https://github.com/mlorentedev/kubelab/issues/776)) — a human still merges it, but there's no separate staging step and no manual dispatch.
+
+None of this auto-commits to `master` directly — `master` is protected; every version change lands as a reviewed PR (ADR-046 D3/D6).
+
+## No global release bundle
 
 `ci-release.yml` (the CalVer `vYYYY.MM.DD` + zip bundle described in earlier versions of
 this doc) was retired — see
 [ADR-059](../adr/adr-059-retire-calver-release-bundle.md). Nothing in the repo pinned to it,
 and its `make deploy` instructions predated the K3s/Argo CD GitOps deploy path. `infra/` and
-`toolkit/` are applied at git `HEAD` (Argo CD sync, Ansible, `poetry run toolkit`) and have no
-release of their own — see ADR-059 for the pin-vs-HEAD rationale and the optional showcase-release
-follow-up.
+`toolkit/` are applied at git `HEAD` and have no release of their own — see ADR-059 for the
+pin-vs-HEAD rationale and the optional showcase-release follow-up.
 
-## GitOps Auto-Update
+## Current baseline
 
-On `master` and `develop`, the CI automatically commits version bumps to config files:
+`api-v*` and `errors-v*` tags exist and are cut by release-please as described above. `web-v*`
+tags remain from before the `web` app was extracted to its own repo (ADR-048) and are not
+produced here anymore.
 
-- `master` → updates `infra/config/values/prod.yaml`
-- `develop` → updates `infra/config/values/staging.yaml`
+## Workflow files (versioning-relevant)
 
-Commit format: `chore(infra): update {app} version to {version} [skip ci]`
+| File | Role |
+|---|---|
+| `ci-pipeline.yml` | Per-PR: builds the `sha-<short>` preview tag for the changed app(s) |
+| `release.yml` | release-please: cuts `api-vX.Y.Z`/`errors-vX.Y.Z`, re-tags (`api`) or rebuilds (`errors`), auto-promotes `errors` |
+| `staging-deploy.yml` / `web-image-receiver.yml` | Continuous staging promotion (`api` / `web`) |
+| `promote-prod.yml` | Manual gated prod promotion (`api`/`web`) |
+| `ci-cleanup.yml` | Weekly janitor — prunes old `sha-*` tags, never touches prod semver |
 
-## Current Baseline
+Full pipeline (validation, security scanning, drift gates, board automation) is in
+[cicd.md](../runbooks/cicd.md).
 
-Stale from the 2026-02-28 pre-restructuring reset (`develop → master`, `blog`, no tags yet
-are no longer real — see DOCS-002 for the full rewrite). Current state: `api-v*` and
-`errors-v*` tags exist and are cut by release-please as described above; `web-v*` tags remain
-from before the `web` app was extracted to its own repo (ADR-048) and are not produced here
-anymore. Nothing resets this baseline going forward — releases accumulate normally.
+## Best practices
 
-## Workflow Files
-
-| File | Purpose |
-|------|---------|
-| `ci.yml` | Orchestrator: validate, detect changes, dispatch per-app pipelines |
-| `ci-pipeline.yml` | Per-app: version calculation, build, test, security scan, Docker push, GitOps update |
-| `ci-publish.yml` | Reusable: Docker build + push + Trivy scan |
-| `release.yml` | release-please: per-component semver; `api` re-tags the staging digest instead of rebuilding (build-once, ADR-056), `errors` still rebuilds |
-
-## Best Practices
-
-1. **Always use conventional commits** — they drive version bumps automatically
-2. **Keep feature branches short-lived** — merge to develop frequently
-3. **Delete branches after merge** — prevents zombie tags
-4. **Never manually create version tags** — let CI handle it
-5. **Monitor Docker tags** — only `kubelab-*` image repos should exist
+1. **Always use Conventional Commits** — they drive every version bump automatically; a commit
+   with the wrong prefix either doesn't bump when it should, or bumps the wrong number.
+2. **Keep feature/fix/hotfix/chore branches short-lived** — `master` is the only permanent
+   branch (trunk-based); there is no `develop` to stage work in.
+3. **Never hand-create a version tag or edit `.release-please-manifest.json`'s tracked
+   versions** — let release-please own both; a manual edit fights the next release PR.
+4. **A merged release-please PR is not a deploy** — the code was already on staging from its
+   original feature-branch merge; release-please just cuts the prod-ready semver. Prod itself
+   always needs the explicit `promote-prod.yml` dispatch (`api`/`web`) or the auto-opened
+   `promote-errors` PR merge (`errors`).
+5. **Monitor Docker tags** — only `kubelab-*` image repos should exist on the registry; the
+   weekly `ci-cleanup.yml` prune keeps `sha-*` tag counts bounded.

--- a/docs/runbooks/cicd.md
+++ b/docs/runbooks/cicd.md
@@ -4,6 +4,7 @@ type: runbook
 status: active
 tags: [runbook, kubelab]
 created: "2026-02-08"
+updated: "2026-08-12"
 owner: manu
 ---
 
@@ -11,7 +12,15 @@ owner: manu
 
 ## Overview
 
-GitHub Actions CI/CD pipeline for KubeLab. 4 workflow files handle validation, build, Docker publish, and release bundling.
+GitHub Actions CI/CD for KubeLab: 11 workflow files covering PR validation, per-app build/test,
+Docker publish, release-please, continuous staging delivery, gated prod promotion, and repo
+housekeeping (image pruning, config-drift gates, bitácora board automation).
+
+For **how a build actually reaches staging/prod** (the delivery model, troubleshooting
+promotion, rollback), see [gitops-delivery-promotion.md](gitops-delivery-promotion.md) — that
+is the canonical doc; this runbook covers the pipeline mechanics and workflow inventory. For
+**what gets versioned and how**, see
+[versioning-strategy.md](../architecture/versioning-strategy.md).
 
 ## Prerequisites
 
@@ -20,71 +29,80 @@ GitHub Actions CI/CD pipeline for KubeLab. 4 workflow files handle validation, b
 - Git repository cloned with tags fetched (`git fetch --tags`)
 - DockerHub account with valid access token (Read & Write)
 
-## Pipeline Architecture
+## Pipeline architecture
 
-```
-ci.yml (entry point)
-├── validate          → yamllint, branch rules, Makefile syntax
-├── detect-changes    → dorny/paths-filter (blog, api, web)
-└── {app}-pipeline    → calls ci-pipeline.yml per changed app
-    ├── semver        → paulhatch/semantic-version (tag prefix: {app}-v)
-    ├── app validation → Go vet/build, npm build, Jekyll build
-    ├── security scan → gitleaks, bandit, gosec, npm audit
-    └── call-publish  → calls ci-publish.yml
-        ├── Docker build (multi-arch amd64+arm64)
-        ├── Docker push to DockerHub
-        ├── Trivy scan → GitHub Security tab
-        └── n8n webhook notification
-
-release.yml (release-please, on push to master)
-├── Per-component semver PR → api-v{X.Y.Z}, errors-v{X.Y.Z}
-└── On merge → api re-tags the staging digest (build-once, ADR-056); errors rebuilds
+```mermaid
+flowchart LR
+    PR["PR: feature/*, fix/*,<br/>hotfix/*, chore/*"] --> CI["ci.yml<br/>validate + test + detect-changes<br/>(api, errors)"]
+    CI --> BUILD["ci-pipeline.yml → ci-publish.yml<br/>build sha-&lt;short&gt; preview image"]
+    BUILD --> MERGE["squash-merge to master<br/>(protected, 0 reviews, admins enforced)"]
+    MERGE --> SD["staging-deploy.yml (api)<br/>web-image-receiver.yml (web, cross-repo)<br/>build sha-&lt;short&gt; + open deploy PR"]
+    SD --> AS["Argo CD staging<br/>selfHeal: false (ADR-037)"]
+    MERGE --> RP["release.yml (release-please)<br/>api-vX.Y.Z / errors-vX.Y.Z"]
+    RP -->|"api: re-tag staging digest<br/>(ADR-056 build-once)"| PP["promote-prod.yml<br/>manual dispatch, human-gated"]
+    RP -->|"errors: rebuild + auto-open<br/>promote PR (DELIVERY-003)"| PPE["human merges<br/>pin PR"]
+    PP --> AP["Argo CD prod<br/>selfHeal: true"]
+    PPE --> AP
 ```
 
-There is no global/CalVer release step. `ci-release.yml` (the `vYYYY.MM.DD` + zip bundle
-this diagram used to show here) was retired — see
-[ADR-059](../adr/adr-059-retire-calver-release-bundle.md). This file otherwise predates the
-current pipeline (`ci-pipeline.yml`, `paulhatch/semantic-version`, `develop`, `blog`/`web`
-below are no longer real) — full rewrite tracked as DOCS-002.
+Nothing commits to `master` directly outside this flow — it is protected (0 required reviews,
+admins enforced, no force-push/deletion). Every version or deploy change lands as a PR.
 
-## Docker Registry
+## Runner routing
+
+CI runs on GitHub-hosted runners by default (`ubuntu-latest`) since the repo is public and
+hosted minutes are free — see [ADR-030](../adr/adr-030-self-hosted-ci-runner.md) (amended
+2026-06-26). Self-hosted (`kubelab-bee`, the Beelink on-demand node) is opt-in:
+
+```bash
+gh variable set RUNNER_DOCKER --body '["self-hosted","linux","docker"]'  # opt in
+gh variable unset RUNNER_DOCKER                                          # falls back to hosted
+```
+
+Every job that can route routes via `fromJSON(vars.RUNNER_DOCKER || '"ubuntu-latest"')`.
+**Fork PRs are always forced to `ubuntu-latest`**, regardless of the variable — a self-hosted
+runner has Docker socket access, and a fork PR's workflow content isn't trusted. `ci.yml` and
+`check-config-drift.yml` both carry this fork check explicitly (`github.event.pull_request.head.repo.fork`).
+
+Superseded runs are cancelled on a new push to the same PR/ref
+(`concurrency: cancel-in-progress: true` on `ci.yml` and `check-config-drift.yml`) — frees
+runners instead of letting stale builds occupy the fleet.
+
+## Docker registry
 
 - **Registry**: `mlorentedev/kubelab-{app}` (e.g., `mlorentedev/kubelab-api`)
 - **Config variable**: `vars.REGISTRY_PREFIX` (default: `kubelab`)
 
-## Versioning Strategy
+## Versioning
 
-| Branch | Docker Tag | Git Tag | Example |
-|--------|-----------|---------|---------|
-| feature/* | `0.0.0-dev.{sha}` | none | `0.0.0-dev.a1b2c3d` |
-| develop | `X.Y.Z-rc.N` | `{app}-v{X.Y.Z}` | `1.2.3-rc.5` |
-| master | `X.Y.Z` + `:latest` | `{app}-v{X.Y.Z}` | `1.2.3` |
+Full detail in [versioning-strategy.md](../architecture/versioning-strategy.md). In short:
+release-please owns `api`/`errors` semver (Conventional Commits drive the bump); feature
+branches and staging both run immutable `sha-<short>` tags; prod runs immutable semver. No
+RC scheme, no CalVer bundle (see [ADR-059](../adr/adr-059-retire-calver-release-bundle.md)).
 
-- Default bump: **patch** (every commit)
-- Minor bump: include `(MINOR)` in commit body
-- Major bump: include `(MAJOR)` in commit body
-- Versioning restarted from `0.0.1` on 2026-02-16 (registry rebrand)
-
-## Change Detection Paths
+## Change detection paths
 
 | App | Triggers on changes to |
-|-----|----------------------|
-| api | `apps/api/src/**`, `apps/api/go.mod`, `apps/api/go.sum`, `apps/api/Dockerfile`, `infra/stacks/apps/api/**` |
-| web | `apps/web/site/**`, `apps/web/Dockerfile`, `infra/stacks/apps/web/**` |
-| blog | `apps/blog/jekyll-site/**`, `apps/blog/Dockerfile`, `infra/stacks/apps/blog/**` |
+|---|---|
+| `api` | `apps/api/**` |
+| `errors` | `edge/errors/**` |
 
-Changes to `infra/config/values/*.yaml` do NOT trigger rebuilds (GitOps pull model).
+`web` has no build trigger in this repo — its source and CI live in `mlorentedev/web`; a
+`repository_dispatch` (`web-image-published`) is what reaches `web-image-receiver.yml` here.
+Changes to `infra/config/values/*.yaml` do NOT trigger app rebuilds (GitOps pull model).
 
-## Required GitHub Secrets
+## Required GitHub secrets
 
 | Secret | Purpose | How to rotate |
-|--------|---------|---------------|
+|---|---|---|
 | `DOCKERHUB_USERNAME` | DockerHub login user | `github-secrets-manager.sh --from-mapping --select DOCKERHUB_USERNAME` |
 | `DOCKERHUB_TOKEN` | DockerHub push access (Read & Write) | Regenerate at hub.docker.com/settings/security, then `github-secrets-manager.sh --from-mapping --select DOCKERHUB_TOKEN` |
-| `N8N_WEBHOOK_URL` | Build notification endpoint | Update in n8n, then `gh secret set N8N_WEBHOOK_URL` |
+| `N8N_WEBHOOK_URL` | Build notification endpoint (ADR-044 envelope) | Update in n8n, then `gh secret set N8N_WEBHOOK_URL` |
 | `N8N_DEPLOY_TOKEN` | Webhook auth token | Rotate in n8n, then `gh secret set N8N_DEPLOY_TOKEN` |
+| `RELEASE_PLEASE_TOKEN` | PAT used by release-please and every auto-opened deploy/promotion PR — a `GITHUB_TOKEN`-opened PR does not trigger `on: pull_request` checks, so it could never be merged | Regenerate the PAT (repo + workflow scopes), then `gh secret set RELEASE_PLEASE_TOKEN` |
+| `BITACORA_PAT` | Board automation (`add-to-project.yml`); skipped gracefully for fork/Dependabot PRs, which run without repo secrets | Regenerate the PAT, then `gh secret set BITACORA_PAT` |
 
-**Rotation workflow** (using dotfiles):
+**Rotation workflow** (DockerHub, using dotfiles):
 
 ```bash
 # 1. Rotate the secret in dotfiles (decrypts → prompts new value → re-encrypts)
@@ -99,7 +117,7 @@ gh secret list
 
 See [sops-and-secrets](sops-and-secrets.md) for KubeLab-specific secrets (Authelia, Grafana, MinIO, etc.).
 
-## Common Operations
+## Common operations
 
 ### Trigger manual build
 
@@ -121,16 +139,15 @@ gh run view <run-id> --log
 git diff --name-only HEAD~1
 
 # Filter by apps
-git diff --name-only HEAD~1 | grep -E "(apps/blog|apps/api|apps/web)"
+git diff --name-only HEAD~1 | grep -E "(apps/api|edge/errors)"
 ```
 
 ### Debug version calculation
 
 ```bash
-# View latest tags per app
+# View latest tags per component
 git tag --sort=-version:refname | grep "api-v" | head -3
-git tag --sort=-version:refname | grep "web-v" | head -3
-git tag --sort=-version:refname | grep "blog-v" | head -3
+git tag --sort=-version:refname | grep "errors-v" | head -3
 
 # Commits since last tag
 git log $(git tag --sort=-version:refname | grep "api-v" | head -1)..HEAD --oneline -- apps/api/
@@ -146,7 +163,7 @@ gh run rerun <run-id> --failed
 
 ```bash
 # Check image exists on DockerHub
-docker manifest inspect mlorentedev/kubelab-api:0.0.0-dev.abc1234
+docker manifest inspect mlorentedev/kubelab-api:sha-abc1234
 
 # Pull and test locally
 docker pull mlorentedev/kubelab-api:latest
@@ -168,72 +185,69 @@ Token was created with Read-only permissions. Regenerate with **Read, Write, Del
 
 ### Version not bumping
 
-- Check `branch` field in semver config matches actual default branch (`master`)
-- Ensure tag prefix matches: `{app}-v` (e.g., `api-v1.0.0`)
-- Verify `fetch-depth: 0` and `fetch-tags: true` in checkout step
+- Check the commit's Conventional Commits prefix matches what you expect (`fix:`/`feat:`/`feat!:`)
+- Verify the commit actually touches the component's path (`apps/api/**` or `edge/errors/**`) —
+  release-please won't bump a component for commits outside its path
+- Confirm `release-please-config.json` / `.release-please-manifest.json` weren't hand-edited
+  (release-please owns both)
 
 ### Trivy SARIF upload fails
 
 - Ensure job has `permissions: security-events: write`
-- Uses `github/codeql-action/upload-sarif@v4` (not v3)
+- Uses `github/codeql-action/upload-sarif@v4`
 
-### Push rejected after CI GitOps commit
+### A deploy/promotion PR never gets its checks
 
-The pipeline auto-commits version updates to `infra/config/values/{env}.yaml` on the same branch (via `stefanzweifel/git-auto-commit-action`). This means after CI runs, the remote has a commit you don't have locally.
+The PR was opened with `GITHUB_TOKEN` instead of `RELEASE_PLEASE_TOKEN` — a `GITHUB_TOKEN`-opened
+PR does not trigger `on: pull_request` workflows, so required checks never run and it can't be
+merged. Every automated PR-opening step (`staging-deploy.yml`, `web-image-receiver.yml`,
+`promote-prod.yml`, `release.yml`'s `promote-errors` job) must use `secrets.RELEASE_PLEASE_TOKEN`
+for its checkout/push/`gh pr create` steps.
 
-```bash
-# Always rebase before pushing when CI has run on the branch
-git pull --rebase origin <branch-name>
-```
+### Deploy/promotion troubleshooting
 
-This is expected behavior, not an error. The GitOps step updates the values file so deployment configs always reflect the latest built version.
+For staging/prod promotion failures ("tag not found", stuck config-drift gate, rollback), see
+[gitops-delivery-promotion.md](gitops-delivery-promotion.md)'s own Troubleshooting section — not
+duplicated here to avoid the two docs drifting apart.
 
-## Rollback
+## Workflow files
 
-If a bad build was deployed, use the [deployment](../troubleshooting/deployment.md) rollback procedure. For CI pipeline issues:
+| File | Purpose |
+|---|---|
+| `ci.yml` | Entry point (PR-triggered): validate, unit test, detect changed apps, dispatch per-app pipelines |
+| `ci-pipeline.yml` | Reusable: per-app build/lint/test/security-scan, `sha-<short>` preview tag |
+| `ci-publish.yml` | Reusable: Docker build + push + Trivy scan + build-completion notify (ADR-044) |
+| `release.yml` | release-please: cuts `api`/`errors` semver; re-tags (`api`, ADR-056) or rebuilds (`errors`); auto-opens the `errors` prod-pin PR (DELIVERY-003) |
+| `staging-deploy.yml` | Continuous staging delivery for `api` — builds `sha-<short>` on every `master` push touching `apps/**`, opens the deploy PR |
+| `web-image-receiver.yml` | Cross-repo receiver for `web` (ADR-053) — `repository_dispatch` from `mlorentedev/web` triggers the same staging promotion + PR, with coalescing of stale open PRs |
+| `promote-prod.yml` | Manual `workflow_dispatch` — gated prod promotion for `api`/`web` |
+| `ci-cleanup.yml` | Weekly cron (Mondays 04:00 UTC) — prunes old `sha-*` tags via `toolkit registry prune`; never touches prod semver |
+| `check-config-drift.yml` | PR/push/nightly — generator-vs-committed-file drift gate (CI-GATE-002/003), image-sync check, Headscale ACL validation, Windows `toolkit sync` parity |
+| `add-to-project.yml` | Adds every opened/reopened issue and PR to the bitácora board (Project #1) |
+| `bitacora-status.yml` | Flips an assigned issue's board Status to "In Progress" |
 
-```bash
-git revert <commit-sha>
-git push
-```
+## Branch protection rules
 
-## Workflow Files
-
-- `.github/workflows/ci.yml` — entry point, validation, change detection
-- `.github/workflows/ci-pipeline.yml` — build, test, version, security scan
-- `.github/workflows/ci-publish.yml` — Docker build + push + Trivy
-- `.github/workflows/release.yml` — release-please, per-component semver; `api` build-once re-tag (ADR-056), `errors` rebuilds
-
-## Branch Protection Rules
+Trunk-based development — `master` is the only permanent branch (no `develop`). Feature work
+uses `feature/`, `fix/`, `hotfix/`, `chore/` prefixes and squash-merges.
 
 ### master
 
 | Setting | Value |
-|---------|-------|
-| Required status checks | `Validate Branch Name`, `Validate Merge Rules` (strict) |
-| PR reviews required | Yes (0 approvals — self-managed repo) |
+|---|---|
+| Required status checks | `Validate`, `Detect Changes` (strict) |
+| PR reviews required | 0 (self-managed repo) |
 | Enforce admins | Yes |
 | Allow force pushes | No |
-| Allow deletions | No |
-
-### develop
-
-| Setting | Value |
-|---------|-------|
-| Required status checks | Strict mode (no specific checks) |
-| PR reviews required | No |
-| Enforce admins | Yes |
-| Allow force pushes | Yes (useful for history cleanup) |
 | Allow deletions | No |
 
 ### Restore via CLI
 
 ```bash
-# master
 gh api repos/mlorentedev/kubelab/branches/master/protection -X PUT \
   --input - << 'RULES'
 {
-  "required_status_checks": {"strict": true, "contexts": ["Validate Branch Name", "Validate Merge Rules"]},
+  "required_status_checks": {"strict": true, "contexts": ["Validate", "Detect Changes"]},
   "enforce_admins": true,
   "required_pull_request_reviews": {"required_approving_review_count": 0},
   "restrictions": null,
@@ -241,31 +255,17 @@ gh api repos/mlorentedev/kubelab/branches/master/protection -X PUT \
   "allow_deletions": false
 }
 RULES
-
-# develop
-gh api repos/mlorentedev/kubelab/branches/develop/protection -X PUT \
-  --input - << 'RULES'
-{
-  "required_status_checks": {"strict": true, "contexts": []},
-  "enforce_admins": true,
-  "required_pull_request_reviews": null,
-  "restrictions": null,
-  "allow_force_pushes": true,
-  "allow_deletions": false
-}
-RULES
 ```
 
-### Emergency: Temporarily disable protection
+### Emergency: temporarily disable protection
 
 ```bash
 # Disable (e.g., for git filter-repo force push)
 gh api repos/mlorentedev/kubelab/branches/master/protection -X DELETE
-gh api repos/mlorentedev/kubelab/branches/develop/protection -X DELETE
 
-# IMPORTANT: Re-enable immediately after using the restore commands above
+# IMPORTANT: Re-enable immediately after using the restore command above
 ```
 
 ## Last tested
 
-2026-02-28
+2026-08-12 — every workflow file and the branch protection API response read directly for this rewrite; not a smoke-tested end-to-end run.


### PR DESCRIPTION
Takes the two highest-severity findings from DOCS-002 (#825, docs audit 2026-07-07: D5/D6) — both docs still described the pre-migration pipeline. Not the full DOCS-002 scope (diagram.md, service-catalog, hardware-setup, headscale-setup, dns-homelab remain open).

## What was wrong

- `versioning-strategy.md` (D5): described `paulhatch/semantic-version` + Gitflow `develop` + `0.0.0-dev.{sha}` tags. Reality is release-please + trunk + `sha-<short>`.
- `cicd.md` (D6): documented 4 of the repo's 11 workflow files, a CalVer/`develop`-branch-protection world that no longer exists, and had zero mention of the real delivery path.
- D40 (runner routing) and D74 (dropped RC scheme) were undocumented gaps in the same two files.

## What changed

Rewrote both against the current pipeline, verified file-by-file against every workflow in `.github/workflows/` and the real GitHub branch protection API response (`develop` doesn't exist at all; `master`'s actual required checks are `Validate`/`Detect Changes`, not the fictional `Validate Branch Name`/`Validate Merge Rules`).

Notable corrections that weren't just "update the tag scheme":
- `web` carries its own semver but builds in `mlorentedev/web` (ADR-053) — only its staging/prod *deployment* tracking lives in this repo, via `web-image-receiver.yml`'s cross-repo `repository_dispatch`. Confirmed by reading that workflow end to end before writing the versioning table, after an earlier assumption that `web` was dead residue turned out to be wrong (see the sibling PR #1010 description for how that got sorted out).
- `errors` auto-promotes to *both* environments via a single env-agnostic SSOT (DELIVERY-003) — no staging lane, no manual dispatch, unlike `api`/`web` which need the explicit `promote-prod.yml` gate. Verified via `promotion.py` and the `promote-errors` job in `release.yml`, not assumed.
- Added a mermaid pipeline diagram to `cicd.md`, adapted from the audit's §5.2 proposal to the real branch prefixes and job names.
- `cicd.md` now points to `gitops-delivery-promotion.md` (the canonical delivery/promotion doc, untouched by this PR) for promotion troubleshooting/rollback instead of re-documenting it — avoids introducing a third contradictory rollback procedure (the audit's D61 already flags two).

## Verification

- [x] Every markdown link in both files resolves to a real file (scripted check, not eyeballed)
- [x] Every ADR citation's filename verified against `docs/adr/` (caught and fixed two wrong slugs before commit)
- [x] Branch protection claims verified against `gh api repos/.../branches/master/protection`, not transcribed from the old doc
- [x] Workflow inventory (11 files) verified by reading each one, not inferred from names
- [x] `pre-commit` (markdownlint, etc.) clean