### PR TITLE
docs(spec): scaffold SEC-004 rate-limit middleware

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -3793,3 +3793,48 @@ Recovery was cheap only by accident — the edits had been applied by a script r
 - **Fail-safe (skip, do nothing) beats fail-destructive (converge to empty) on any unattended sync path**, same principle #962/#925 already established for `bootstrap`'s delegation to `apply_monitors` — this is the third time a "the safe default is obviously X" instinct turned out backwards on this exact codepath.
 
 **Tags:** `#uptime-kuma` `#defaults` `#ssot` `#mon-002` `#gotcha`
+
+---
+
+### [2026-08-14] `max_over_time` remembers a spike long after the value that caused it is gone — it silently defeats `for:`
+
+**Context:** OBS-010 — two Grafana alert rules (`obs010-quota-requests`/`-limits`) on `kubelab` namespace memory utilization, `for: 5m` so a rules should only fire on a *sustained* breach, not a momentary one during a routine deploy restart.
+
+**Problem:** the surge-drill acceptance criterion — a normal `make deploy-k8s` + rollout restart must NOT fire the alert — failed for real on its first live run. The query was `max_over_time({container="quota-watcher"} | json | unwrap pct [10m]) > 80`. That function returns the *peak* value observed anywhere inside the 10-minute lookback window, not the current value — so a single transient spike (the surge itself, ~88% for well under a minute) stayed visible to every evaluation for up to 10 minutes after the real value had already dropped back under 71%. `for: 5m` requires the query result to stay above threshold across multiple evaluations, but with `max_over_time` the *query result itself* is an artifact of window memory, not of present reality — the sustain check was satisfied by the window, not by anything actually sustained. Caught by watching the rule transition `inactive` → `pending` → **`firing`** live during the drill (a 15-minute background poll of the rules API), then cross-checking the raw Loki log lines directly and finding the real value had already recovered to 70.54% within 5 minutes — the rule was alerting on a ghost.
+
+A second surprise on the same incident: restarting the Grafana pod (to deploy the `last_over_time` fix) did **not** clear the stale `firing` state — Grafana's alert state lives in its own database, not in-memory, so the pod restart was a no-op for the already-firing alert. It needed one more real evaluation cycle after the fix deployed to naturally resolve.
+
+**Solution:** `sed -i 's/max_over_time(/last_over_time(/g'` on both rules — `last_over_time` reflects only the most recent sample in the window, so `for:` genuinely requires the underlying value to stay elevated across real evaluations, not just within one remembered peak. Locked in with a permanent regression test, `test_query_uses_last_not_max_over_time`, asserting the provisioned query string contains `last_over_time` and not `max_over_time`. Re-ran an identical drill afterward: same 88% peak, rule reached `pending` at worst, never `firing`.
+
+**Rule:**
+- **`max_over_time`/`min_over_time` over a window and a `for:` sustain check are two different memories of the same interval, and stacking them double-counts.** `for:` already provides "did this stay true across N evaluations" — feeding it a query that itself remembers the window's peak makes the alert fire on "was this ever true in the window", which is a much weaker, and often wrong, condition. Use `last_over_time` (or no windowing function at all, if the metric is already a point value) whenever `for:` is doing the sustain-detection work.
+- **A passing static review of the LogQL expression would not have caught this** — `max_over_time` reads as the obviously-correct choice for "did utilization get too high," and only diverges from `last_over_time` under exactly the condition a surge drill creates. This is the same "exercised, not assumed" lesson OBS-009/IDP-031 already established for prod ordering claims, now shown to apply to alert *logic*, not just deployment state.
+- **A restart does not clear alert state if that state lives outside the pod.** Don't treat "the fix is deployed" as "the symptom is gone" for anything with its own persisted state machine — wait for a real evaluation cycle and check the actual state transition, not just rollout status.
+
+**Tags:** `#grafana` `#logql` `#alerting` `#obs-010` `#gotcha`
+
+---
+
+### [2026-08-14] K3s's built-in ServiceLB masks every client's real IP — `externalTrafficPolicy: Local` cannot fix it
+
+**Context:** SEC-004 — before adding any rate-limit middleware to K3s Traefik, checking whether a per-client-IP `sourceCriterion` would actually see distinct client IPs.
+
+**Problem:** it does not. A request from a known source IP (verified via `tailscale ip -4`) reached Traefik's access log tagged with an internal pod-CIDR address instead — and a different one on a second, near-simultaneous request. The standard first fix for source-IP mangling behind a Kubernetes `LoadBalancer` Service, `externalTrafficPolicy: Local` (skips kube-proxy's SNAT for cross-node delivery), was tried and changed nothing.
+
+The actual cause sits one layer below kube-proxy entirely: K3s's built-in ServiceLB (`klipper-lb`) is not a real load balancer, it is a per-node `iptables` script. Reading its container logs directly (`kubectl logs <svclb-pod> -c lb-tcp-443`) showed the exact rules it installs for every `LoadBalancer` Service:
+
+```
+iptables -t nat -I PREROUTING -p TCP --dport 443 -j DNAT --to <service-clusterIP>:443
+iptables -t nat -I POSTROUTING -d <service-clusterIP>/32 -p TCP -j MASQUERADE
+```
+
+The `POSTROUTING ... MASQUERADE` rule is unconditional — every packet reaching that Service's ClusterIP gets its source rewritten, regardless of `externalTrafficPolicy`, because the rewrite happens at the klipper-lb hostPort DNAT hop, before the packet is anywhere near the Service or kube-proxy's own forwarding logic. This is klipper-lb's documented design (it avoids asymmetric routing without needing anything smarter than raw NAT), not a misconfiguration — so there is no flag to flip; the fix is a different ServiceLB implementation (e.g. MetalLB) entirely.
+
+**Solution:** not fixed — filed as its own prerequisite issue (kubelab#1067) rather than attempted inline, since the real remediation is an infrastructure-level replacement affecting every `LoadBalancer` Service in the cluster, not a K3s Traefik config change. The ticket this was discovered under (SEC-004, rate-limit middleware) was rescoped to a global, non-per-client limit as a direct, documented consequence rather than shipping a per-IP limiter that silently buckets everyone together.
+
+**Rule:**
+- **Before designing anything keyed on "the client's IP" behind K3s's default `LoadBalancer` implementation, verify empirically what Traefik actually sees — do not assume `externalTrafficPolicy: Local` is sufficient.** It is the correct fix for kube-proxy-level SNAT, and irrelevant to klipper-lb's own masquerade, which happens upstream of that layer. Test with a temporary `--accesslog=true` and a real request from a known source, not by reading Kubernetes docs about `externalTrafficPolicy` in isolation.
+- **"We already have CrowdSec" does not mean client-IP visibility is a solved problem for every future feature.** CrowdSec's bouncer plugin consumes application-level decisions from its own LAPI and doesn't need Traefik's view of source IP the same way a `sourceCriterion`-based rate limiter would — the two security layers have different dependencies on this fact, and assuming one implies the other is how this would have shipped broken.
+- **A finding that changes a ticket's feasible scope belongs in that ticket and a dedicated follow-up issue, not folded silently into "ship what we can."** Global vs. per-client rate limiting are different guarantees; conflating them in the PR description would have overstated what the feature actually protects against.
+
+**Tags:** `#k3s` `#networking` `#servicelb` `#klipper-lb` `#sec-004` `#gotcha`

--- a/specs/SEC-004-rate-limit-middleware/proposal.md
+++ b/specs/SEC-004-rate-limit-middleware/proposal.md
@@ -1,0 +1,50 @@
+---
+id: "SEC-004-rate-limit-middleware"
+type: spec
+status: draft # draft | implementing | verifying | archived
+created: "2026-08-14"
+issue: "kubelab#970"
+tags: [spec, proposal]
+template_version: "1.0"
+---
+
+# SEC-004: Rate limit middleware
+
+> **Naming**: file lives at `<repo>/specs/<feature-id>/proposal.md`. `<feature-id>` is `AREA-NNN-slug` (e.g. `TOOL-001-secret-drift`).
+
+## Why
+
+<!-- from issue #970: SEC-004: no rate-limit middleware exists on any K3s route -->
+
+Every existing IngressRoute on K3s Traefik (base and both overlays, static and generator-produced) lacks any rate-limit middleware — the VPS's Docker Compose Traefik has one (`edge.traefik.rate_limit_*` in `common.yaml`, applied via Ansible), but that value set has never had a K3s consumer. Cloudflare is not proxied for any hostname except `api` (#704), so CrowdSec's reputation/behavior-based bouncer is currently the *only* thing between the public internet and K3s Traefik for every other route. CrowdSec answers "is this a known-bad actor" — nothing today answers "is total request volume about to exceed what the origin can serve."
+
+## What
+
+A shared `rate-limit` Traefik Middleware, sourced from the existing `edge.traefik.rate_limit_{average,burst,period}` SSOT in `common.yaml`, applied to every public-facing K3s IngressRoute alongside `secure-headers`/`crowdsec-bouncer`/`error-pages`. **Scoped to a single global bucket, not per-client**, per the investigation below — this is a volumetric backstop protecting origin capacity, not a per-abuser throttle.
+
+## Out of scope
+
+- Per-client / per-IP rate limiting — blocked on #1067 (klipper-lb MASQUERADEs every client's source IP to an internal pod-CIDR address before Traefik ever sees it; a per-IP bucket today would either share one bucket across all real clients, or bucket by the wrong, unstable internal IP). Revisit once #1067 lands a real client-IP signal (most likely a MetalLB migration).
+- Any change to the VPS Docker Compose Traefik's existing `rate-limit@file` middleware — that one already works correctly and is untouched.
+- Rate-limiting VPN-only / Tailscale-only routes (Loki, pihole, argocd, headscale, n8n if VPN-gated) — exposure there is the tailnet, not the internet; applying the same global bucket to them is harmless but adds no protection. `[AGENT-DRAFT — review before archive]` recommend blanket application (simpler, consistent with staging-mirrors-prod, and the shared bucket is harmless-if-sized-right) over selective (public routes only, tighter but adds a per-route decision that rots) — needs explicit user confirmation before `tasks.md` is frozen, not a silent default.
+
+## Risks / open questions
+
+- **[MUST resolve before tasks.md] Values need re-measurement, not blind reuse.** The VPS's `50/s average, 25 burst` were tuned for that topology (one Middleware per app, no ForwardAuth fan-out in the hot path for most apps). K3s routes include Authelia-gated ones (ForwardAuth sub-request per page-load) and the Homepage cockpit (multi-tile dashboard, bursty asset fetch on load). Exercise the noisiest known UI path in staging and record real request-per-second counts before freezing the threshold — reusing the VPS numbers unmeasured risks 429s on legitimate traffic, which is the failure this ticket's own existence is supposed to prevent, not cause.
+- **[Resolved by this investigation, load-bearing]** A per-client-IP `sourceCriterion` would be actively harmful, not just ineffective — see #1067. Confirmed empirically in staging on 2026-08-14 (temporary Traefik accesslog + `externalTrafficPolicy: Local` test, both reverted): every request reaches Traefik under an internal pod-CIDR address regardless of real source. This spec commits to a global (non-keyed) rate limit as a direct consequence; do not revisit the per-client design without #1067 first.
+- **CI-GATE-002 drift gate**: any change to `_build_middlewares()` in `toolkit/features/generator_k8s.py` must be paired with regenerating and committing `infra/k8s/overlays/{staging,prod}/generated/ingress.yaml` in the same commit, or `make config-check-drift` fails in CI. This is not new risk — it's the exact failure shape SEC-K8S-001 already documented in that gate's own comments — but it is a concrete task-ordering constraint for `tasks.md`.
+- Middleware ordering: VPS convention is `[secure-headers@file, rate-limit@file, error-pages]` (dashboard adds `auth@file` first). K3s's existing `_build_middlewares()` emits `[secure-headers, (authelia), error-pages]` with inconsistent relative ordering across some hand-written IngressRoutes (n8n vs headscale differ). Insert `rate-limit` relative to what's already there per-route; do not use this ticket to silently reorder unrelated middleware.
+
+## Acceptance criteria
+
+- [ ] A `rate-limit` Middleware object exists (mirrors `secure-headers.yaml`'s pattern), values sourced from `edge.traefik.rate_limit_*` in `common.yaml`, no hardcoded duplicate.
+- [ ] Every public-facing K3s IngressRoute (base + generated `ingress.yaml` for both envs) includes `rate-limit` in its middlewares list, positioned consistently with the existing `secure-headers`/`error-pages`/optional-auth chain.
+- [ ] A synthetic burst test (staging) proves the limit fires above threshold (HTTP 429) and passes clean below it — exercised, not assumed, matching this session's established verification discipline (OBS-010's `max_over_time`→`last_over_time` catch was found exactly this way).
+- [ ] `make config-check-drift` stays green after the `_build_middlewares()` change — regenerated `ingress.yaml` for both envs is part of the same commit as the generator change.
+
+## References
+
+- Bitácora board: kubelab#970 (this spec), kubelab#1067 (blocking follow-up: real client IP / per-client rate limiting)
+- Related issue: kubelab#704 (CF-PROXY-001 — a different, Cloudflare-side hop; not a substitute for #1067's K3s-internal finding)
+- Precedent: `infra/k8s/base/edge/secure-headers.yaml` (shared Middleware pattern to mirror), `infra/ansible/roles/traefik_vps/templates/middlewares.yml.j2` (working VPS `rate-limit@file` reference implementation)
+- Drift gate: `make config-check-drift` in the root `Makefile` (~lines 215-286), its comments cite SEC-K8S-001 as the incident this gate exists to prevent recurring

--- a/specs/SEC-004-rate-limit-middleware/tasks.md
+++ b/specs/SEC-004-rate-limit-middleware/tasks.md
@@ -1,0 +1,54 @@
+---
+tags: [spec, tasks]
+created: "2026-08-14"
+---
+
+# Tasks - SEC-004-rate-limit-middleware
+
+> TDD order. One task = one focused commit. Tick as you go. Reorder freely while spec is in `draft` state; freeze once you start `implementing`.
+>
+> **Inline markers:**
+> - `[P]` — no dependency on another unchecked task, safe to run in parallel.
+> - `[AC<n>]` — helps satisfy acceptance criterion #`<n>` from `proposal.md`.
+
+> **Not yet broken into concrete tasks.** `proposal.md`'s Risks section has one still-open item (blanket vs. selective route scope, tagged `[AGENT-DRAFT]`) that should be resolved with the user before this list is frozen. Next session: resolve that, measure real request rates for the noisiest staging route (Homepage cockpit or an Authelia-gated route) per the "Risks" note on reusing the VPS's `50/s`/`25` unmeasured, then write the task breakdown in the same style as OBS-010's `tasks.md` (this repo, same spec folder pattern) — Middleware manifest -> generator change + regenerated `ingress.yaml` for both envs (paired in one commit per the CI-GATE-002 constraint) -> per-route middleware list updates -> burst-drill test exercised in staging, not assumed.
+
+## Setup
+
+- [x] Branch: work done so far lives on `docs/IDP-031-coderabbit-evidence-fix` (investigation only, no code) — a fresh `feat/SEC-004-rate-limit-middleware` branch off `origin/master` is still needed once implementation starts. ✓ 2026-08-14
+- [ ] `proposal.md` is complete and acceptance criteria are testable — blocked on resolving the one `[AGENT-DRAFT]` tag (blanket vs. selective scope)
+- [ ] No open questions left in `proposal.md` "Risks / open questions" — two remain: the values re-measurement, and the route-scope decision above
+
+## Implementation
+
+(To be written once the open questions above are resolved.)
+
+## Closing
+
+- [ ] Every acceptance criterion from `proposal.md` is covered by at least one test
+- [ ] Every acceptance criterion has a matching entry in `features.json` with a non-vacuous verification command
+- [ ] Type checks pass
+- [ ] Lint passes
+- [ ] No unrelated changes in the diff (no scope creep)
+- [ ] `verification.md` filled in
+- [ ] PR opened referencing this spec folder
+
+## Machine-readable features
+
+This spec emits a sibling `features.json` (alongside this file) following [[pattern-feature-list-as-primitive]]. The JSON is the harness-facing contract: each acceptance criterion maps to ≥1 feature with `id`, `behavior`, `verification` (executable command), `state` (lifecycle), and `evidence` (harness-captured output).
+
+**Pass-state gating:** the agent CANNOT write `"state": "passing"` — only the harness, after running `verification` and capturing exit code 0, may set that terminal state. Reviewers must reject PRs where features.json contains `passing` entries with empty `evidence`.
+
+Minimal `features.json` skeleton (drop into `<repo>/specs/<feature-id>/features.json`):
+
+```json
+[
+  {
+    "id": "SEC-004-rate-limit-middleware-f1",
+    "behavior": "<one-line copy of an acceptance criterion>",
+    "verification": "<single shell command; exit 0 means pass>",
+    "state": "pending",
+    "evidence": ""
+  }
+]
+```

--- a/specs/SEC-004-rate-limit-middleware/verification.md
+++ b/specs/SEC-004-rate-limit-middleware/verification.md
@@ -1,0 +1,42 @@
+---
+tags: [spec, verification, templates]
+created: "2026-08-14"
+---
+
+# Verification - SEC-004-rate-limit-middleware
+
+## Evidence
+
+Map every acceptance criterion from `proposal.md` to concrete proof (commit hash, test name, or observed behavior).
+
+- [ ] Criterion 1 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 2 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 3 -> commit `<hash>` / test `<name>`
+- [ ] Criterion 4 -> commit `<hash>` / test `<name>`
+
+## Test status
+
+- Test suite: `<command> -> <output / coverage %>`
+- Manual smoke test: what was exercised, what was observed
+- No regressions in existing test suite: yes / no (if no, document)
+
+## Decisions made during implementation
+
+Brief log of non-obvious trade-offs or course corrections taken during the work. Routine choices belong in commit messages, not here.
+
+- **Pre-implementation investigation (2026-08-14) already produced one significant finding, captured here for continuity even though implementation hasn't started**: klipper-lb (K3s's built-in ServiceLB) MASQUERADEs every client's source IP before Traefik sees it, confirmed empirically in staging (temporary accesslog + `externalTrafficPolicy: Local` test, both reverted cleanly). This forced the scope from a per-client to a global rate limit and spawned a separate prerequisite issue (#1067) rather than silently narrowing this ticket. See `proposal.md` Risks section and #970's issue comments for full detail.
+
+## Promotion candidates
+
+Before archiving, flag what (if anything) should be promoted to the vault. If all three are "no", archive in repo is the only persistence.
+
+- [ ] Lesson for the repo's `docs/lessons.md`? <yes / no - one line of what> — likely candidate: "klipper-lb MASQUERADEs client IPs unconditionally; `externalTrafficPolicy: Local` does not help because the masquerade happens upstream of the Service" — genuinely non-obvious, worth capturing regardless of how #1067 resolves.
+- [ ] ADR-worthy decision for the repo's `docs/adr/adr-XXX.md`? <yes / no - one line of what>
+- [ ] New pattern candidate for `00_meta/patterns/`? Only if this recurs in >1 project. <yes / no - one line>
+
+## Archive checklist
+
+- [ ] `proposal.md` frontmatter set to `status: archived`
+- [ ] Folder moved: `specs/<feature-id>/` -> `specs/archive/<feature-id>/`
+- [ ] Bitácora board ticket for this spec moved to Done / closed with PR link (ADR-018)
+- [ ] Promotions above executed (if any)


