### PR TITLE
fix(k8s): raise n8n CPU limit to stop liveness-probe kills (#1009)

### DIFF
--- a/infra/k8s/base/services/n8n.yaml
+++ b/infra/k8s/base/services/n8n.yaml
@@ -95,9 +95,17 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 3
           resources:
+            # cpu limit raised 1.0 -> 2.0 (#1009): cgroup cpu.stat measured
+            # nr_throttled=211/554 accounting periods with throttled_usec
+            # (30.9s) exceeding usage_usec (27.5s) over that window — n8n was
+            # regularly hitting the 1-core ceiling, and the liveness probe's
+            # tight timeout (5s) turned that throttling into repeated kills.
+            # ace1 has 4 allocatable cores at 59% CPU *requests* utilization
+            # (raising a limit doesn't change scheduling accounting, only how
+            # far the container may burst) — real headroom, not a guess.
             limits:
               memory: 512Mi
-              cpu: "1.0"
+              cpu: "2.0"
             requests:
               memory: 256Mi
               cpu: "0.2"


### PR DESCRIPTION
## Summary

Closes #1009. Root-cause fix, found while verifying OPS-022 in staging. #1018 (merged) fixed the symptom — retry a flaky exec after a pod restart; this fixes the cause the symptom was compensating for.

cgroup `cpu.stat` measured n8n regularly hitting its 1-core limit: `nr_throttled=211/554` accounting periods (38%), with `throttled_usec` (30.9s) exceeding `usage_usec` (27.5s) over that window — the container spent more time waiting on the CPU limit than actually running. The liveness probe's 5s timeout turned that throttling into repeated restarts (4 in 45h, confirmed via `kubectl describe pod`).

## Change

`infra/k8s/base/services/n8n.yaml`: `resources.limits.cpu` 1.0 → 2.0. Requests unchanged (0.2). No LimitRange CPU default exists to interact with (`governance/limitrange.yaml` only defaults memory). ace1 has 4 allocatable cores at 59% CPU *requests* utilization — real headroom; raising a limit doesn't change scheduling accounting, only how far the container may burst.

## Verification

Deployed to staging and soaked ~7 minutes with light synthetic load (repeated `/healthz` requests), then re-read the same counter that diagnosed the defect:

| | Before (1.0 core) | After (2.0 cores, ~7 min soak) |
|---|---|---|
| Throttled periods | 211/554 (38%) | 66/2026 (3.3%) |
| throttled_usec / usage_usec | 30.9s / 27.5s (112%) | 5.7s / 23.5s (24%) |
| Restarts observed | 4 in 45h (baseline) | 0 in soak window |

Full evidence posted on #1009. Roughly an order-of-magnitude drop in the throttle ratio — the same measurement that diagnosed the defect confirms the fix.

## Test plan

- [x] `yamllint` clean
- [x] `kubectl kustomize infra/k8s/overlays/staging` confirms the rendered limit is `2.0`
- [x] Deployed to staging, live cgroup measurement before/after (see table above)