### PR TITLE
docs: rewrite docs/README.md as a routed index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@ This directory had two full audits on 2026-07-07 (`audits/docs-audit-2026-07-07.
 outer ring a newcomer reads first — architecture diagram, service catalog, versioning/CI/CD,
 hardware/VPN setup — describing a platform two or three migrations old. Fixes are tracked
 incrementally as **DOCS-002** ([#825](https://github.com/mlorentedev/kubelab/issues/825));
-`versioning-strategy.md` and `cicd.md` are done, the rest of the table above is not. If a doc
+`versioning-strategy.md` and `cicd.md` are rewritten in
+[#1011](https://github.com/mlorentedev/kubelab/pull/1011), the rest of the table above is not.
+If a doc
 you're reading contradicts what you observe in the code or cluster, trust the code — and file
 or update the DOCS-002 ticket.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,44 @@
 # Documentation
 
-Project-bound knowledge (docs-as-code). The *build/operate* layer lives here, versioned with the code and readable by any agent in-context.
+Project-bound knowledge (docs-as-code). The *build/operate* layer lives here, versioned with the code and readable by any agent in-context. The *decide/position* layer (roadmap, prestudy, strategy) and session memory live in the maintainer's cross-project knowledge store, not committed here.
+
+## I want to…
+
+| …do this | Start here |
+|---|---|
+| Understand what's versioned and how a release ships | [`architecture/versioning-strategy.md`](architecture/versioning-strategy.md) |
+| Understand the CI/CD pipeline (workflows, runner routing) | [`runbooks/cicd.md`](runbooks/cicd.md) |
+| Get a build from a merge into staging or prod | [`runbooks/gitops-delivery-promotion.md`](runbooks/gitops-delivery-promotion.md) — canonical deploy/promotion doc |
+| Add a brand-new service to the platform | [`runbooks/new-service.md`](runbooks/new-service.md), [`runbooks/deploy-new-k3s-service.md`](runbooks/deploy-new-k3s-service.md) |
+| Manage SOPS secrets | [`runbooks/sops-and-secrets.md`](runbooks/sops-and-secrets.md) (mechanics), [`runbooks/secrets-reference.md`](runbooks/secrets-reference.md) (catalog) |
+| Restore a backup / PVC | [`runbooks/pvc-backup-restore.md`](runbooks/pvc-backup-restore.md) |
+| Bootstrap or rotate the AWS ArgoCD hub | [`runbooks/aws1-destroy-replace.md`](runbooks/aws1-destroy-replace.md), [`runbooks/aws1-ebs-resize.md`](runbooks/aws1-ebs-resize.md) |
+| Set up K3s on a node | [`runbooks/k3s-setup.md`](runbooks/k3s-setup.md), [`runbooks/k3s-upgrade.md`](runbooks/k3s-upgrade.md) |
+| Diagnose a symptom (something's broken) | [`troubleshooting/quick-diagnostics.md`](troubleshooting/quick-diagnostics.md) — router into the rest of `troubleshooting/` |
+| Read a past architecture decision | [`adr/`](adr/) — filename is `adr-NNN-slug.md`, no generated index yet ([D58](audits/docs-audit-2026-07-07.md)) |
+| See what's actually deployed where | [`architecture/service-catalog.md`](architecture/service-catalog.md) — accuracy not re-verified since the 2026-07-07 audit ([D4](audits/docs-audit-2026-07-07.md)) |
+| Check hardware/node topology | [`architecture/hardware/`](architecture/hardware/), [`architecture/infra/networking-topology.md`](architecture/infra/networking-topology.md) |
+| Bootstrap a brand-new bare-metal node | [`runbooks/hardware-setup.md`](runbooks/hardware-setup.md) — **known stale** ([D9](audits/docs-audit-2026-07-07.md), pre-migration Proxmox world), not yet rewritten |
+| Set up Headscale / the VPN mesh | [`runbooks/headscale-setup.md`](runbooks/headscale-setup.md) — **known stale** ([D15-D17](audits/docs-audit-2026-07-07.md), node roster + config paths), not yet rewritten |
+| Debug staging/prod DNS | [`runbooks/dns-homelab.md`](runbooks/dns-homelab.md), [`runbooks/dns-and-domains.md`](runbooks/dns-and-domains.md) — **known stale** ([D18-D19](audits/docs-audit-2026-07-07.md)), not yet rewritten |
+| Understand a past gotcha or post-mortem | [`lessons.md`](lessons.md) — chronological, 3k+ lines, no index yet ([D39](audits/docs-audit-2026-07-07.md)) |
+
+## Directories
 
 - [`adr/`](adr/) — Architecture Decision Records
 - [`architecture/`](architecture/) — system/design docs
 - [`runbooks/`](runbooks/) — operational procedures
 - [`troubleshooting/`](troubleshooting/) — known issues & fixes
+- [`audits/`](audits/) — point-in-time documentation/process audits
 - [`lessons.md`](lessons.md) — accumulated gotchas & post-mortems
 
-The *decide/position* layer (roadmap, prestudy, strategy) and session memory live in the maintainer's cross-project knowledge store, not committed here.
+## Doc accuracy
+
+This directory had two full audits on 2026-07-07 (`audits/docs-audit-2026-07-07.md`,
+`audits/process-audit-2026-07-07.md`) that found the *recent* operational docs healthy but the
+outer ring a newcomer reads first — architecture diagram, service catalog, versioning/CI/CD,
+hardware/VPN setup — describing a platform two or three migrations old. Fixes are tracked
+incrementally as **DOCS-002** ([#825](https://github.com/mlorentedev/kubelab/issues/825));
+`versioning-strategy.md` and `cicd.md` are done, the rest of the table above is not. If a doc
+you're reading contradicts what you observe in the code or cluster, trust the code — and file
+or update the DOCS-002 ticket.


### PR DESCRIPTION
Missing-docs backlog item #1 from docs/audits/docs-audit-2026-07-07.md §6: "cheapest fix with the broadest effect; nothing else is findable until this exists." Independent of #1011 (the versioning-strategy.md/cicd.md rewrite) — separate branch on purpose, no file overlap, safe to merge in either order.

## What changed

Old `docs/README.md` was 5 bare folder links, no routing by question (the audit's own D-finding: "Accurate but minimal"). New version adds an "I want to..." table pointing at the actual doc for common tasks (versioning, CI/CD, deploy/promote, secrets, backups, new services, diagnostics).

Rather than presenting every linked doc as equally trustworthy, three known-stale runbooks (`hardware-setup.md`, `headscale-setup.md`, `dns-homelab.md`) are explicitly flagged with their audit D-number and "not yet rewritten" — they're still real, still the closest thing that exists, but silently linking them without the caveat would launder staleness the audit already found. Same treatment for the ADR index gap (D58) and the lessons.md size (D39).

## Verification

- [x] Every link in the file resolves to a real path (scripted check against the actual `docs/` tree, not eyeballed)
- [x] `pre-commit` (markdownlint, etc.) clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a navigation table for common operational and architectural topics.
  * Expanded the documentation directory overview to include audits.
  * Added documentation accuracy notes, including audit status, known stale content, and tracking information.
  * Reorganized the introductory knowledge-scope section for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->