### PR DESCRIPTION
## Summary
- Scaffolds `specs/SEC-004-rate-limit-middleware/` (proposal, tasks, verification) ahead of implementation, per this repo's Discipline Gate (touches a deployed config schema across manifest + generator + regenerated files).
- The proposal is investigation-driven, not a blind template fill: staging testing found klipper-lb (K3s's built-in ServiceLB) masquerades every client's source IP before Traefik ever sees it, regardless of `externalTrafficPolicy`. Confirmed by reading klipper-lb's own iptables rules directly, not inferred. Full evidence in kubelab#1067.
- Scope decision that finding forced: SEC-004 ships a **global**, not per-client, rate limit. Per-client rate limiting stays blocked on kubelab#1067 (likely a MetalLB migration), tracked explicitly rather than silently dropped.
- One open item remains tagged `[AGENT-DRAFT — review before archive]` in `proposal.md`: blanket vs. selective application to VPN-only routes. Needs your call before `tasks.md` is frozen and implementation starts.

## Test plan
- [ ] Docs-only change, no tests apply.
- [ ] Implementation (Middleware manifest, generator change, regenerated `ingress.yaml` for both envs, burst-drill test) is a separate follow-up PR once the open question above is resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added operational guidance for configuring sustained-utilization alerts and clarified client-IP behavior in K3s ServiceLB.
  * Added a draft plan for shared global rate limiting across public ingress routes.
  * Documented implementation scope, measurement requirements, traffic-handling constraints, acceptance criteria, and configuration-drift checks.
  * Added verification guidance covering test evidence, implementation decisions, promotion readiness, and archival steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->